### PR TITLE
fixes call to partial custom_fields/render

### DIFF
--- a/app/views/camaleon_cms/admin/appearances/nav_menus/_custom_fields.html.erb
+++ b/app/views/camaleon_cms/admin/appearances/nav_menus/_custom_fields.html.erb
@@ -1,5 +1,5 @@
 <form class="menus_field_form required">
-    <%= render partial: "camaleon_cms/camaleon_cms/admin/settings/custom_fields/render", locals: {record: @nav_menu, field_groups: @nav_menu.get_field_groups()} %>
+    <%= render partial: "camaleon_cms/admin/settings/custom_fields/render", locals: {record: @nav_menu, field_groups: @nav_menu.get_field_groups()} %>
     <div class="text-right">
         <button class="btn btn-primary" type="submit"><%= t("camaleon_cms.admin.button.submit") %> <i class="fa fa-arrow-right"></i></button>
     </div>


### PR DESCRIPTION
Simply removed the extra 'camaleon_cms' in the path, and it works for me now.

![screen shot 2016-01-21 at 11 07 13 am](https://cloud.githubusercontent.com/assets/6540262/12488047/66340336-c02f-11e5-80e7-3f5af050c2a9.png)
