### PR TITLE
fix lastmod date format in sitemap.xml.builder to be Google-compliant

### DIFF
--- a/app/views/default_theme/sitemap.xml.builder
+++ b/app/views/default_theme/sitemap.xml.builder
@@ -3,7 +3,7 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
   current_site.get_languages.each_with_index do |lang, index| lang = (index == 0 ? nil : lang);
     xml.url do
       xml.loc current_site.the_url(locale: lang)
-      xml.lastmod current_site.updated_at
+      xml.lastmod current_site.updated_at.to_date
       xml.changefreq "daily"
       xml.priority "1.0"
     end
@@ -12,7 +12,7 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
       next if @r[:skip_post_ids].include?(post.id)
       xml.url do
         xml.loc post.the_url(locale: lang)
-        xml.lastmod post.updated_at
+        xml.lastmod post.updated_at.to_date
         xml.changefreq "monthly"
         xml.priority "0.5"
       end
@@ -22,7 +22,7 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
       next if @r[:skip_cat_ids].include?(cat.id)
       xml.url do
         xml.loc cat.the_url(locale: lang)
-        xml.lastmod cat.updated_at
+        xml.lastmod cat.updated_at.to_date
         xml.changefreq "monthly"
         xml.priority "0.5"
       end
@@ -32,7 +32,7 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
       next if @r[:skip_posttype_ids].include?(ptype.id)
       xml.url do
         xml.loc ptype.the_url(locale: lang)
-        xml.lastmod ptype.updated_at
+        xml.lastmod ptype.updated_at.to_date
         xml.changefreq "monthly"
         xml.priority "0.5"
       end
@@ -42,7 +42,7 @@ xml.urlset "xmlns" => "http://www.sitemaps.org/schemas/sitemap/0.9" do
       next if @r[:skip_tag_ids].include?(tag.id)
       xml.url do
         xml.loc tag.the_url(locale: lang)
-        xml.lastmod tag.updated_at
+        xml.lastmod tag.updated_at.to_date
         xml.changefreq "monthly"
         xml.priority "0.5"
       end


### PR DESCRIPTION
The current updated_at yields something like: `2015-11-01 13:46:22 UTC` which Google doesn't consider valid.
Adding to_date makes it valid.