### PR TITLE
Allow email domains up to 10 characters in the contact form plugin

### DIFF
--- a/app/apps/plugins/contact_form/front_controller.rb
+++ b/app/apps/plugins/contact_form/front_controller.rb
@@ -37,7 +37,7 @@ class Plugins::ContactForm::FrontController < Apps::PluginsFrontController
           validate = false
         end
         if f[:field_type].to_s == "email"
-          if !fields[cid].match(/\b[A-Z0-9._%a-z\-]+@(?:[A-Z0-9a-z\-]+\.)+[A-Za-z]{2,4}\z/)
+          if !fields[cid].match(/\b[A-Z0-9._%a-z\-]+@(?:[A-Z0-9a-z\-]+\.)+[A-Za-z]{2,10}\z/)
             errors << "#{label}: #{settings[:railscf_message][:invalid_email]}"
             validate = false
           end


### PR DESCRIPTION
For new email domains terminations (example: .digital)