### PR TITLE
Captcha on user registration - enable/disable options

### DIFF
--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -28,15 +28,15 @@ class Admin::SessionsController < CamaleonController
     @user = current_site.users.find_by_username(data_user[:username])
     captcha_validate = captcha_verify_if_under_attack("login")
     r = {user: @user, params: params, password: data_user[:password], captcha_validate: captcha_validate}; hooks_run("user_before_login", r)
-    if captcha_validate && @user &&  @user.authenticate(data_user[:password])
+    if captcha_validate && @user && @user.authenticate(data_user[:password])
       captcha_reset_attack("login")
       login_user(@user)
     else
       captcha_increment_attack("login")
       if captcha_validate
-        flash[:error] =  t('admin.login.message.fail')
+        flash[:error] = t('admin.login.message.fail')
       else
-        flash[:error] =  "Invalid captcha"
+        flash[:error] = "Invalid captcha"
       end
       @user = current_site.users.new(data_user)
       render 'admin/sessions/login'
@@ -91,7 +91,7 @@ class Admin::SessionsController < CamaleonController
         html = "<p>#{t('admin.login.message.hello')}, <b>#{@user.fullname}</b></p>
             <p>#{t('admin.login.message.reset_url')}:</p>
             <p><a href='#{reset_url}'><b>#{reset_url}</b></a></p> "
-        sendmail(@user.email,t('admin.login.message.subject_email'), html)
+        sendmail(@user.email, t('admin.login.message.subject_email'), html)
 
         flash[:notice] = t('admin.login.message.send_mail_succes')
         redirect_to admin_login_path
@@ -112,21 +112,28 @@ class Admin::SessionsController < CamaleonController
       user_data = params[:user]
 
       @user = current_site.users.new(user_data)
-      r = {user: @user, params: params}; hooks_run("user_before_register", r)
-      if captcha_verified? && @user.save
-        @user.set_meta_from_form(params[:meta])
-        r = {user: @user, message: t('admin.users.message.created'), redirect_url: admin_login_path}; hooks_run("user_after_register", r)
-        flash[:notice] = r[:message]
-        redirect_to r[:redirect_url]
-      else
+      r = {user: @user, params: params}; hooks_run('user_before_register', r)
+
+      if current_site.security_user_register_captcha_enabled? && !captcha_verified?
         @first_name = params[:meta][:first_name]
         @last_name = params[:meta][:last_name]
 
-        @user.errors[:captcha]  = t('admin.users.message.error_captcha')
-        render "register"
+        @user.errors[:captcha] = t('admin.users.message.error_captcha')
+        render 'register'
+      else
+        if @user.save
+          @user.set_meta_from_form(params[:meta])
+          r = {user: @user, message: t('admin.users.message.created'), redirect_url: admin_login_path}; hooks_run('user_after_register', r)
+          flash[:notice] = r[:message]
+          redirect_to r[:redirect_url]
+        else
+          @first_name = params[:meta][:first_name]
+          @last_name = params[:meta][:last_name]
+          render 'register'
+        end
       end
     else
-      render "register"
+      render 'register'
     end
   end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -122,6 +122,11 @@ class Site < TermTaxonomy
     get_option("comment_status", "pending")
   end
 
+  # security: user register form show captcha?
+  def security_user_register_captcha_enabled?
+    get_option('security_captcha_user_register', true) == true
+  end
+
   # auto create default user roles
   def set_default_user_roles(post_type = nil)
     user_role = self.user_roles.where({slug: 'admin', term_group: -1}).first_or_create({name: 'Administrator', description: 'Default roles admin'})

--- a/app/views/admin/sessions/register.html.erb
+++ b/app/views/admin/sessions/register.html.erb
@@ -42,12 +42,14 @@
             </div>
         </div>
 
-        <h4><%= t('admin.login.captcha') %></h4>
-        <div class="form-group">
-            <div class="col-md-12">
-                <%= raw captcha_tag(5, {}, {class: "form-control required", placeholder: t("admin.login.captcha")}) %>
+        <% if current_site.security_user_register_captcha_enabled? %>
+            <h4><%= t('admin.login.captcha') %></h4>
+            <div class="form-group">
+                <div class="col-md-12">
+                    <%= raw captcha_tag(5, {}, {class: 'form-control required', placeholder: t('admin.login.captcha')}) %>
+                </div>
             </div>
-        </div>
+        <% end %>
 
         <%= r = {html: ""}; hooks_run("user_register_form", r); raw(r[:html]); %>
 

--- a/app/views/admin/settings/site.html.erb
+++ b/app/views/admin/settings/site.html.erb
@@ -83,6 +83,10 @@
                             <label for=""><%= t('admin.settings.allow_user_registration') %></label><br>
                             <%= check_box :meta, :has_create_account, {checked: @site.get_option('has_create_account', false), class: "icheckbox0"}, "true", "" %>
                         </div>
+                        <div class="form-group">
+                            <label for=""><%= t('admin.settings.security.captcha_user_register') %></label><br>
+                            <%= check_box :options, :security_captcha_user_register, {checked: @site.security_user_register_captcha_enabled?, class: "icheckbox0"}, "true", "" %>
+                        </div>
                     </div>
                     <% if groups.present? %>
                         <div id="tab-other-configuration" class="<%= "active" if "other_config" == params[:tab] %> tab-pane col-md-10 col-md-offset-1">

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -314,6 +314,8 @@ en:
       author: "Author Name"
       seo_setting: "Seo Settings"
       email_settings: "Email Settings (SMTP)"
+      security:
+        captcha_user_register: "Enable captcha on user registration?"
 
       message:
         language_updated: 'Your languages was configured.'

--- a/config/locales/admin/es.yml
+++ b/config/locales/admin/es.yml
@@ -314,6 +314,8 @@ es:
       author: "Nombre de Autor"
       seo_setting: "Posicionamiento Web."
       email_settings: "Configuración de Correo (SMTP)"
+      security:
+        captcha_user_register: "¿Activar captcha en el registro de usuarios?"
       message:
         language_updated: 'Tus idiomas se han configurado.'
         site_updated: 'El sitio ha sido actualizado.'


### PR DESCRIPTION
I added aa new configuration option to enable/disable captcha on user registration.

![option](https://cloud.githubusercontent.com/assets/2389019/10043777/8ddc182e-61ed-11e5-9ac2-474552d53781.png)
