### PR TITLE
Take 3 at doorkeeper_token fix.

### DIFF
--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -141,7 +141,9 @@ module CamaleonCms::SessionHelper
   private
   # calculate the current user for API
   def cama_calc_api_current_user
-    if !respond_to?(:doorkeeper_token)
+    begin
+      doorkeeper_token
+    rescue NameError
       # hack, this method should be called from a context which has
       # doorkeeper_token defined
       return nil


### PR DESCRIPTION
`respond_to?(:doorkeeper_token)` is always false even though the method is there, hence try calling it and rescue `NameError` instead