### PR TITLE
email_late hook, to permit modifying e.g. smtp settings

### DIFF
--- a/app/mailers/camaleon_cms/html_mailer.rb
+++ b/app/mailers/camaleon_cms/html_mailer.rb
@@ -9,36 +9,52 @@ class CamaleonCms::HtmlMailer < ActionMailer::Base
   # content='', from=nil, attachs=[], url_base='', current_site, template_name, layout_name, extra_data, format, cc_to
   def sender(email, subject='Hello', data = {})
     data = data.to_sym
-    data[:current_site] = CamaleonCms::Site.main_site.decorate unless data[:current_site].present?
-    data[:current_site] = CamaleonCms::Site.find(data[:current_site]).decorate if data[:current_site].is_a?(Integer)
-    current_site = @current_site = data[:current_site]
-    data = {cc_to: current_site.get_option("email_cc", '').split(','), from: current_site.get_option("email_from") || current_site.get_option("email"), template_name: 'mailer', layout_name: 'camaleon_cms/mailer', format: 'html'}.merge(data)
-    @subject = subject
-    @html = data[:content]
-    @url_base = data[:url_base]
-    @extra_data = data[:extra_data]
+    if data[:current_site].present?
+      if data[:current_site].is_a?(Integer)
+        data[:current_site] = CamaleonCms::Site.find(data[:current_site]).decorate
+      end
+    else
+      data[:current_site] = CamaleonCms::Site.main_site.decorate
+    end
+    @current_site = data[:current_site]
+    data = {
+      cc_to: @current_site.get_option("email_cc", '').split(','),
+      from: @current_site.get_option("email_from") || @current_site.get_option("email"),
+      template_name: 'mailer',
+      layout_name: 'camaleon_cms/mailer',
+      format: 'html',
+    }.merge(data)
     data[:cc_to] = [data[:cc_to]] if data[:cc_to].is_a?(String) || !data[:cc_to].present?
 
     mail_data = {to: email, subject: subject}
-    if current_site.get_option("mailer_enabled") == 1
+    if @current_site.get_option("mailer_enabled") == 1
       mail_data[:delivery_method] = :smtp
-      mail_data[:delivery_method_options] = {user_name: current_site.get_option("email_username"),
-                                             password: current_site.get_option("email_pass"),
-                                             address: current_site.get_option("email_server"),
-                                             port: current_site.get_option("email_port"),
-                                             domain: (current_site.the_url.to_s.parse_domain rescue "localhost"),
-                                             authentication: "plain",
-                                             enable_starttls_auto: true
+      mail_data[:delivery_method_options] = {
+        user_name: @current_site.get_option("email_username"),
+        password: @current_site.get_option("email_pass"),
+        address: @current_site.get_option("email_server"),
+        port: @current_site.get_option("email_port"),
+        domain: (@current_site.the_url.to_s.parse_domain rescue "localhost"),
+        authentication: "plain",
+        enable_starttls_auto: true,
       }
     end
     mail_data[:cc] = data[:cc_to].clean_empty.join(",") if data[:cc_to].present?
     mail_data[:from] = data[:from] if data[:from].present?
+    
+    data[:mail_data] = mail_data
+    hooks_run('email_late', data)
+    
+    @subject = subject
+    @html = data[:content]
+    @url_base = data[:url_base]
+    @extra_data = data[:extra_data]
 
     views_dir = "app/apps/"
     self.prepend_view_path(File.join($camaleon_engine_dir, views_dir).to_s)
     self.prepend_view_path(Rails.root.join(views_dir).to_s)
 
-    theme = current_site.get_theme
+    theme = @current_site.get_theme
     lookup_context.prefixes.prepend("themes/#{theme.slug}") if theme.settings["gem_mode"]
     lookup_context.prefixes.prepend("themes/#{theme.slug}/views") unless theme.settings["gem_mode"]
     lookup_context.use_camaleon_partial_prefixes = true


### PR DESCRIPTION
This adds a second email hook to permit modifying email parameters just before the email is about to be sent. It is needed to make camaleon mandrill plugin work again with the latest camaleon cms version (https://github.com/raulanatol/camaleon-mandrill-plugin/pull/2 for the plugin change).