### PR TITLE
Do not rescue nil in session helper

### DIFF
--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -115,7 +115,7 @@ module CamaleonCms::SessionHelper
     return nil unless c.size == 3
 
     if c[1] == request.user_agent && request.ip == c[2]
-      @cama_current_user = (current_site.users_include_admins.find_by_auth_token(c[0]).decorate rescue nil)
+      @cama_current_user = current_site.users_include_admins.find_by_auth_token(c[0]).try(:decorate)
     end
   end
 
@@ -141,6 +141,6 @@ module CamaleonCms::SessionHelper
   private
   # calculate the current user for API
   def cama_calc_api_current_user
-    current_site.users_include_admins.find(doorkeeper_token.resource_owner_id).decorate if doorkeeper_token rescue nil
+    current_site.users_include_admins.find_by_id(doorkeeper_token.resource_owner_id).try(:decorate) if doorkeeper_token
   end
 end


### PR DESCRIPTION
Rescuing nil hides all kinds of errors, such as doorkeeper_token
not being defined. This subsequently causes strange failures
downstream, like current_user being nil in some parts of the code
when a user session is clearly present at controller level.