### PR TITLE
Lowercase user email addresses

### DIFF
--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -15,8 +15,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
     validates_with CamaleonCms::UniqValidatorUser
 
     before_create { generate_token(:auth_token) }
-    before_save :cama_before_save
-    before_create :cama_before_save
+    before_validation :cama_before_validation
     before_destroy :reassign_posts
     # relations
 
@@ -107,7 +106,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   end
 
   private
-  def cama_before_save
+  def cama_before_validation
     self.role = PluginRoutes.system_info["default_user_role"] if self.role.blank?
     if self.email
       self.email = self.email.downcase

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -15,7 +15,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
     validates_with CamaleonCms::UniqValidatorUser
 
     before_create { generate_token(:auth_token) }
-    before_save :cam_before_save
+    before_save :cama_before_save
     before_create :cama_before_save
     before_destroy :reassign_posts
     # relations
@@ -109,6 +109,9 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   private
   def cama_before_save
     self.role = PluginRoutes.system_info["default_user_role"] if self.role.blank?
+    if self.email
+      self.email = self.email.downcase
+    end
   end
 
   # deprecated

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -15,8 +15,8 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
     validates_with CamaleonCms::UniqValidatorUser
 
     before_create { generate_token(:auth_token) }
-    before_save :before_saved
-    before_create :before_saved
+    before_save :cam_before_save
+    before_create :cama_before_save
     before_destroy :reassign_posts
     # relations
 
@@ -107,7 +107,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   end
 
   private
-  def before_saved
+  def cama_before_save
     self.role = PluginRoutes.system_info["default_user_role"] if self.role.blank?
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::User, type: :model do
+  describe 'email' do
+    it 'is lowercased' do
+      user = CamaleonCms::User.create!(
+        email: 'FOO@BAR.COM',
+        username: 'test', password: 'test')
+      user.email.should == 'foo@bar.com'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
     # ...rather than:
     #     # => "be bigger than 2"
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+    
+    expectations.syntax = :should
   end
 
   # rspec-mocks config goes here. You can use an alternate test double


### PR DESCRIPTION
Email addresses are case insensitive, however camaleon-cms allowed different case versions of the same email addresses to exist. This PR lowercases email addresses before validation.

I have not looked into usernames yet or whether it is possible to log in by specifying the email address in a different case from what is stored in the database (e.g. all caps).