### PR TITLE
Fix Clean Theme to avoid creating duplicate main_menu

### DIFF
--- a/app/apps/themes/new/custom_helper.rb
+++ b/app/apps/themes/new/custom_helper.rb
@@ -27,7 +27,9 @@ module Themes::New::CustomHelper
       group.add_manual_field({"name"=>"Footer text", "slug"=>"theme_custom_footer_text"},{field_key: "editor", translate: true})
     end
 
-    theme.site.nav_menus.create(name: "Main Menu", slug: "main_menu")
+    unless theme.site.nav_menus.where(slug: "main_menu").any?
+      theme.site.nav_menus.create(name: "Main Menu", slug: "main_menu")
+    end
   end
 
   def theme_custom_on_uninstall_theme(theme)

--- a/lib/generators/camaleon_cms/theme_template/app/apps/themes/my_theme/main_helper.rb
+++ b/lib/generators/camaleon_cms/theme_template/app/apps/themes/my_theme/main_helper.rb
@@ -7,6 +7,7 @@ module Themes::ThemeClass::MainHelper
     # here your code on save settings for current site, by default params[:theme_fields] is auto saved into theme
     # Also, you can save your extra values added in admin/settings.html.erb
     # sample: theme.set_meta("my_key", params[:my_value])
+    theme.set_field_values(params[:field_options])
   end
 
   # callback called after theme installed

--- a/lib/generators/camaleon_cms/theme_template/app/apps/themes/my_theme/views/layouts/index.html.erb
+++ b/lib/generators/camaleon_cms/theme_template/app/apps/themes/my_theme/views/layouts/index.html.erb
@@ -2,7 +2,7 @@
     <html lang="en">
     <head>
         <!-- META SECTION -->
-        <title>My theme</title>
+        <title><%= current_site.the_title %></title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
If user switches away from the Clean Theme, and later re-selects it, a duplicate entry for Main Menu is created. This fix prevents that from happening.