### PR TITLE
Bugfix set_field_values

### DIFF
--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -196,8 +196,9 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   def set_field_values(datas = {})
     if datas.present?
       self.field_values.delete_all
-      datas.each do |index, fields_data|
-        fields_data.each do |field_key, values|
+      #datas.each do |index, fields_data|
+        #fields_data.each do |field_key, values|
+        datas.each do |field_key, values|
           if values[:values].present?
             order_value = -1
             (values[:values].is_a?(Hash) ? values[:values].values : values[:values]).each do |value|
@@ -205,7 +206,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
             end
           end
         end
-      end
+      #end
     end
   end
 


### PR DESCRIPTION
input datas structure has changed.
it was   {"0"=>{ "untitled-text-box"=>{"id"=>"262",
"values"=>{"0"=>"33333"}}} }
now it is : { "untitled-text-box"=>{"id"=>"262",
"values"=>{"0"=>"33333"}}}