### PR TITLE
Frontcache plugin

### DIFF
--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -9,8 +9,7 @@
 class Plugins::FrontCache::AdminController < CamaleonCms::Apps::PluginsAdminController
   include Plugins::FrontCache::FrontCacheHelper
   def settings
-    add_asset_library("multiselect")
-    @caches = current_site.get_meta("front_cache_elements", {})
+    @caches = current_site.get_meta("front_cache_elements", {paths: []})
     @caches[:paths] << "" unless @caches[:paths].present?
   end
 

--- a/app/apps/plugins/front_cache/views/admin/settings.html.erb
+++ b/app/apps/plugins/front_cache/views/admin/settings.html.erb
@@ -10,6 +10,7 @@
         form.on("click", ".del_path", function(){
             $(this).closest(".input-group").remove();
         });
+        $('#cache_front_form select').selectpicker();
     });
 </script>
 <%= form_for(admin_plugins_front_cache_settings_path, html:{ id: "cache_front_form" }) do %>


### PR DESCRIPTION
Frontcache settings page was returning error on first load because `@caches[:paths]` was nil.
`bootstrap-select.js` library is included into main.js now so there is no need for explicit include. And actually it does not work because file name is `_bootstrap-select.js` (not `bootstrap-select.js`)