### PR TITLE
Added fix to ability iteration

### DIFF
--- a/app/models/camaleon_cms/ability.rb
+++ b/app/models/camaleon_cms/ability.rb
@@ -77,7 +77,7 @@ class CamaleonCms::Ability
       can :manage, :plugins   if @roles_manager[:plugins] rescue false
       can :manage, :users     if @roles_manager[:users] rescue false
       can :manage, :settings  if @roles_manager[:settings] rescue false
-      @roles_manager.each do |rol_manage_key, val_role|
+      @roles_manager.try(:each) do |rol_manage_key, val_role|
         can :manage, rol_manage_key.to_sym if val_role.to_s.cama_true? rescue false
       end
     end


### PR DESCRIPTION
When a dynamic role is created without any power of editing 'other permissions' (those checkboxes in create role screen) @roles_manager returns nil in ability.rb. 

Because of this nil return the method .each fails and raises an error. I believe it's now fixed by using the try before each.