### PR TITLE
Handle the case of shortcodes not being initialized, as might happen …

### DIFF
--- a/app/helpers/camaleon_cms/short_code_helper.rb
+++ b/app/helpers/camaleon_cms/short_code_helper.rb
@@ -131,7 +131,7 @@ module CamaleonCms::ShortCodeHelper
   # if empty, codes will be replaced with all registered shortcodes
   # Return: (String) reg expression string
   def cama_reg_shortcode(codes = nil)
-    "(\\[(#{codes || @_shortcodes.join("|")})(\s|\\]){0}(.*?)\\])"
+    "(\\[(#{codes || (@_shortcodes || []).join("|")})(\s|\\]){0}(.*?)\\])"
   end
 
   # determine the content to replace instead the shortcode


### PR DESCRIPTION
…in tests with factories

Hit this while testing a serializer for a Post - camaleon expects short codes to be initialized, but that initialization is done in a controller and it is not performed when a test instantiates a post via factory girl and then serializes said post.