### PR TITLE
User update more actions hook

### DIFF
--- a/app/views/admin/users/form.html.erb
+++ b/app/views/admin/users/form.html.erb
@@ -141,7 +141,14 @@
                     </div>
 
                 </div>
+                <div class="panel panel-default form-horizontal">
+                  <div class="panel-body">
+                    <h3><span class="fa fa-cube"></span> <%= t('admin.table.more_actions') %></h3>
+                    <p><%= t('admin.message.more_actions_info') %></p>
+                  </div>
 
+                  <%= r = { html: ""}; hooks_run('user_update_more_actions', r); raw(r[:html]); %>
+                </div>
             </div>
         </div>
 

--- a/config/locales/admin/en.yml
+++ b/config/locales/admin/en.yml
@@ -476,6 +476,8 @@ en:
       visibility: 'Visibility'
       page_404: '404 Page'
       youtube: 'Youtube'
+      more_actions: 'More actions'
+      more_actions_info: 'More actions...'
     themes:
       footer_copyright: 'Footer Copyright'
       theme_select: 'Select Theme'

--- a/config/locales/admin/es.yml
+++ b/config/locales/admin/es.yml
@@ -474,6 +474,8 @@ es:
       visibility: 'Visibilidad'
       page_404: 'Página 404'
       youtube: 'Youtube'
+      more_actions: 'Más acciones'
+      more_actions_info: 'Más acciones...'
     themes:
       footer_copyright: 'Derechos de Autor'
       theme_select: 'Seleccionar Plantilla'


### PR DESCRIPTION
This new hooks permits add more actions in admin user edit profile for each plugin.

![more_action_hook](https://cloud.githubusercontent.com/assets/2389019/10101111/6d3081d0-638e-11e5-860d-ba5248a5ce61.png)
