### PR TITLE
Don't rescue generic exception. This will hang the process

### DIFF
--- a/config/initializers/rufus_cron.rb
+++ b/config/initializers/rufus_cron.rb
@@ -6,29 +6,24 @@
   This program is distributed in the hope that it will be useful,  but WITHOUT ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
   See the  GNU Affero General Public License (GPLv3) for more details.
 =end
+require 'rufus-scheduler'
+$scheduler = Rufus::Scheduler.singleton
+$scheduler.cron '00 05 * * *' do
+  system("rake camaleon_cms:sitemap")
+end
+# cronjob for hook by site
 begin
-  require 'rufus-scheduler'
-  $scheduler = Rufus::Scheduler.singleton
-  $scheduler.cron '00 05 * * *' do
-    system("rake camaleon_cms:sitemap")
-  end
-  #cronjob for hook by site
-  begin
-    Site.all.each do |site|
-      # hooks
-      c = CamaleonController.new
-      c.instance_eval do
-        @current_site = site
-        @_hooks_skip = []
-      end
-      r = {site: site, eval: nil}; c.hooks_run("cron", r)
-      r[:eval].call(r) if r[:eval].present?
+  Site.all.each do |site|
+    # hooks
+    c = CamaleonController.new
+    c.instance_eval do
+      @current_site = site
+      @_hooks_skip = []
     end
-  rescue => e # skipping sites not found
-
+    r = {site: site, eval: nil}; c.hooks_run("cron", r)
+    r[:eval].call(r) if r[:eval].present?
   end
-rescue LoadError
-  
+rescue ActiveRecord::RecordNotFound # skipping sites not found
 end
 
 # only for camaleon site


### PR DESCRIPTION
Also removes rescuing `LoadError` when rufus cannot be loaded