### PR TITLE
Indicate development dependencies on rspec and capybara

### DIFF
--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -39,4 +39,7 @@ Gem::Specification.new do |s|
 
   # MEDIA MANAGER
   s.add_dependency 'aws-sdk', '~> 2'
+  
+  s.add_development_dependency 'rspec', '>= 2', '< 4'
+  s.add_development_dependency 'capybara'
 end


### PR DESCRIPTION
Without this `bundle exec rspec` produces:

<pre>
Gem::LoadError: rspec-core is not part of the bundle. Add it to Gemfile.
</pre>