### PR TITLE
Raise error when visiting unexisting urls.

### DIFF
--- a/config/routes/frontend.rb
+++ b/config/routes/frontend.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
 
     instance_eval(PluginRoutes.load("front"))
 
-    get "*slug" => 'frontend#post', format: true, :as => :post1, defaults: { format: :html }, constraints: { slug: /(?!admin)[a-zA-Z0-9\._=\s\-]+/}
-    get "*slug" => 'frontend#post', :as => :post, constraints: { slug: /(?!admin)[a-zA-Z0-9\._=\s\-]+/}
+    get "*slug" => 'frontend#post', format: true, :as => :post1, defaults: { format: :html }, constraints: { slug: /(?!admin)[a-zA-Z0-9\._=\s\-\/]+/}
+    get "*slug" => 'frontend#post', :as => :post, constraints: { slug: /(?!admin)[a-zA-Z0-9\._=\s\-\/]+/}
   end
 end


### PR DESCRIPTION
Example: Random troll writes domain.com/asdasdasd/adfasdasd.

Just changed the regexp to allow '/' in the urls.