### PR TITLE
Render widgets translated to the current locale

### DIFF
--- a/app/views/shortcode_templates/widget.html.erb
+++ b/app/views/shortcode_templates/widget.html.erb
@@ -6,6 +6,6 @@
     <% if key == 'visits-counter' %>
         <%=  render partial: plugin_view("visits_counter", "admin/partials/table") %>
     <% else %>
-        <%= raw widget[:description] %>
+        <%= raw widget[:description].translate %>
     <% end %>
 <% end  %>


### PR DESCRIPTION
Widgets should be rendered by default in the current locale, not the full :description database field