### PR TITLE
Fix checkbox custom fields always being checked in admin

### DIFF
--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -61,7 +61,9 @@ function cama_build_custom_field(panel, field_data, values){
             field.prepend(field_actions);
             if(field_counter == 0) field.children('.actions').find('.fa-times').remove();
         }
-        if(!$field.find('.group-input-fields-content').hasClass('cama_skip_cf_rename_multiple')) field.find('input, textarea, select').each(function(){ $(this).attr('name', $(this).attr('name').replace('[]', '['+field_counter+']')) });
+        if(!$field.find('.group-input-fields-content').hasClass('cama_skip_cf_rename_multiple')) {
+            field.find('input, textarea, select').each(function(){ $(this).attr('name', $(this).attr('name').replace('[]', '['+field_counter+']')) });
+        }
         if(field_data.disabled){
             field.find('input, textarea, select').prop('readonly', true).filter('select').click(function(){ return false; }).focus(function(){ $(this).blur(); });
             field.find('.btn').addClass('disabled').unbind().click(function(){ return false; });

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -69,17 +69,27 @@ function cama_build_custom_field(panel, field_data, values){
             field.find('.btn').addClass('disabled').unbind().click(function(){ return false; });
         }
 
-        if(value) field.find('.input-value').val(value);
+        if (field_data.kind == 'checkbox') {
+            field.find('input')[0].checked = value;
+        } else if (value) {
+            field.find('.input-value').val(value);
+        }
         $sortable.append(field);
         if(callback) eval(callback + "(field, value);");
         field_counter ++;
     }
-    if(values.length <= 0) values = [field_data.default_value];
+    if(field_data.kind != 'checkbox' && values.length <= 0) {
+        values = [field_data.default_value];
+    }
     if(field_data.kind != 'checkboxes') {
         if (!field_data.multiple && values.length > 1) values = [values[0]];
-        $.each(values, function (i, value) {
-            add_field(value);
-        });
+        if (field_data.kind == 'checkbox') {
+            add_field(values[0]);
+        } else {
+            $.each(values, function (i, value) {
+                add_field(value);
+            });
+        }
     } else add_field(values);
 
     if(field_data.multiple){ // sortable actions

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkbox.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkbox.html.erb
@@ -1,3 +1,8 @@
 <div class="group-input-fields-content" data-callback-render="custom_field_checkbox_val">
-    <div class="checkbox"><label><input type="checkbox" value="1" name="<%= field_name %>[<%= field.slug %>][values][]">  <%= field.the_name %> </label></div>
+  <div class="checkbox">
+    <label>
+      <input type="checkbox" value="1" name="<%= field_name %>[<%= field.slug %>][values][]">
+      <%= field.the_name %>
+    </label>
+  </div>
 </div>


### PR DESCRIPTION
   Checkboxes are checked by setting the checked attribute to true/false,
    not by manipulating value. Previously checkbox custom fields would
    always be checked, regardless of actual state of the field; with
    this change, the checkbox custom fields are behaving correctly.
