### PR TITLE
optimized get_meta when using eager_load

### DIFF
--- a/app/models/concerns/camaleon_cms/metas.rb
+++ b/app/models/concerns/camaleon_cms/metas.rb
@@ -29,7 +29,11 @@ module CamaleonCms::Metas extend ActiveSupport::Concern
   # return default if meta value == ""
   def get_meta(key, default = nil)
     cama_fetch_cache("meta_#{key}") do
-      option = metas.where(key: key).first
+      if metas.is_a?(ActiveRecord::Associations::CollectionProxy)
+        option = metas.select{|m| m.key.eql?(key)}.first
+      else
+        option = metas.where(key: key).first
+      end
       res = ""
       if option.present?
         value = JSON.parse(option.value) rescue option.value


### PR DESCRIPTION
When using eager_load metas are preloaded, so it's quicker to browse the array instead of sending a new SQL request.