### PR TITLE
fix syntax api_controller for Heroku

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -10,17 +10,17 @@ class Api::ApiController < CamaleonController
 
   def render_json_error_message(internal_message = 'Unexpected error', code = 100, status = 404, user_message = 'Unexpected error')
     error = {
-        userMessage: user_message,
-        internalMessage: internal_message,
-        code: code
+        :userMessage => user_message,
+        :internalMessage => internal_message,
+        :code => code
     }
     render_json_error(error, status)
   end
 
   def render_json_ok(message = 'Success', status = 200, more_info = {})
     msg = {
-        message: message,
-        more_info: more_info
+        :message => message,
+        :more_info => more_info
     }
     render json: msg, status: status
   end

--- a/app/controllers/concerns/frontend_concern.rb
+++ b/app/controllers/concerns/frontend_concern.rb
@@ -13,7 +13,7 @@ module FrontendConcern extend ActiveSupport::Concern
   #   you can add custom sitemap elements in the attr "custom", like: https://github.com/owen2345/camaleon-cms/issues/106#issuecomment-146232211
   #   you can customize your content for html or xml format
   def sitemap
-    r = {layout: (params[:format] == "html" ? (self.send :_layout) : false), render: "sitemap", custom: {a: a}, format: params[:format], skip_post_ids: [], skip_posttype_ids: [], skip_cat_ids: [], skip_tag_ids: []}
+    r = {layout: (params[:format] == "html" ? (self.send :_layout) : false), render: "sitemap", custom: {}, format: params[:format], skip_post_ids: [], skip_posttype_ids: [], skip_cat_ids: [], skip_tag_ids: []}
     hooks_run("on_render_sitemap", r)
     @r = r
     render r[:render], layout: r[:layout]


### PR DESCRIPTION
Error Stack on heroku:

[3] ! Unable to load application: SyntaxError: /app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:10: syntax error, unexpected ':', expecting =>
        'userMessage': user_message,
                      ^
/app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:11: syntax error, unexpected ':', expecting :: or '[' or '.'
    'internalMessage': internal_message,
                      ^
/app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:12: syntax error, unexpected ':', expecting :: or '[' or '.'
    'code': code
           ^
/app/vendor/bundle/ruby/2.1.0/gems/activesupport-4.2.4/lib/active_support/dependencies.rb:274:in `require': /app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:10: syntax error, unexpected ':', expecting => (SyntaxError)
        'userMessage': user_message,
                      ^
/app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:11: syntax error, unexpected ':', expecting :: or '[' or '.'
    'internalMessage': internal_message,
                      ^
/app/vendor/bundle/ruby/2.1.0/gems/camaleon_cms-1.0.8/app/controllers/api/api_controller.rb:12: syntax error, unexpected ':', expecting :: or '[' or '.'
    'code': code