### PR TITLE
code cleanup in models

### DIFF
--- a/app/models/camaleon_cms/ability.rb
+++ b/app/models/camaleon_cms/ability.rb
@@ -10,9 +10,10 @@ class CamaleonCms::Ability
     elsif user.client?
       can :read, :all
     else
-      #conditions:
-      @roles_manager ||= (user.get_role(current_site).get_meta("_manager_#{current_site.id.to_s}", {}) || {})
-      @roles_post_type ||= (user.get_role(current_site).get_meta("_post_type_#{current_site.id.to_s}", {}) || {})
+      # conditions:
+      role_current_site = user.get_role(current_site)
+      @roles_manager ||= (role_current_site.get_meta("_manager_#{current_site.id}", {}) || {})
+      @roles_post_type ||= (role_current_site.get_meta("_post_type_#{current_site.id}", {}) || {})
 
       ids_publish = @roles_post_type[:publish] || []
       ids_edit = @roles_post_type[:edit] || []
@@ -49,26 +50,25 @@ class CamaleonCms::Ability
       can :update, CamaleonCms::Post do |post|
         pt_id = post.post_type.id
         r = false
-        r ||= (ids_edit).to_i.include?(pt_id) && post.user_id == user.id rescue false
-        r ||= (ids_edit_publish).to_i.include?(pt_id) && post.published? rescue false
-        r ||= (ids_edit_other).to_i.include?(pt_id) && post.user_id != user.id rescue false
+        r ||= ids_edit.to_i.include?(pt_id) && post.user_id == user.id rescue false
+        r ||= ids_edit_publish.to_i.include?(pt_id) && post.published? rescue false
+        r ||= ids_edit_other.to_i.include?(pt_id) && post.user_id != user.id rescue false
         r
       end
 
       can :destroy, CamaleonCms::Post do |post|
         pt_id = post.post_type.id
         r = false
-        r ||= (ids_delete).to_i.include?(pt_id) && post.user_id == user.id rescue false
-        r ||= (ids_delete_publish).to_i.include?(pt_id) && post.published? rescue false
-        r ||= (ids_delete_other).to_i.include?(pt_id) && post.user_id != user.id rescue false
+        r ||= ids_delete.to_i.include?(pt_id) && post.user_id == user.id rescue false
+        r ||= ids_delete_publish.to_i.include?(pt_id) && post.published? rescue false
+        r ||= ids_delete_other.to_i.include?(pt_id) && post.user_id != user.id rescue false
         r
       end
 
-
-      #others
+      # others
       can :manage, :media     if @roles_manager[:media] rescue false
       can :manage, :comments  if @roles_manager[:comments] rescue false
-      #can :manage, :forms     if @roles_manager[:forms] rescue false
+      # can :manage, :forms     if @roles_manager[:forms] rescue false
       can :manage, :themes    if @roles_manager[:themes] rescue false
       can :manage, :widgets   if @roles_manager[:widgets] rescue false
       can :manage, :nav_menu  if @roles_manager[:nav_menu] rescue false
@@ -81,18 +81,17 @@ class CamaleonCms::Ability
     end
   end
 
-  #overwrite can method to support decorator class names
+  # overwrite can method to support decorator class names
   def can?(action, subject, *extra_args)
     if subject.is_a?(Draper::Decorator)
-      super(action,subject.model,*extra_args)
+      super(action, subject.model, *extra_args)
     else
-      super(action,subject,*extra_args)
+      super(action, subject, *extra_args)
     end
   end
 
-  #overwrite cannot method to support decorator class names
+  # overwrite cannot method to support decorator class names
   def cannot?(*args)
     !can?(*args)
   end
-
 end

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -1,25 +1,28 @@
 class CamaleonCms::Category < CamaleonCms::TermTaxonomy
   alias_attribute :site_id, :term_group
   alias_attribute :post_type_id, :status
+
   default_scope { where(taxonomy: :category) }
-  has_many :metas, ->{ where(object_class: 'Category')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
-  has_many :children, class_name: "CamaleonCms::Category", foreign_key: :parent_id, dependent: :destroy
-  belongs_to :parent, class_name: "CamaleonCms::Category", foreign_key: :parent_id
-  belongs_to :post_type_parent, class_name: "CamaleonCms::PostType", foreign_key: :parent_id, inverse_of: :categories
+  # scope :parents, -> { where('term_taxonomy.parent_id IS NULL') }
+  scope :no_empty, -> { where('count > 0') } # return all categories that contains at least one post
+  scope :empty, -> { where(count: [0, nil]) } # return all categories that does not contain any post
+
+  has_many :metas, -> { where(object_class: 'Category') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :objects
+  has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id,
+    dependent: :destroy
+  belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id
+  belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id,
+    inverse_of: :categories
   belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :site_id
-
-  scope :no_empty, ->{ where("count > 0") } # return all categories that contains at least one post
-  scope :empty, ->{ where(count: [0,nil]) } # return all categories that does not contain any post
-
-  #scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
 
   before_save :set_site
   before_destroy :set_posts_in_default_category
 
   # return the post type of this category
   def post_type
-    cama_fetch_cache("post_type") do
+    cama_fetch_cache('post_type') do
       ctg = self
       begin
         pt = ctg.post_type_parent
@@ -30,21 +33,21 @@ class CamaleonCms::Category < CamaleonCms::TermTaxonomy
   end
 
   private
+
   def set_site
-    pt = self.post_type
-    self.site_id = pt.site_id unless self.site_id.present?
-    self.status = pt.id unless self.status.present?
+    pt = post_type
+    site_id = pt.site_id unless site_id.present?
+    status = pt.id unless status.present?
   end
 
   # rescue all posts to assign into default category if they don't have any category assigned
   def set_posts_in_default_category
-    category_default = self.post_type.default_category
+    category_default = post_type.default_category
     return if category_default == self
-    self.posts.each do |post|
-      if post.categories.where.not(id: self.id).blank?
+    posts.each do |post|
+      if post.categories.where.not(id: id).blank?
         post.assign_category(category_default.id)
       end
     end
   end
-
 end

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -1,26 +1,35 @@
 class CamaleonCms::CustomField < ActiveRecord::Base
-  self.primary_key = :id
   include CamaleonCms::Metas
-  has_many :metas, ->{ where(object_class: 'CustomField')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}custom_fields"
-  default_scope {order("#{CamaleonCms::CustomField.table_name}.field_order ASC")}
-  # status: nil -> visible on list group fields
-  # attr_accessible :object_class, :objectid, :description, :parent_id, :count, :name, :slug, :field_order, :status, :is_repeat
-  validates :name, :object_class, presence: true
-  has_many :values, :class_name => "CamaleonCms::CustomFieldsRelationship", :foreign_key => :custom_field_id, dependent: :destroy
-  belongs_to :custom_field_group, class_name: "CamaleonCms::CustomFieldGroup"
-  belongs_to :parent, class_name: "CamaleonCms::CustomField", :foreign_key => :parent_id
-  alias_attribute :label, :name
-  validates_uniqueness_of :slug, scope: [:parent_id, :object_class], unless: lambda{|o| o.is_a?(CamaleonCms::CustomFieldGroup) }
 
-  scope :configuration, -> {where(parent_id: -1)}
-  scope :visible_group, -> {where(status: nil)}
+  self.primary_key = :id
+  self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}custom_fields"
+
+  alias_attribute :label, :name
+
+  default_scope { order("#{CamaleonCms::CustomField.table_name}.field_order ASC") }
+  scope :configuration, -> { where(parent_id: -1) }
+  scope :visible_group, -> { where(status: nil) }
+
+  # status: nil -> visible on list group fields
+  # attr_accessible :object_class, :objectid, :description, :parent_id, :count, :name, :slug,
+  # :field_order, :status, :is_repeat
+  has_many :metas, -> { where(object_class: 'CustomField') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :values, class_name: 'CamaleonCms::CustomFieldsRelationship',
+    foreign_key: :custom_field_id, dependent: :destroy
+  belongs_to :custom_field_group, class_name: 'CamaleonCms::CustomFieldGroup'
+  belongs_to :parent, class_name: 'CamaleonCms::CustomField', foreign_key: :parent_id
+
+  validates :name, :object_class, presence: true
+  validates_uniqueness_of :slug, scope: [:parent_id, :object_class],
+      unless: -> (o){ o.is_a?(CamaleonCms::CustomFieldGroup) }
 
   before_validation :before_validating
 
   private
+
   def before_validating
-    self.slug = self.name if self.slug.blank?
-    self.slug = self.slug.to_s.parameterize
+    slug = name if slug.blank?
+    slug = slug.to_s.parameterize
   end
 end

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -30,6 +30,6 @@ class CamaleonCms::CustomField < ActiveRecord::Base
 
   def before_validating
     slug = name if slug.blank?
-    slug = slug.to_s.parameterize
+    slug.to_s.parameterize
   end
 end

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -1,29 +1,41 @@
 class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
   self.primary_key = :id
+
   # attrs required: name, slug, description
   alias_attribute :site_id, :parent_id
-  default_scope { where.not(object_class: '_fields').reorder("#{CamaleonCms::CustomField.table_name}.field_order ASC") }
 
-  has_many :metas, ->{ where(object_class: 'CustomFieldGroup')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :fields, -> {where(object_class: '_fields')}, :class_name => "CamaleonCms::CustomField", foreign_key: :parent_id, dependent: :destroy
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
+  default_scope {
+    where.not(object_class: '_fields')
+    .reorder("#{CamaleonCms::CustomField.table_name}.field_order ASC")
+  }
+
+  has_many :metas, -> { where(object_class: 'CustomFieldGroup') },
+    class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
+  has_many :fields, -> { where(object_class: '_fields') },
+    class_name: 'CamaleonCms::CustomField', foreign_key: :parent_id, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+
   validates_uniqueness_of :slug, scope: [:object_class, :objectid, :parent_id]
   before_validation :before_validating
 
   # add fields to group
   # item:
-  # -  sample:  {"name"=>"Label", "slug"=>"my_slug", "description"=>"my description (optional)"}
-  # -  options (textbox sample):  {"field_key":"text_box","multiple":"1","required":"1","translate":"1"}
-  #   * field_key (string) | translate (boolean) | default_value (unique value) | default_values (array - multiple values for this field) | label_eval (boolean) | multiple_options (array)
-  #   * multiple_options (used for select, radio and checkboxes ): [{"title"=>"Option Title", "value"=>"2", "default"=>"1"}, {"title"=>"abcde", "value"=>"3"}]
-  #   * label_eval: (Boolean, default false), true => will evaluate the label and description of current field using (eval('my_label')) to have translatable|dynamic labels
-  #****** check all options for each case in Admin::CustomFieldsHelper ****
-  # SAMPLE: my_model.add_field({"name"=>"Sub Title", "slug"=>"subtitle"}, {"field_key"=>"text_box", "translate"=>true, default_value: "Get in Touch"})
+  # - sample:  {"name"=>"Label", "slug"=>"my_slug", "description"=>"my description (optional)"}
+  # - options(textbox sample): {"field_key":"text_box","multiple":"1","required":"1","translate":"1"}
+  #   * field_key (string) | translate (boolean) | default_value (unique value) | default_values
+  #      (array - multiple values for this field) | label_eval (boolean) | multiple_options (array)
+  #   * multiple_options (used for select, radio and checkboxes ): [{"title"=>"Option Title",
+  #      "value"=>"2", "default"=>"1"}, {"title"=>"abcde", "value"=>"3"}]
+  #   * label_eval: (Boolean, default false), true => will evaluate the label and description of
+  #      current field using (eval('my_label')) to have translatable|dynamic labels
+  # ****** check all options for each case in Admin::CustomFieldsHelper ****
+  # SAMPLE: my_model.add_field({"name"=>"Sub Title", "slug"=>"subtitle"}, {"field_key"=>"text_box",
+  #	 "translate"=>true, default_value: "Get in Touch"})
   def add_manual_field(item, options)
-    c = get_field(item[:slug] || item["slug"])
+    c = get_field(item[:slug] || item['slug'])
     return c if c.present?
 
-    field_item = self.fields.new(item)
+    field_item = fields.new(item)
     if field_item.save
       field_item.set_options(options)
       auto_save_default_values(field_item, options)
@@ -34,23 +46,23 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
 
   # return a field with slug = slug from current group
   def get_field(slug)
-    self.fields.where(slug: slug).first
+    fields.find_by(slug: slug)
   end
 
   # only used by form on admin panel (protected)
   # return array of failed_fields and full_fields [[failed fields], [all fields]]
   def add_fields(items, item_options)
-    self.fields.where.not(id: items.map{|k, obj| obj['id'] }.uniq).destroy_all
+    fields.where.not(id: items.map { |k, obj| obj['id'] }.uniq).destroy_all
     cache_fields, order_index, errors_saved = [], 0, []
     if items.present?
-      items.each do |i,item|
+      items.each do |i, item|
         item[:field_order] = order_index
         options = item_options[i] || {}
-        if item[:id].present? && (field_item = self.fields.where(id: item[:id]).first).present?
+        if item[:id].present? && (field_item = fields.find(id: item[:id]))
           saved = field_item.update(item)
           cache_fields << field_item
         else
-          field_item = self.fields.new(item)
+          field_item = fields.new(item)
           cache_fields << field_item
           saved = field_item.save
           auto_save_default_values(field_item, options) if saved
@@ -69,52 +81,55 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
   def get_caption
     caption = ""
     begin
-      case self.object_class
+      case object_class
         when "PostType_Post"
-          caption = "Fields for Contents in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+          caption = "Fields for Contents in <b>#{site.post_types.find(objectid).decorate.the_title}</b>"
         when 'PostType_Category'
-          caption = "Fields for Categories in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+          caption = "Fields for Categories in <b>#{site.post_types.find(objectid).decorate.the_title}</b>"
         when 'PostType_PostTag'
-          caption = "Fields for Post tags in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+          caption = "Fields for Post tags in <b>#{site.post_types.find(objectid).decorate.the_title}</b>"
         when 'Widget::Main'
-          caption = "Fields for Widget <b>(#{CamaleonCms::Widget::Main.find(self.objectid).name.translate})</b>"
+          caption = "Fields for Widget <b>(#{CamaleonCms::Widget::Main.find(objectid).name.translate})</b>"
         when 'Theme'
-          caption = "Field settings for Theme <b>(#{self.site.themes.find(self.objectid).name rescue self.objectid})</b>"
+          caption = "Field settings for Theme <b>(#{site.themes.find(objectid).name rescue objectid})</b>"
         when 'NavMenu'
-          caption = "Field settings for Menus <b>(#{CamaleonCms::NavMenu.find(self.objectid).name})</b>"
+          caption = "Field settings for Menus <b>(#{CamaleonCms::NavMenu.find(objectid).name})</b>"
         when 'Site'
           caption = "Field settings the site"
         when 'PostType'
           caption = "Fields for all <b>Post_Types</b>"
         when 'Post'
-          p = CamaleonCms::Post.find(self.objectid).decorate
+          p = CamaleonCms::Post.find(objectid).decorate
           caption = "Fields for content <b>(#{p.the_title})</b>"
         else # 'Plugin' or other class
-          caption = "Fields for <b>#{self.object_class}</b>"
+          caption = "Fields for <b>#{object_class}</b>"
       end
     rescue => e
-      Rails.logger.info "----------#{e.message}----#{self.attributes}"
+      Rails.logger.info "----------#{e.message}----#{attributes}"
     end
     caption
   end
 
   private
+
   def before_validating
-    self.slug = "_group-#{self.name.to_s.parameterize}" unless self.slug.present?
+    slug = "_group-#{name.to_s.parameterize}" unless slug.present?
   end
 
   # auto save the default field values
   def auto_save_default_values(field, options)
     options = options.with_indifferent_access
-    class_name = self.object_class.split("_").first
-    if ["Post", "Category", "Plugin", "Theme"].include?(class_name) && self.objectid.present? && (options[:default_value].present? || options[:default_values].present?)
+    class_name = object_class.split("_").first
+    if %w(Post Category Plugin Theme).include?(class_name) && objectid.present? &&
+      (options[:default_value].present? || options[:default_values].present?)
       if class_name == "Theme"
-        owner = "CamaleonCms::#{class_name}".constantize.where(id: self.objectid).first # owner model
+        owner = "CamaleonCms::#{class_name}".constantize.find(objectid) # owner model
       else
-        owner = "CamaleonCms::#{class_name}".constantize.find(self.objectid) rescue "CamaleonCms::#{class_name}".constantize.where(slug: self.objectid).first # owner model
+        owner = "CamaleonCms::#{class_name}".constantize.find(objectid) rescue "CamaleonCms::#{class_name}".constantize.find_by(slug: objectid) # owner model
       end
       (options[:default_values] || [options[:default_value]] || []).each do |value|
-        owner.field_values.create!({custom_field_id: field.id, custom_field_slug: field.slug, value: fix_meta_value(value)}) if owner.present?
+        owner.field_values.create!({ custom_field_id: field.id, custom_field_slug: field.slug,
+          value: fix_meta_value(value) }) if owner.present?
       end
     end
   end

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -1,9 +1,13 @@
 class CamaleonCms::CustomFieldsRelationship < ActiveRecord::Base
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}custom_fields_relationships"
-  # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class, :custom_field_slug, :group_number
-  default_scope {order("#{CamaleonCms::CustomFieldsRelationship.table_name}.term_order ASC")}
+
+  # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class,
+  # :custom_field_slug, :group_number
+  default_scope { order("#{CamaleonCms::CustomFieldsRelationship.table_name}.term_order ASC") }
+
   # relations
-  belongs_to :custom_fields, :class_name => "CamaleonCms::CustomField", foreign_key: :custom_field_id
+  belongs_to :custom_fields, class_name: 'CamaleonCms::CustomField',
+    foreign_key: :custom_field_id
 
   # validates :objectid, :custom_field_id, presence: true
   validates :custom_field_id, presence: true # error on clone model
@@ -11,8 +15,8 @@ class CamaleonCms::CustomFieldsRelationship < ActiveRecord::Base
   after_save :set_parent_slug
 
   private
-  def set_parent_slug
-    #self.update_column('custom_field_slug', self.custom_fields.slug)
-  end
 
+  def set_parent_slug
+    # self.update_column('custom_field_slug', self.custom_fields.slug)
+  end
 end

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -15,7 +15,7 @@ class CamaleonCms::NavMenu < CamaleonCms::TermTaxonomy
   # value: (Hash) is a hash object that contains label, type, link
   #   options for type: post | category | post_type | post_tag | external
   # sample: {label: "my label", type: "external", link: "http://camaleon.tuzitio.com",
-  #	  target: '_blank'}
+  #   target: '_blank'}
   # sample: {label: "my label", type: "post", link: 10}
   # sample: {label: "my label", type: "category", link: 12}
   # return item created

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -1,19 +1,27 @@
 class CamaleonCms::NavMenu < CamaleonCms::TermTaxonomy
-  default_scope { where(taxonomy: :nav_menu).order(id: :asc) }
+
   alias_attribute :site_id, :parent_id
-  has_many :metas, ->{ where(object_class: 'NavMenu')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :children, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id, inverse_of: :nav_menus
+
+  default_scope { where(taxonomy: :nav_menu).order(id: :asc) }
+
+  has_many :metas, -> { where(object_class: 'NavMenu') }, class_nam: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :children, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id,
+    dependent: :destroy, inverse_of: :parent
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id,
+    inverse_of: :nav_menus
 
   # add menu item for current menu
   # value: (Hash) is a hash object that contains label, type, link
   #   options for type: post | category | post_type | post_tag | external
-  # sample: {label: "my label", type: "external", link: "http://camaleon.tuzitio.com", target: '_blank'}
+  # sample: {label: "my label", type: "external", link: "http://camaleon.tuzitio.com",
+  #	  target: '_blank'}
   # sample: {label: "my label", type: "post", link: 10}
   # sample: {label: "my label", type: "category", link: 12}
   # return item created
   def append_menu_item (value)
-    item = children.create!({name: value[:label], url: value[:link], kind: value[:type], target: value[:target]})
+    item = children.create!({ name: value[:label], url: value[:link], kind: value[:type],
+      target: value[:target] })
     item
   end
 
@@ -23,6 +31,7 @@ class CamaleonCms::NavMenu < CamaleonCms::TermTaxonomy
   end
 
   private
+
   # overwrite termtaxonomy method
   def destroy_dependencies
   end

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -30,7 +30,7 @@ class CamaleonCms::NavMenuItem < CamaleonCms::TermTaxonomy
 
   # check if this menu have children
   def have_children?
-    children.count != 0
+    children.any?
   end
 
   # add sub menu for a menu item

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -5,57 +5,66 @@ class CamaleonCms::NavMenuItem < CamaleonCms::TermTaxonomy
   alias_attribute :kind, :slug
   alias_attribute :target, :status
   # attr_accessible :label, :url, :kind
+
   default_scope { where(taxonomy: :nav_menu_item).order(id: :asc) }
-  has_many :metas, ->{ where(object_class: 'NavMenuItem')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :parent, class_name: "CamaleonCms::NavMenu", inverse_of: :children
-  belongs_to :parent_item, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, inverse_of: :children
-  has_many :children, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent_item
+
+  has_many :metas, -> { where(object_class: 'NavMenuItem') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :parent, class_name: 'CamaleonCms::NavMenu', inverse_of: :children
+  belongs_to :parent_item, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id,
+    inverse_of: :children
+  has_many :children, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id,
+    dependent: :destroy, inverse_of: :parent_item
 
   before_create :set_parent_site
   after_create :update_count
-  #before_destroy :update_count
+  # before_destroy :update_count
 
   # return the main menu
   def main_menu
-    main_menu = self.parent
+    main_menu = parent
     return main_menu if main_menu.present?
-    parent_menu = self.parent_item
+    parent_menu = parent_item
     parent_menu.main_menu if parent_menu.present?
   end
 
   # check if this menu have children
   def have_children?
-    self.children.count != 0
+    children.count != 0
   end
 
   # add sub menu for a menu item
   # same values of NavMenu#append_menu_item
   # return item created
   def append_menu_item(value)
-    children.create({name: value[:label], url: value[:link], kind: value[:type], target: value[:target]})
+    children.create({ name: value[:label], url: value[:link], kind: value[:type],
+      target: value[:target] })
   end
 
   # update current menu
   # value: same as append_menu_item (label, link, target)
   def update_menu_item(value)
-    self.update({name: value[:label], url: value[:link], target: value[:target]})
+    update({ name: value[:label], url: value[:link], target: value[:target] })
   end
 
   # overwrite skip uniq slug validation
   def skip_slug_validation?; true end
 
   private
+
   def update_count
-    self.parent.update_column('count', self.parent.children.size) if self.parent.present?
-    self.parent_item.update_column('count', self.parent_item.children.size) if self.parent_item.present?
-    self.update_column(:term_group, main_menu.parent_id)
-    self.update_column(:term_order, CamaleonCms::NavMenuItem.where(parent_id: self.parent_id).count) # update position
+    parent.update_column('count', parent.children.size) if parent.present?
+    parent_item.update_column('count', parent_item.children.size) if parent_item.present?
+    update_column(:term_group, main_menu.parent_id)
+    # update position
+    update_column(:term_order, CamaleonCms::NavMenuItem.where(parent_id: parent_id).count)
   end
 
   # fast access from site to menu items
   def set_parent_site
-    self.site_id = self.parent_item.site_id if self.parent_item.present?
-    self.site_id = self.parent.site_id if self.parent.present?
+    site_id = parent_item.site_id if parent_item.present?
+    site_id = parent.site_id if parent.present?
+    site_id
   end
 
   # overwrite inherit method

--- a/app/models/camaleon_cms/plugin.rb
+++ b/app/models/camaleon_cms/plugin.rb
@@ -6,35 +6,36 @@ class CamaleonCms::Plugin < CamaleonCms::TermTaxonomy
 
   attr_accessor :error
 
-  has_many :metas, -> { where(object_class: 'Plugin') }, class_name: "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :site, class_name: "CamaleonCms::Site", foreign_key: :parent_id
-
   default_scope { where(taxonomy: :plugin) }
   scope :active, -> { where(term_group: 1) }
+
+  has_many :metas, -> { where(object_class: 'Plugin') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
 
   before_validation :set_default
   before_destroy :destroy_custom_fields
 
   # active the plugin
   def active
-    self.term_group = 1
-    self.save
+    term_group = 1
+    save
   end
 
   # inactive the plugin
   def inactive
-    self.term_group = nil
-    self.save
+    term_group = nil
+    save
   end
 
   # check if plugin is active
   def active?
-    self.term_group.to_s == "1"
+    term_group.to_s == '1'
   end
 
   # return theme settings configured in config.json
   def settings
-    PluginRoutes.plugin_info(self.slug)
+    PluginRoutes.plugin_info(slug)
   end
 
   # check if current installation version is older
@@ -46,32 +47,32 @@ class CamaleonCms::Plugin < CamaleonCms::TermTaxonomy
 
   # set a new installation version for this plugin
   def installed_version=(version)
-    self.set_option("version_installed", version)
+    set_option('version_installed', version)
   end
 
   # return gem installed version
   def installed_version
     return ""
-    res = self.get_option("version_installed")
+    res = get_option('version_installed')
     unless res.present? # fix for old installations
-      res = self.settings["version"]
-      self.installed_version= res
+      res = settings['version']
+      installed_version = res
     end
     res
   end
 
   # return the title of this plugin
   def title
-    PluginRoutes.plugin_info(self.slug)["title"]
+    PluginRoutes.plugin_info(slug)['title']
   end
 
   private
+
   def set_default
-    self.name = self.slug unless self.name.present?
+    name = slug unless name.present?
   end
 
   def destroy_custom_fields
-    self.get_field_groups.destroy_all
+    get_field_groups.destroy_all
   end
-
 end

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -4,12 +4,14 @@ class CamaleonCms::PostUniqValidator < ActiveModel::Validator
       slug_array = record.slug.to_s.translations_array
       ptype = record.post_type
       if ptype.present? # only for posts that belongs to a post type model
-        posts = ptype.site.posts.where("(#{slug_array.map {|s| "#{CamaleonCms::Post.table_name}.slug LIKE '%-->#{s}<!--%'"}.join(" OR ")} ) OR #{CamaleonCms::Post.table_name}.slug = ?",  record.slug).where("#{CamaleonCms::Post.table_name}.status != 'draft'").where.not(id: record.id)
-        if posts.size > 0
+        posts = ptype.site.posts.where("(#{slug_array.map { |s| "#{CamaleonCms::Post.table_name}.slug LIKE '%-->#{s}<!--%'"}
+          .join(" OR ")} ) OR #{CamaleonCms::Post.table_name}.slug = ?", record.slug)
+          .where("#{CamaleonCms::Post.table_name}.status != 'draft'").where.not(id: record.id)
+        if !posts.empty?
           if slug_array.size > 1
-            record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{posts.pluck(:slug).map{|slug| record.slug.to_s.translations.map{|lng, r_slug| "#{r_slug} (#{lng})" if slug.translations_array.include?(r_slug) }.join(",") }.join(",").split(",").uniq.clean_empty.join(", ")} "
+            record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{posts.pluck(:slug).map{|slug| record.slug.to_s.translations.map{|lng, r_slug| "#{r_slug} (#{lng})" if slug.translations_array.include?(r_slug) }.join(",") }.join(",").split(",").uniq.clean_empty.join(", ")}"
           else
-            record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{record.slug.to_s} "
+            record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{record.slug}"
           end
         end
 
@@ -24,45 +26,55 @@ end
 
 class CamaleonCms::Post < CamaleonCms::PostDefault
   include CamaleonCms::CategoriesTagsForPosts
+
   alias_attribute :post_type_id, :taxonomy_id
-  default_scope ->{ where(post_class: "Post").order(post_order: :asc, created_at: :desc) }
-  has_many :metas, ->{ where(object_class: 'Post')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :delete_all
+  attr_accessor :show_title_with_parent
+
+  default_scope -> { where(post_class: 'Post').order(post_order: :asc, created_at: :desc) }
+  scope :visible_frontend, -> { where(status: 'published') }
+  # public posts (not passwords, not privates)
+  scope :public_posts, -> { visible_frontend.where(visibility: ['public', ""]) }
+  scope :trash, -> { where(status: 'trash') }
+  scope :no_trash, -> { where.not(status: 'trash') }
+  scope :published, -> { where(status: 'published') }
+  scope :root_posts, -> { where(post_parent: [nil, '']) }
+  scope :drafts, -> { where(status: 'draft') }
+  scope :pendings, -> { where(status: 'pending') }
+  scope :latest, -> { reorder(created_at: :desc) }
 
   # DEPRECATED
-  has_many :post_relationships, class_name: "CamaleonCms::PostRelationship", foreign_key: :objectid, dependent: :destroy,  inverse_of: :posts
-  has_many :post_types, class_name: "CamaleonCms::PostType", through: :post_relationships, :source => :post_type
+  has_many :post_relationships, class_name: 'CamaleonCms::PostRelationship', foreign_key: :objectid,
+    dependent: :destroy, inverse_of: :posts
+  has_many :post_types, class_name: 'CamaleonCms::PostType', through: :post_relationships,
+    source: :post_type
   # END DEPRECATED
 
-  has_many :term_relationships, class_name: "CamaleonCms::TermRelationship", foreign_key: :objectid, dependent: :destroy,  inverse_of: :objects
-  has_many :categories, class_name: "CamaleonCms::Category", through: :term_relationships, :source => :term_taxonomies
-  has_many :post_tags, class_name: "CamaleonCms::PostTag", through: :term_relationships, :source => :term_taxonomies
-  has_many :comments, class_name: "CamaleonCms::PostComment", foreign_key: :post_id, dependent: :destroy
-  has_many :drafts, ->{where(status: 'draft')}, class_name: "CamaleonCms::Post", foreign_key: :post_parent, dependent: :destroy
-  has_many :children, class_name: "CamaleonCms::Post", foreign_key: :post_parent, dependent: :destroy, primary_key: :id
-
-  belongs_to :owner, class_name: "CamaleonCms::User", foreign_key: :user_id
-  belongs_to :parent, class_name: "CamaleonCms::Post", foreign_key: :post_parent
-  belongs_to :post_type, class_name: "CamaleonCms::PostType", foreign_key: :taxonomy_id, inverse_of: :posts
-
-  scope :visible_frontend, -> {where(status: 'published')}
-  scope :public_posts, -> {visible_frontend.where(visibility: ['public', ""]) } #public posts (not passwords, not privates)
-
-  scope :trash, -> {where(status: 'trash')}
-  scope :no_trash, -> {where.not(status: 'trash')}
-  scope :published, -> {where(status: 'published')}
-  scope :root_posts, -> {where(post_parent: [nil, ''])}
-  scope :drafts, -> {where(status: 'draft')}
-  scope :pendings, -> {where(status: 'pending')}
-  scope :latest, -> {reorder(created_at: :desc)}
+  has_many :metas, -> { where(object_class: 'Post') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :delete_all
+  has_many :term_relationships, class_name: 'CamaleonCms::TermRelationship', foreign_key: :objectid,
+    dependent: :destroy, inverse_of: :objects
+  has_many :categories, class_name: 'CamaleonCms::Category', through: :term_relationships,
+    source: :term_taxonomies
+  has_many :post_tags, class_name: 'CamaleonCms::PostTag', through: :term_relationships,
+    source: :term_taxonomies
+  has_many :comments, class_name: 'CamaleonCms::PostComment', foreign_key: :post_id,
+    dependent: :destroy
+  has_many :drafts, ->{ where(status: 'draft') }, class_name: 'CamaleonCms::Post',
+    foreign_key: :post_parent, dependent: :destroy
+  has_many :children, class_name: 'CamaleonCms::Post', foreign_key: :post_parent,
+    dependent: :destroy, primary_key: :id
+  belongs_to :owner, class_name: 'CamaleonCms::User', foreign_key: :user_id
+  belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent
+  belongs_to :post_type, class_name: 'CamaleonCms::PostType', foreign_key: :taxonomy_id,
+  inverse_of: :posts
 
   validates_with CamaleonCms::PostUniqValidator
-  attr_accessor :show_title_with_parent
 
   # return all parents for current page hierarchy ordered bottom to top
   def parents
-    cama_fetch_cache("parents_#{self.id}") do
+    cama_fetch_cache("parents_#{id}") do
       res = []
-      p = self.parent
+      p = parent
       while p.present?
         res << p
         p = p.parent
@@ -73,9 +85,9 @@ class CamaleonCms::Post < CamaleonCms::PostDefault
 
   # return all children elements for current post (page hierarchy)
   def full_children
-    cama_fetch_cache("full_children_#{self.id}") do
-      res = self.children.to_a
-      res.each{|c|  res += c.full_children }
+    cama_fetch_cache("full_children_#{id}") do
+      res = children.to_a
+      res.each { |c| res += c.full_children }
       res
     end
   end
@@ -108,49 +120,49 @@ class CamaleonCms::Post < CamaleonCms::PostDefault
   # check if current post can manage content
   # return boolean
   def manage_content?(posttype = nil)
-    get_option('has_content', (posttype || self.post_type).get_option('has_content', true))
+    get_option('has_content', (posttype || post_type).get_option('has_content', true))
   end
 
   # return boolean
   def manage_layout?(posttype = nil)
-    get_option('has_layout', (posttype || self.post_type).get_option('has_layout', false))
+    get_option('has_layout', (posttype || post_type).get_option('has_layout', false))
   end
 
   # check if current post can manage template
   # return boolean
   def manage_template?(posttype = nil)
-    get_option('has_template', (posttype || self.post_type).get_option('has_template', true))
+    get_option('has_template', (posttype || post_type).get_option('has_template', true))
   end
 
   # check if current post can manage summary
   # return boolean
   def manage_summary?(posttype = nil)
-    get_option('has_summary', (posttype || self.post_type).get_option('has_summary', true))
+    get_option('has_summary', (posttype || post_type).get_option('has_summary', true))
   end
 
   # check if current post can manage keywords
   # return boolean
   def manage_keywords?(posttype = nil)
-    get_option('has_keywords', (posttype || self.post_type).get_option('has_keywords', true))
+    get_option('has_keywords', (posttype || post_type).get_option('has_keywords', true))
   end
 
   # check if current post can manage picture
   # return boolean
   def manage_picture?(posttype = nil)
-    get_option('has_picture', (posttype || self.post_type).get_option('has_picture', true))
+    get_option('has_picture', (posttype || post_type).get_option('has_picture', true))
   end
 
   # check if current post can manage comments
   # return boolean
   def manage_comments?(posttype = nil)
-    get_option('has_comments', (posttype || self.post_type).get_option('has_comments', false))
+    get_option('has_comments', (posttype || post_type).get_option('has_comments', false))
   end
 
   # check if the post can be commented
   # sample: @post.can_commented?
   # return Boolean (true/false)
   def can_commented?
-    manage_comments? && get_meta('has_comments').to_s == "1"
+    manage_comments? && get_meta('has_comments').to_s == '1'
   end
 
   # define post configuration for current post
@@ -161,10 +173,13 @@ class CamaleonCms::Post < CamaleonCms::PostDefault
   #   has_picture, boolean (default true)
   #   has_template, boolean (default false)
   #   has_comments, boolean (default false)
-  #   default_layout:  (string) (default layout) # this is still used if post type was inactivated layout and overwritten by dropdown in post view
-  #   default_template:  (string) (default template) # this is still used if post type was inactivated template and overwritten by dropdown in post view
+  #   default_layout:  (string) (default layout) # this is still used if post type was inactivated
+  #     layout and overwritten by dropdown in post view
+  #   default_template:  (string) (default template) # this is still used if post type was
+  #     inactivated template and overwritten by dropdown in post view
   #   has_layout:  (boolean) (default false)
-  #   skip_fields:  (array) (default empty) array of custom field keys to avoid for this post, sample: ["subtitle", "icon"]
+  #   skip_fields:  (array) (default empty) array of custom field keys to avoid for this post,
+  #     sample: ["subtitle", "icon"]
   # val: value for the setting
   def set_setting(key, val)
     set_option(key, val)
@@ -172,71 +187,71 @@ class CamaleonCms::Post < CamaleonCms::PostDefault
 
   # assign multiple settings
   def set_settings(settings = {})
-    settings.each do |key, val|
-      set_setting(key, val)
-    end
+    settings.each { |key, val| set_setting(key, val) }
   end
 
   # put a new order position for this post
   # new_order_position: (Integer) position number
   # return nil
   def set_position(new_order_position)
-    self.update_column("post_order", new_order_position)
+    update_column('post_order', new_order_position)
   end
 
   # save the summary for current post
   # summary: Text String without html
   def set_summary(summary)
-    set_meta("summary", summary)
+    set_meta('summary', summary)
   end
 
   # save the thumbnail url for current post
   # thumb_url: String url
   def set_thumb(thumb_url)
-    set_meta("thumb", thumb_url)
+    set_meta('thumb', thumb_url)
   end
 
   # save the layout name to be used on render this post
   # layout_name: String layout name: my_layout.html.erb => 'my_layout'
   def set_layout(layout_name)
-    set_meta("layout", layout_name)
+    set_meta('layout', layout_name)
   end
 
   # return the layout assigned to this post
   # post_type: post type owner of this post
   def get_layout(posttype = nil)
-    return get_option("default_layout") if !manage_layout?(posttype)
-    get_meta('layout', get_option("default_layout") || (posttype || self.post_type).get_option('default_layout', nil))
+    return get_option('default_layout') if !manage_layout?(posttype)
+    get_meta('layout', get_option('default_layout') ||
+      (posttype || post_type).get_option('default_layout', nil))
   end
 
   # return the template assigned to this post
   # verify default template defined in post type
   # post_type: post type owner of this post
   def get_template(posttype = nil)
-    return get_option("default_template") if !manage_template?(posttype)
-    get_meta('template', get_option("default_template") || (posttype || self.post_type).get_option('default_template', nil))
+    return get_option('default_template') if !manage_template?(posttype)
+    get_meta('template', get_option('default_template') ||
+      (posttype || post_type).get_option('default_template', nil))
   end
 
   # increment the counter of visitors
   def increment_visits!
-    set_meta("visits", total_visits+1)
+    set_meta('visits', total_visits+1)
   end
 
   # return the quantity of visits for this post
   def total_visits
-    get_meta("visits", 0).to_i
+    get_meta('visits', 0).to_i
   end
 
   # return the quantity of comments for this post
   # TODO comments count
   def total_comments
-    self.get_meta("comments_count", 0).to_i
+    get_meta('comments_count', 0).to_i
   end
 
   # manage the custom decorators for posts
   # sample: my_post_type.set_option('cama_post_decorator_class', 'ProductDecorator')
-    # Sample: https://github.com/owen2345/camaleon-ecommerce/tree/master/app/decorators/
+  # Sample: https://github.com/owen2345/camaleon-ecommerce/tree/master/app/decorators/
   def decorator_class
-    (self.post_type.get_option('cama_post_decorator_class', 'CamaleonCms::PostDecorator') rescue 'CamaleonCms::PostDecorator').constantize
+    (post_type.get_option('cama_post_decorator_class', 'CamaleonCms::PostDecorator') rescue 'CamaleonCms::PostDecorator').constantize
   end
 end

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -1,44 +1,48 @@
 class CamaleonCms::PostComment < ActiveRecord::Base
   include CamaleonCms::Metas
+
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}comments"
-  # attr_accessible :user_id, :post_id, :content, :author, :author_email, :author_url, :author_IP, :approved, :agent, :agent, :typee, :comment_parent, :is_anonymous
+
+  # attr_accessible :user_id, :post_id, :content, :author, :author_email, :author_url, :author_IP,
+  # :approved, :agent, :agent, :typee, :comment_parent, :is_anonymous
   attr_accessor :is_anonymous
 
   #default_scope order('comments.created_at ASC')
   #approved: approved | pending | spam
 
-  has_many :metas, ->{ where(object_class: 'PostComment')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :children, class_name: "CamaleonCms::PostComment", foreign_key: :comment_parent, dependent: :destroy
-  belongs_to :post, class_name: "CamaleonCms::Post", foreign_key: :post_id
-  belongs_to :parent, class_name: "CamaleonCms::PostComment", foreign_key: :comment_parent
-  belongs_to :user, class_name: "CamaleonCms::User", foreign_key: :user_id
+  default_scope { order("#{CamaleonCms::PostComment.table_name}.created_at DESC") }
+  scope :main, -> { where(comment_parent: nil) }
+  scope :comment_parent, -> { where(comment_parent: 'is not null') }
+  scope :approveds, -> { where(approved: 'approved') }
 
-  default_scope {order("#{CamaleonCms::PostComment.table_name}.created_at DESC")}
+  has_many :metas, -> { where(object_class: 'PostComment')}, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :children, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent,
+    dependent: :destroy
+  belongs_to :post, class_name: 'CamaleonCms::Post', foreign_key: :post_id
+  belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent
+  belongs_to :user, class_name: 'CamaleonCms::User', foreign_key: :user_id
 
-  scope :main, -> { where(:comment_parent => nil) }
-  scope :comment_parent, -> { where(:comment_parent => 'is not null') }
-  scope :approveds, -> { where(:approved => 'approved') }
-
-  validates :content, :presence => true
+  validates :content, presence: true
   validates_presence_of :author, :author_email, if: Proc.new { |c| c.is_anonymous.present? }
+
   after_create :update_counter
   after_destroy :update_counter
 
   # return the owner of this comment
   def comment_user
-    self.user
+    user
   end
 
   # check if this comments is already approved
   def is_approved?
-    self.approved == 'approved'
+   approved == 'approved'
   end
 
   private
+
   # update comment counter
   def update_counter
-    p = self.post
-    p.set_meta("comments_count", p.comments.count) if p.present?
+    post.set_meta('comments_count', p.comments.count) if post.present?
   end
-
 end

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -1,18 +1,23 @@
 class CamaleonCms::PostDefault < ActiveRecord::Base
   include CamaleonCms::Metas
   include CamaleonCms::CustomFieldsRead
+  
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}posts"
 
-  # attr_accessible :user_id, :title, :slug, :content, :content_filtered, :status,  :visibility, :visibility_value, :post_order, :post_type_key, :taxonomy_id, :published_at, :post_parent, :post_order, :is_feature
+  # attr_accessible :user_id, :title, :slug, :content, :content_filtered, :status,  :visibility, 
+  # :visibility_value, :post_order, :post_type_key, :taxonomy_id, :published_at, :post_parent, 
+  # :post_order, :is_feature
   attr_accessor :draft_id
   # attr_accessible :data_options
   # attr_accessible :data_metas
   cattr_accessor :current_user
   cattr_accessor :current_site
 
-  has_many :term_relationships, class_name: "CamaleonCms::TermRelationship", foreign_key: :objectid, dependent: :destroy, primary_key: :id
-  has_many :children, ->{ where(post_class: "PostDefault") }, class_name: "CamaleonCms::PostDefault", foreign_key: :post_parent, dependent: :destroy, primary_key: :id
-  scope :featured, ->{ where(is_feature: true) }
+  has_many :term_relationships, class_name: 'CamaleonCms::TermRelationship', foreign_key: :objectid,
+    dependent: :destroy, primary_key: :id
+  has_many :children, -> { where(post_class: 'PostDefault') }, class_name: 'CamaleonCms::PostDefault',
+    foreign_key: :post_parent, dependent: :destroy, primary_key: :id
+  scope :featured, -> { where(is_feature: true) }
 
   validates :title, :slug, presence: true
 
@@ -25,22 +30,22 @@ class CamaleonCms::PostDefault < ActiveRecord::Base
   # find a content by slug (support multi language)
   def self.find_by_slug(slug)
     if current_site.present? && current_site.get_meta("languages_site", []).count <= 1
-      res = self.where(slug: slug)
+      res = where(slug: slug)
     else
-      res = self.where("#{CamaleonCms::Post.table_name}.slug = ? OR #{CamaleonCms::Post.table_name}.slug LIKE ? ", slug, "%-->#{slug}<!--%")
+      res = where("#{CamaleonCms::Post.table_name}.slug = ? OR #{CamaleonCms::Post.table_name}.slug LIKE ? ", slug, "%-->#{slug}<!--%")
     end
     res.reorder("").first
   end
 
   # return the parent of a post (support for sub contents or tree of posts)
   def parent
-    CamaleonCms::Post.where(id: self.post_parent).first
+    CamaleonCms::Post.find(post_parent)
   end
 
   # return the author of this Content
   def author
     begin
-      CamaleonCms::User.find(self.user_id)
+      CamaleonCms::User.find(user_id)
     rescue
       CamaleonCms::User.admin_scope.first
     end
@@ -48,17 +53,18 @@ class CamaleonCms::PostDefault < ActiveRecord::Base
 
   # return all menu items in which this post was assigned
   def in_nav_menu_items
-    CamaleonCms::NavMenuItem.where(url: self.id, kind: 'post')
+    CamaleonCms::NavMenuItem.where(url: id, kind: 'post')
   end
 
   # Set the meta, field values and the post keywords here
   def set_params(meta, custom_fields, options)
-    self.set_metas(meta)
-    self.set_field_values(custom_fields)
-    self.set_options(options)
+    set_metas(meta)
+    set_field_values(custom_fields)
+    set_options(options)
   end
 
   private
+
   def before_validating
     #self.slug = self.title if self.slug.blank?
     #self.slug = self.slug.to_s.parameterize
@@ -66,8 +72,13 @@ class CamaleonCms::PostDefault < ActiveRecord::Base
 
   # do all before actions to save the content
   def before_saved
-    self.title = "Untitled" unless self.title.present?
-    self.content_filtered = content.to_s.include?('<!--:-->') ? content.translations.inject({}) { |h, (key, value)| h[key] = value.squish.strip_tags; h }.to_translate : content.to_s.squish.strip_tags
+    title = 'Untitled' unless title.present?
+    content_filtered =
+      if content.to_s.include?('<!--:-->')
+        content.translations.inject({}) { |h, (key, value)| h[key] = value.squish.strip_tags; h }.to_translate
+      else
+        content.to_s.squish.strip_tags
+      end
   end
 
   # destroy all dependencies of this content

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -1,7 +1,7 @@
 class CamaleonCms::PostDefault < ActiveRecord::Base
   include CamaleonCms::Metas
   include CamaleonCms::CustomFieldsRead
-  
+
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}posts"
 
   # attr_accessible :user_id, :title, :slug, :content, :content_filtered, :status,  :visibility, 

--- a/app/models/camaleon_cms/post_relationship.rb
+++ b/app/models/camaleon_cms/post_relationship.rb
@@ -1,20 +1,23 @@
-
 # DEPRECATED MODEL, NOT USED ANY MORE
 class CamaleonCms::PostRelationship < ActiveRecord::Base
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}term_relationships"
-  # attr_accessible :objectid, :term_taxonomy_id, :term_order
-  default_scope ->{ order(term_order: :asc) }
 
-  belongs_to :post_type, :class_name => "CamaleonCms::PostType", foreign_key: :term_taxonomy_id, inverse_of: :post_relationships
-  belongs_to :posts, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, :class_name => "CamaleonCms::Post", foreign_key: :objectid, inverse_of: :post_relationships, dependent: :destroy
+  # attr_accessible :objectid, :term_taxonomy_id, :term_order
+  default_scope -> { order(term_order: :asc) }
+
+  belongs_to :post_type, class_name: 'CamaleonCms::PostType', foreign_key: :term_taxonomy_id,
+    inverse_of: :post_relationships
+  belongs_to :posts, -> { order("#{CamaleonCms::Post.table_name}.id DESC") },
+    class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :post_relationships,
+    dependent: :destroy
 
   # callbacks
   after_create :update_count
   before_destroy :update_count
 
   private
-  def update_count
-    self.post_type.update_column('count', self.post_type.posts.size) if self.post_type.present?
-  end
 
+  def update_count
+    post_type.update_column('count', post_type.posts.size) if post_type.present?
+  end
 end

--- a/app/models/camaleon_cms/post_tag.rb
+++ b/app/models/camaleon_cms/post_tag.rb
@@ -1,7 +1,10 @@
 class CamaleonCms::PostTag < CamaleonCms::TermTaxonomy
   default_scope { where(taxonomy: :post_tag) }
-  has_many :metas, ->{ where(object_class: 'PostTag')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
-  belongs_to :post_type, class_name: "CamaleonCms::PostType", foreign_key: :parent_id, inverse_of: :post_tags
-  belongs_to :owner, class_name: "CamaleonCms::User", foreign_key: :user_id
+
+  has_many :metas, -> { where(object_class: 'PostTag') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :objects
+  belongs_to :post_type, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id,
+    inverse_of: :post_tags
+  belongs_to :owner, class_name: 'CamaleonCms::User', foreign_key: :user_id
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -1,20 +1,28 @@
 class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   alias_attribute :site_id, :parent_id
+
   default_scope { where(taxonomy: :post_type) }
-  has_many :metas, ->{ where(object_class: 'PostType')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :delete_all
-  has_many :categories, :class_name => "CamaleonCms::Category", foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type_parent
-  has_many :post_tags, :class_name => "CamaleonCms::PostTag", foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type
-  has_many :posts, class_name: "CamaleonCms::Post", foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type
+  scope :visible_menu, -> { where(term_group: nil) }
+  scope :hidden_menu, -> { where(term_group: -1) }
+
+  has_many :metas, -> { where(object_class: 'PostType') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :delete_all
+  has_many :categories, class_name: 'CamaleonCms::Category', foreign_key: :parent_id,
+    dependent: :destroy, inverse_of: :post_type_parent
+  has_many :post_tags, class_name: 'CamaleonCms::PostTag', foreign_key: :parent_id,
+    dependent: :destroy, inverse_of: :post_type
+  has_many :posts, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id, dependent: :destroy,
+    inverse_of: :post_type
   has_many :comments, through: :posts
-  has_many :posts_through_categories, foreign_key: :objectid, through: :term_relationships, :source => :objects
-  has_many :posts_draft, class_name: "CamaleonCms::Post", foreign_key: :taxonomy_id, dependent: :destroy, source: :drafts, inverse_of: :post_type
-  has_many :field_group_taxonomy, -> {where("object_class LIKE ?","PostType_%")}, :class_name => "CamaleonCms::CustomField", foreign_key: :objectid, dependent: :destroy
+  has_many :posts_through_categories, foreign_key: :objectid, through: :term_relationships,
+    source: :objects
+  has_many :posts_draft, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id,
+    dependent: :destroy, source: :drafts, inverse_of: :post_type
+  has_many :field_group_taxonomy, -> { where("object_class LIKE ?","PostType_%") },
+    class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy
+  belongs_to :owner, class_name: 'CamaleonCms::User', foreign_key: :user_id
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
 
-  belongs_to :owner, class_name: "CamaleonCms::User", foreign_key: :user_id
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
-
-  scope :visible_menu, -> {where(term_group: nil)}
-  scope :hidden_menu, -> {where(term_group: -1)}
   before_destroy :destroy_field_groups
   after_create :set_default_site_user_roles
   after_create :refresh_routes
@@ -30,12 +38,12 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   # hide or show this post type on admin -> contents -> menu
   # true => enable, false => disable
   def toggle_show_for_admin_menu(flag)
-    self.update(term_group: flag == true ? nil : -1)
+    update(term_group: flag == true ? nil : -1)
   end
 
   # check if this post type is shown on admin -> contents -> menu
   def show_for_admin_menu?
-    self.term_group == nil
+    term_group == nil
   end
 
   # check if this post type manage post tags
@@ -60,28 +68,28 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   # }
   def set_settings(settings = {})
     settings.each do |key, val|
-      self.set_option(key, val)
+      set_option(key, val)
     end
   end
 
   # set or update a setting for this post type
   def set_setting(key, value)
-    self.set_option(key, value)
+    set_option(key, value)
   end
 
   # select full_categories for the post type, include all children categories
   def full_categories
-    s = self.site
-    CamaleonCms::Category.where("term_group = ? or status in (?)", s.id, s.post_types.pluck(:id).to_s)
+    CamaleonCms::Category.where("term_group = ? or status in (?)",
+      site.id, site.post_types.pluck(:id))
   end
 
   # return default category for this post type
   # only return a category for post types that manage categories
   def default_category
     if manage_categories?
-      cat = self.categories.find_by_slug("uncategorized")
+      cat = categories.find_by_slug("uncategorized")
       unless cat.present?
-        cat = self.categories.create({name: 'Uncategorized', slug: 'uncategorized', parent_id: self.id})
+        cat = categories.create({ name: 'Uncategorized', slug: 'uncategorized', parent_id: id })
         cat.set_option("not_deleted", true)
       end
       cat
@@ -91,17 +99,23 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   # add a post for current model
   #   title: title for post,    => required
   #   content: html text content, => required
-  #   thumb: image url, => default (empty). check http://camaleon.tuzitio.com/api-methods.html#section_fileuploads
+  #   thumb: image url, => default (empty).
+  #     check http://camaleon.tuzitio.com/api-methods.html#section_fileuploads
   #   categories: [1,3,4,5],    => default (empty)
   #   tags: String comma separated, => default (empty)
   #   slug: string key for post,    => default (empty)
   #   summary: String resume (optional)  => default (empty)
   #   post_order: Integer to define the order position in the list (optional)
-  #   fields: Hash of values for custom fields, sample => fields: {subtitle: 'abc', icon: 'test' } (optional)
+  #   fields: Hash of values for custom fields,
+  #     sample => fields: {subtitle: 'abc', icon: 'test' } (optional)
   #   settings: Hash of post settings, sample => settings:
-  #     {has_content: false, has_summary: true, default_layout: 'my_layout', default_template: 'my_template' } (optional, see more in post.set_setting(...))
+  #     {has_content: false, has_summary: true, default_layout: 'my_layout',
+  #       default_template: 'my_template' } (optional, see more in post.set_setting(...))
   #   data_metas: {template: "", layout: ""}
-  # sample: my_posttype.add_post(title: "My Title", post_order: 5, content: 'lorem_ipsum', settings: {default_template: "home/counters", has_content: false, has_keywords: false, skip_fields: ["sub_tite", 'banner']}, fields: {pattern: true, bg: 'http://www.reallusion.com/de/images/3dx5/whatsnew/3dx5_features_banner_bg_02.jpg'})
+  # sample: my_posttype.add_post(title: "My Title", post_order: 5, content: 'lorem_ipsum',
+  #   settings: {default_template: "home/counters", has_content: false, has_keywords: false,
+  #   skip_fields: ["sub_tite", 'banner']}, fields: {pattern: true, 
+  #     bg: 'http://www.reallusion.com/de/images/3dx5/whatsnew/3dx5_features_banner_bg_02.jpg'})
   #   More samples here: https://gist.github.com/owen2345/eba9691585ed78ad6f7b52e9591357bf
   # return created post if it was created, else return errors
   def add_post(args)
@@ -112,8 +126,8 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
     args[:data_categories] = _categories = args.delete(:categories)
     args[:data_tags] = args.delete(:tags)
     _thumb = args.delete(:thumb)
-    p = self.posts.new(args)
-    p.slug = self.site.get_valid_post_slug(p.title.parameterize) unless p.slug.present?
+    p = posts.new(args)
+    p.slug = site.get_valid_post_slug(p.title.parameterize) unless p.slug.present?
     if p.save!
       _settings.each{ |k, v| p.set_setting(k, v) } if _settings.present?
       p.set_position(_order_position) if _order_position.present?
@@ -129,18 +143,23 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   # return all available route formats of this post type for content posts
   def contents_route_formats
     {
-      "post_of_post_type" => "<code>/group/:post_type_id-:title/:slug</code><br>  (Sample: http://localhost.com/group/17-services/myservice.html)",
-      "post_of_category" => "<code>/category/:category_id-:title/:slug</code><br>  (Sample: http://localhost.com/category/17-services/myservice.html)",
-      "post_of_category_post_type" => "<code>/:post_type_title/category/:category_id-:title/:slug</code><br>  (Sample: http://localhost.com/services/category/17-services/myservice.html)",
-      "post_of_posttype" => "<code>/:post_type_title/:slug</code><br>  (Sample: http://localhost.com/services/myservice.html)",
+      "post_of_post_type" => "<code>/group/:post_type_id-:title/:slug</code><br>  " \
+        "(Sample: http://localhost.com/group/17-services/myservice.html)",
+      "post_of_category" => "<code>/category/:category_id-:title/:slug</code><br>  " \
+        "(Sample: http://localhost.com/category/17-services/myservice.html)",
+      "post_of_category_post_type" => "<code>/:post_type_title/category/:category_id-:title/:slug" \
+        "</code><br>  (Sample: http://localhost.com/services/category/17-services/myservice.html)",
+      "post_of_posttype" => "<code>/:post_type_title/:slug</code><br>  " \
+        "(Sample: http://localhost.com/services/myservice.html)",
       "post" => "<code>/:slug</code><br>  (Sample: http://localhost.com/myservice.html)",
-      "hierarchy_post" => "<code>/:parent1_slug/:parent2_slug/.../:slug</code><br>  (Sample: http://localhost.com/item-1/item-1-1/item-111.html)"
+      "hierarchy_post" => "<code>/:parent1_slug/:parent2_slug/.../:slug</code><br>  " \
+        "(Sample: http://localhost.com/item-1/item-1-1/item-111.html)"
     }
   end
 
   # return the configuration of routes for post contents
   def contents_route_format
-    get_option("contents_route_format", "post")
+    get_option('contents_route_format', 'post')
   end
 
   # verify if this post_type support for page hierarchy (parents)
@@ -149,7 +168,9 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   end
 
   private
-  # skip save_metas_options callback after save changes (inherit from taxonomy) to call from here manually
+
+  # skip save_metas_options callback after save changes (inherit from taxonomy) to call from
+  # here manually
   def save_metas_options_skip
     true
   end
@@ -157,29 +178,32 @@ class CamaleonCms::PostType < CamaleonCms::TermTaxonomy
   # assign default roles for this post type
   # define default settings for this post type
   def set_default_site_user_roles
-    self.set_multiple_options({has_category: false, has_tags: false, has_summary: true, has_content: true, has_comments: false, has_picture: true, has_template: true, has_keywords: true, not_deleted: false, has_layout: false, default_layout: ""}.merge(PluginRoutes.fixActionParameter(data_options||{}).to_sym))
-    self.site.set_default_user_roles(self)
+    set_multiple_options({ has_category: false, has_tags: false, has_summary: true,
+      has_content: true, has_comments: false, has_picture: true, has_template: true,
+      has_keywords: true, not_deleted: false, has_layout: false, default_layout: "" }
+        .merge(PluginRoutes.fixActionParameter(data_options || {}).to_sym))
+    site.set_default_user_roles(self)
     default_category
   end
 
   # destroy all custom field groups assigned to this post type
   def destroy_field_groups
-    unless self.destroyed_by_association.present?
-      if self.slug == "post" || self.slug == "page"
+    unless destroyed_by_association.present?
+      if slug == 'post' || slug == 'page'
         errors.add(:base, "This post type can not be deleted.")
         return false
       end
     end
-    self.get_field_groups.destroy_all
+    get_field_groups.destroy_all
   end
 
   # reload routes to enable this post type url, like: http://localhost/my-slug
   def refresh_routes
-    PluginRoutes.reload unless self.destroyed_by_association.present?
+    PluginRoutes.reload unless destroyed_by_association.present?
   end
 
   # check if slug was changed
   def check_refresh_routes
-    refresh_routes if self.slug_changed?
+    refresh_routes if slug_changed?
   end
 end

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -1,19 +1,24 @@
 class CamaleonCms::TermRelationship < ActiveRecord::Base
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}term_relationships"
-  default_scope ->{ order(term_order: :asc) }
 
-  belongs_to :term_taxonomies, :class_name => "CamaleonCms::TermTaxonomy", foreign_key: :term_taxonomy_id, inverse_of: :term_relationships
-  belongs_to :objects, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, :class_name => "CamaleonCms::Post", foreign_key: :objectid, inverse_of: :term_relationships
+  default_scope -> { order(term_order: :asc) }
+
+  belongs_to :term_taxonomies, class_name: 'CamaleonCms::TermTaxonomy',
+    foreign_key: :term_taxonomy_id, inverse_of: :term_relationships
+  belongs_to :objects, -> { order("#{CamaleonCms::Post.table_name}.id DESC") },
+    class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :term_relationships
 
   # callbacks
   after_create :update_count
   before_destroy :update_count
 
   private
+
   # update counter of post published items
   # TODO verify counter
   def update_count
-    self.term_taxonomies.update_column('count', self.term_taxonomies.posts.published.size) if self.term_taxonomies.present?
+	if term_taxonomies.present?
+	  term_taxonomies.update_column('count', term_taxonomies.posts.published.size)
+	end
   end
-
 end

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -1,41 +1,50 @@
 class CamaleonCms::UniqValidator < ActiveModel::Validator
   def validate(record)
     unless record.skip_slug_validation?
-      record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}" if CamaleonCms::TermTaxonomy.where(slug: record.slug).where.not(id: record.id).where("#{CamaleonCms::TermTaxonomy.table_name}.taxonomy" => record.taxonomy).where("#{CamaleonCms::TermTaxonomy.table_name}.parent_id" => record.parent_id).size > 0
+      if CamaleonCms::TermTaxonomy.where(slug: record.slug).where.not(id: record.id)
+        .where("#{CamaleonCms::TermTaxonomy.table_name}.taxonomy" => record.taxonomy)
+        .where("#{CamaleonCms::TermTaxonomy.table_name}.parent_id" => record.parent_id).size > 0
+          record.errors[:base] << "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}"
+      end
     end
   end
 end
+
 class CamaleonCms::TermTaxonomy < ActiveRecord::Base
   include CamaleonCms::Metas
   include CamaleonCms::CustomFieldsRead
+
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}term_taxonomy"
-  # attr_accessible :taxonomy, :description, :parent_id, :count, :name, :slug, :term_group, :status, :term_order, :user_id
+
+  # attr_accessible :taxonomy, :description, :parent_id, :count, :name, :slug, :term_group, :status,
+  # :term_order, :user_id
   # attr_accessible :data_options
   # attr_accessible :data_metas
 
-  # callbacks
-  before_validation :before_validating
-  before_destroy :destroy_dependencies
+  # relations
+  has_many :term_relationships, class_name: 'CamaleonCms::TermRelationship',
+    foreign_key: :term_taxonomy_id, dependent: :destroy
+  has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :objects
+  belongs_to :parent, class_name: 'CamaleonCms::TermTaxonomy', foreign_key: :parent_id
+  belongs_to :owner, class_name: 'CamaleonCms::User', foreign_key: :user_id
 
   # validates
   validates :name, :taxonomy, presence: true
   validates_with CamaleonCms::UniqValidator
 
-  # relations
-  has_many :term_relationships, :class_name => "CamaleonCms::TermRelationship", :foreign_key => :term_taxonomy_id, dependent: :destroy
-  has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
-  belongs_to :parent, class_name: "CamaleonCms::TermTaxonomy", foreign_key: :parent_id
-  belongs_to :owner, class_name: "CamaleonCms::User", foreign_key: :user_id
+  # callbacks
+  before_validation :before_validating
+  before_destroy :destroy_dependencies
 
   # return all children taxonomy
   # sample: sub categories of a category
   def children
-    CamaleonCms::TermTaxonomy.where("#{CamaleonCms::TermTaxonomy.table_name}.parent_id = ?", self.id)
+    CamaleonCms::TermTaxonomy.where("#{CamaleonCms::TermTaxonomy.table_name}.parent_id = ?", id)
   end
 
   # return all menu items in which this taxonomy was assigned
   def in_nav_menu_items
-    CamaleonCms::NavMenuItem.where(url: self.id, kind: self.taxonomy)
+    CamaleonCms::NavMenuItem.where(url: id, kind: taxonomy)
   end
 
   # permit to skip slug validations for children models, like menu items
@@ -44,12 +53,12 @@ class CamaleonCms::TermTaxonomy < ActiveRecord::Base
   end
 
   private
+
   # callback before validating
   def before_validating
-    slug = self.slug
-    slug = self.name if slug.blank?
-    self.name = slug unless self.name.present?
-    self.slug = slug.to_s.parameterize.try(:downcase)
+    slug = name if slug.blank?
+    name = slug unless name.present?
+    slug = slug.to_s.parameterize.try(:downcase)
   end
 
   # destroy all dependencies
@@ -57,5 +66,4 @@ class CamaleonCms::TermTaxonomy < ActiveRecord::Base
   def destroy_dependencies
     in_nav_menu_items.destroy_all
   end
-
 end

--- a/app/models/camaleon_cms/theme.rb
+++ b/app/models/camaleon_cms/theme.rb
@@ -1,31 +1,32 @@
 class CamaleonCms::Theme < CamaleonCms::TermTaxonomy
   # attrs:
-  #   slug => plugin key
-  has_many :metas, -> { where(object_class: 'Theme') }, class_name: "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :site, class_name: "CamaleonCms::Site", foreign_key: :parent_id
-
+  # slug => plugin key
   default_scope { where(taxonomy: :theme) }
+
+  has_many :metas, -> { where(object_class: 'Theme') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
 
   before_validation :fix_name
   before_destroy :destroy_custom_fields
 
   # return theme settings configured in config.json
   def settings
-    PluginRoutes.theme_info(self.slug)
+    PluginRoutes.theme_info(slug)
   end
 
   # return the path to the settings file for current theme
   def settings_file
-    File.join(self.settings["path"], "views/admin/settings.html.erb").to_s
+    File.join(settings["path"], "views/admin/settings.html.erb").to_s
   end
 
   private
+
   def fix_name
-    self.name = self.slug unless self.name.present?
+    name = slug unless name.present?
   end
 
   def destroy_custom_fields
-    self.get_field_groups.destroy_all
+    get_field_groups.destroy_all
   end
-
 end

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -1,13 +1,18 @@
 unless PluginRoutes.static_system_info['user_model'].present?
   class CamaleonCms::User < ActiveRecord::Base
     include CamaleonCms::UserMethods
-    self.table_name = PluginRoutes.static_system_info["cama_users_db_table"] || "#{PluginRoutes.static_system_info["db_prefix"]}users"
-    # attr_accessible :username, :role, :email, :parent_id, :last_login_at, :site_id, :password, :password_confirmation, :first_name, :last_name #, :profile_attributes
+
+    self.table_name = PluginRoutes.static_system_info["cama_users_db_table"] ||
+      "#{PluginRoutes.static_system_info["db_prefix"]}users"
+    # attr_accessible :username, :role, :email, :parent_id, :last_login_at, :site_id, :password,
+    # :password_confirmation, :first_name, :last_name #, :profile_attributes
     # attr_accessible :is_valid_email
 
-    default_scope {order("#{CamaleonCms::User.table_name}.role ASC")}
-    validates :username, :presence => true
-    validates :email, :presence => true, :format => { :with => /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i } #, :unless => Proc.new { |a| a.auth_social.present? }
+    default_scope { order("#{CamaleonCms::User.table_name}.role ASC") }
+
+    validates :username, presence: true
+    validates :email, presence: true, format: { :with => /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i } #, :unless => Proc.new { |a| a.auth_social.present? }
+
     has_secure_password #validations: :auth_social.nil?
   end
 end

--- a/app/models/camaleon_cms/user_relationship.rb
+++ b/app/models/camaleon_cms/user_relationship.rb
@@ -2,6 +2,7 @@ class CamaleonCms::UserRelationship < ActiveRecord::Base
   self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}user_relationships"
   # attr_accessible :user_id, :term_taxonomy_id, :term_order, :active
 
-  belongs_to :term_taxonomies, :class_name => "CamaleonCms::TermTaxonomy", foreign_key: :term_taxonomy_id, inverse_of: :user_relationships
-  belongs_to :user, :class_name => "CamaleonCms::User", foreign_key: :user_id
+  belongs_to :term_taxonomies, class_name: 'CamaleonCms::TermTaxonomy',
+    foreign_key: :term_taxonomy_id, inverse_of: :user_relationships
+  belongs_to :user, class_name: 'CamaleonCms::User', foreign_key: :user_id
 end

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -1,20 +1,21 @@
 class CamaleonCms::UserRole < CamaleonCms::TermTaxonomy
   default_scope { where(taxonomy: :user_roles) }
-  has_many :metas, ->{ where(object_class: 'UserRole')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
+
+  has_many :metas, -> { where(object_class: 'UserRole') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
 
   def roles_post_type
-    self.get_meta("_post_type")
+    get_meta("_post_type")
   end
 
   def roles_manager
-    self.get_meta("_manager")
+    get_meta("_manager")
   end
 
   def editable?
-      term_group.nil?
+    term_group.nil?
   end
-
 
   ROLES = {
       post_type: [

--- a/app/models/camaleon_cms/widget/assigned.rb
+++ b/app/models/camaleon_cms/widget/assigned.rb
@@ -1,5 +1,6 @@
 class CamaleonCms::Widget::Assigned < CamaleonCms::PostDefault
   default_scope ->{ where(post_class: self.name).order(:taxonomy_id) }
+
   # post_parent: sidebar_id
   # visibility: widget_id
   # comment_count: item_order
@@ -10,18 +11,20 @@ class CamaleonCms::Widget::Assigned < CamaleonCms::PostDefault
 
   # attr_accessible :widget_id, :sidebar_id, :item_order
 
-  has_many :metas, ->{ where(object_class: 'Widget::Assigned')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :sidebar, class_name: "CamaleonCms::Widget::Sidebar", foreign_key: :post_parent
-  belongs_to :widget, class_name: "CamaleonCms::Widget::Main", foreign_key: :visibility
+  has_many :metas, ->{ where(object_class: 'Widget::Assigned')}, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :sidebar, class_name: 'CamaleonCms::Widget::Sidebar', foreign_key: :post_parent
+  belongs_to :widget, class_name: 'CamaleonCms::Widget::Main', foreign_key: :visibility
   after_initialize :fix_slug2
   before_create :set_order
 
   def fix_slug2
-    self.slug = "slug_assigned" unless self.slug.present?
+    slug = 'slug_assigned' unless slug.present?
   end
 
   private
+
   def set_order
-    self.item_order = self.sidebar.assigned.count + 1
+    item_order = sidebar.assigned.count + 1
   end
 end

--- a/app/models/camaleon_cms/widget/main.rb
+++ b/app/models/camaleon_cms/widget/main.rb
@@ -18,21 +18,21 @@ class CamaleonCms::Widget::Main < CamaleonCms::TermTaxonomy
   before_save :check_excerpt
 
   def is_simple?
-    status == "simple"
+    status == 'simple'
   end
 
   def excerpt=(value)
     @excerpt = value
   end
   def excerpt
-    get_option("excerpt")
+    get_option('excerpt')
   end
 
   def renderer=(value)
     @renderer = value
   end
   def renderer
-    get_option("renderer")
+    get_option('renderer')
   end
 
   def short_code

--- a/app/models/camaleon_cms/widget/main.rb
+++ b/app/models/camaleon_cms/widget/main.rb
@@ -8,37 +8,41 @@ class CamaleonCms::Widget::Main < CamaleonCms::TermTaxonomy
   # excerpt: string for message
   # renderer: string (path to the template for render this widget)
 
-  has_many :metas, ->{ where(object_class: 'Widget::Main')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  belongs_to :owner, class_name: "CamaleonCms::User", foreign_key: :user_id
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
+  has_many :metas, -> { where(object_class: 'Widget::Main') }, class_name: 'CamaleonCms::Meta'
+    foreign_key: :objectid, dependent: :destroy
+  belongs_to :owner, class_name: 'CamaleonCms::User', foreign_key: :user_id
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+  has_many :assigned, class_name: 'CamaleonCms::Widget::Assigned', foreign_key: :visibility,
+    dependent: :destroy
 
-  has_many :assigned, class_name: "CamaleonCms::Widget::Assigned", foreign_key: :visibility, dependent: :destroy
   before_save :check_excerpt
+
   def is_simple?
-    self.status == "simple"
+    status == "simple"
   end
 
   def excerpt=(value)
     @excerpt = value
   end
   def excerpt
-    self.get_option("excerpt")
+    get_option("excerpt")
   end
 
   def renderer=(value)
     @renderer = value
   end
   def renderer
-    self.get_option("renderer")
+    get_option("renderer")
   end
 
   def short_code
-    "[widget #{self.slug}]"
+    "[widget #{slug}]"
   end
 
   private
+
   def check_excerpt
-    self.set_option("excerpt", @excerpt)
-    self.set_option("renderer", @renderer)
+    set_option("excerpt", @excerpt)
+    set_option("renderer", @renderer)
   end
 end

--- a/app/models/camaleon_cms/widget/sidebar.rb
+++ b/app/models/camaleon_cms/widget/sidebar.rb
@@ -1,20 +1,20 @@
 class CamaleonCms::Widget::Sidebar < CamaleonCms::TermTaxonomy
-  default_scope { where(taxonomy: :sidebar) }
-  has_many :metas, ->{ where(object_class: 'Widget::Sidebar')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :assigned, foreign_key: :post_parent, dependent: :destroy
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
-
   #scopes
-  scope :default_sidebar, -> { where(:slug => 'default-sidebar') }
+  default_scope { where(taxonomy: :sidebar) }
+  scope :default_sidebar, -> { where(slug: 'default-sidebar') }
   scope :all_sidebar, -> { where("slug != 'default-sidebar'") }
+
+  has_many :metas, -> { where(object_class: 'Widget::Sidebar') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :assigned, foreign_key: :post_parent, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
 
   # assign the widget into this sidebar
   # widget: string(slug)/object
   # data: {title, content}
   def add_widget(widget, data = {})
-    widget = self.site.widgets.where(slug: widget).first if widget.is_a?(String)
+    widget = site.widgets.where(slug: widget).first if widget.is_a?(String)
     data[:widget_id] = widget.id
-    self.assigned.create(data)
+    assigned.create(data)
   end
-
 end

--- a/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
+++ b/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
@@ -20,8 +20,8 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
   end
 
   # update category assignations for this post
-    # remove assignations that no longer exist
-    # add new assignations
+  # remove assignations that no longer exist
+  # add new assignations
   # cats: (Array) array of category ids assigned for this post, sample: [1,2,3]
   def update_categories(cats=[])
     rescue_extra_data
@@ -29,28 +29,32 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
     old_categories = categories.pluck("#{CamaleonCms::TermTaxonomy.table_name}.id")
     delete_categories = old_categories - cats
     news_categories =  cats - old_categories
-    term_relationships.where("term_taxonomy_id in (?)", delete_categories ).destroy_all   if  delete_categories.present?
+    if  delete_categories.present?
+      term_relationships.where("term_taxonomy_id in (?)", delete_categories).destroy_all
+    end
     news_categories.each do |key|
-      term_relationships.create(:term_taxonomy_id => key)
+      term_relationships.create(term_taxonomy_id: key)
     end
     update_counters("categories")
   end
 
   # update tags assignations for this post
-    # remove assignations that no longer exist
-    # add new assignations
+  # remove assignations that no longer exist
+  # add new assignations
   # tags: (String) tags name separated by commas, sample: "Tag1,Tag two,tag new"
   def update_tags(tags)
     rescue_extra_data
     tags = tags.split(",").strip
-    post_tags = self.post_type.post_tags
+    post_tags = post_type.post_tags
     post_tags = post_tags.where("name not in (?)", tags) if tags.present?
-    self.term_relationships.where("term_taxonomy_id in (?)", post_tags.pluck("#{CamaleonCms::TermTaxonomy.table_name}.id")).destroy_all
+    term_relationship
+      .where("term_taxonomy_id in (?)", post_tags.pluck("#{CamaleonCms::TermTaxonomy.table_name}.id"))
+      .destroy_all
     tags.each do |f|
-      post_tag = self.post_type.post_tags.where({name: f}).first_or_create(slug: f.parameterize)
-      self.term_relationships.where({term_taxonomy_id: post_tag.id}).first_or_create
+      post_tag = post_type.post_tags.where({name: f}).first_or_create(slug: f.parameterize)
+      term_relationships.where({ term_taxonomy_id: post_tag.id }).first_or_create
     end
-    update_counters("tags")
+    update_counters('tags')
   end
 
   # Assign this post for category with id: category_id
@@ -59,9 +63,9 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
     categories_id = [categories_id] if categories_id.is_a?(Integer)
     rescue_extra_data
     categories_id.each do |key|
-      term_relationships.where(:term_taxonomy_id => key).first_or_create!
+      term_relationships.where(term_taxonomy_id: key).first_or_create!
     end
-    update_counters("categories")
+    update_counters('categories')
   end
 
   # Assign this post for category with id: category_id
@@ -69,8 +73,8 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
   def unassign_category(categories_id)
     categories_id = [categories_id] if categories_id.is_a?(Integer)
     rescue_extra_data
-    term_relationships.where(:term_taxonomy_id => categories_id).destroy_all
-    update_counters("categories")
+    term_relationships.where(term_taxonomy_id: categories_id).destroy_all
+    update_counters('categories')
   end
 
   # Assign new tags to this post
@@ -79,10 +83,10 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
     update_counters_before
     tags = tag_titles.split(",").strip
     tags.each do |t|
-      post_tag = self.post_type.post_tags.where(name: t).first_or_create!
-      self.term_relationships.where({term_taxonomy_id: post_tag.id}).first_or_create!
+      post_tag = post_type.post_tags.where(name: t).first_or_create!
+      term_relationships.where({ term_taxonomy_id: post_tag.id }).first_or_create!
     end
-    update_counters("tags")
+    update_counters('tags')
   end
 
   # Unassign tags from this post
@@ -90,7 +94,8 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
   def unassign_tags(tag_titles)
     update_counters_before
     tags = tag_titles.split(",").strip
-    self.term_relationships.where({term_taxonomy_id: self.post_type.post_tags.where(name: tags).pluck(:id)}).destroy_all
+    term_relationships
+	  .where({term_taxonomy_id: post_type.post_tags.where(name: tags).pluck(:id)}).destroy_all
     update_counters("tags")
   end
 
@@ -101,32 +106,38 @@ module CamaleonCms::CategoriesTagsForPosts extend ActiveSupport::Concern
   end
 
   private
+
   @cats_before, @tags_before = [], []
   # save as a cache previous categories and tags assigned for this post
   def rescue_extra_data
-    @cats_before = self.categories.pluck(:id) if manage_categories?
-    @tags_before = self.post_tags.pluck(:id) if manage_tags?
+    @cats_before = categories.pluck(:id) if manage_categories?
+    @tags_before = post_tags.pluck(:id) if manage_tags?
   end
 
   # update quantity of posts assigned for tags and categories assigned to this post
   # if kind is empty, then this will update both: cats and tags
   # kind: (string) tags | categories
   def update_counters(kind = "")
-    self.post_type.full_categories.where(id: (@cats_before + self.categories.pluck(:id)).uniq).each { |c| c.update_column("count", c.posts.published.size) } if ["", "categories"].include?(kind) && manage_categories?
-    self.post_type.post_tags.where(id: (@tags_before + self.post_tags.pluck(:id)).uniq).each { |tag| tag.update_column("count", tag.posts.published.size) } if ["", "tags"].include?(kind) && manage_tags?
+    if ["", "categories"].include?(kind) && manage_categories?
+      post_type.full_categories.where(id: (@cats_before + categories.pluck(:id)).uniq)
+        .each { |c| c.update_column("count", c.posts.published.size) }
+    end
+    if ["", "tags"].include?(kind) && manage_tags?
+      post_type.post_tags.where(id: (@tags_before + post_tags.pluck(:id)).uniq)
+        .each { |tag| tag.update_column('count', tag.posts.published.size) }
+    end
   end
 
   # save extra data such as: categories and tags assigned to this post
   def save_extra_data
-    update_categories(self.data_categories) if manage_categories? && !self.data_categories.nil?
-    update_tags(self.data_tags) if manage_tags? && !self.data_tags.nil?
+    update_categories(data_categories) if manage_categories? && !data_categories.nil?
+    update_tags(data_tags) if manage_tags? && !data_tags.nil?
   end
 
   # auto assign default categories if none categories were assigned
   def check_default_category
     if manage_categories?
-      assign_category([self.post_type.default_category.id]) unless self.categories.present?
+      assign_category([post_type.default_category.id]) unless categories.present?
     end
   end
-
 end

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -1,25 +1,32 @@
 module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   included do
     before_destroy :_destroy_custom_field_groups
-    has_many :fields, ->(object){ where(:object_class => object.class.to_s.gsub("Decorator","").gsub("CamaleonCms::",""))} , :class_name => "CamaleonCms::CustomField" ,foreign_key: :objectid
-    has_many :field_values, ->(object){where(object_class: object.class.to_s.gsub("Decorator","").gsub("CamaleonCms::",""))}, :class_name => "CamaleonCms::CustomFieldsRelationship", foreign_key: :objectid, dependent: :delete_all
-    has_many :custom_field_values, ->(object){ where(object_class: object.class.to_s.gsub("Decorator","").gsub("CamaleonCms::", ""))}, :class_name => "CamaleonCms::CustomFieldsRelationship", foreign_key: :objectid, dependent: :delete_all
 
-    # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or children groups
-    has_many :field_groups, ->(object){where(object_class: object.class.to_s.parseCamaClass)}, :class_name => "CamaleonCms::CustomFieldGroup", foreign_key: :objectid
+    has_many :fields, ->(object){ where(object_class: object.class.to_s.gsub("Decorator","")
+      .gsub("CamaleonCms::","")) }, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
+    has_many :field_values, ->(object){ where(object_class: object.class.to_s.gsub("Decorator","")
+      .gsub("CamaleonCms::",""))}, class_name: 'CamaleonCms::CustomFieldsRelationship',
+      foreign_key: :objectid, dependent: :delete_all
+    has_many :custom_field_values, ->(object){ where(object_class: object.class.to_s
+      .gsub("Decorator","").gsub("CamaleonCms::", ""))},
+      class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid,
+      dependent: :delete_all
+    # valid only for simple groups and not for complex like: posts, post, ... 
+    # where the group is for individual or children groups
+    has_many :field_groups, ->(object){where(object_class: object.class.to_s.parseCamaClass)},
+      class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
   end
-
 
   # get custom field groups for current object
   # only: Post_type, Post, Category, PostTag, Widget, Site and a Custom model pre configured
   # return collections CustomFieldGroup
   # args: (Hash, used only for PostType Objects)
-    # kind: (Post (Default) | Category | PostTag | PostType).
-      # If kind = "Post" this will return all groups for all posts from current post type
-      # If kind = "Category" this will return all groups for all categories from current post type
-      # If kind = "PostTag" this will return all groups for all posttags from current post type
-      # If kind = "all" this will return all groups from current post type
-      # If kind = "post_type" this will return groups for all post_types
+  #  kind: (Post (Default) | Category | PostTag | PostType).
+  #   If kind = "Post" this will return all groups for all posts from current post type
+  #   If kind = "Category" this will return all groups for all categories from current post type
+  #   If kind = "PostTag" this will return all groups for all posttags from current post type
+  #   If kind = "all" this will return all groups from current post type
+  #   If kind = "post_type" this will return groups for all post_types
   # Sample: mypost.get_field_groups() ==> return fields for posts from parent posttype
   # Sample: mycat.get_field_groups() ==> return fields for categories from parent posttype
   # Sample: myposttag.get_field_groups() ==> return fields for posttags from parent posttype
@@ -27,25 +34,33 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # Sample: mypost_type.get_field_groups({kind: 'Category'}) => return custom fields for posts
   # Sample: mypost_type.get_field_groups({kind: 'PostTag'}) => return custom fields for posts
   def get_field_groups(args = {})
-    args = args.is_a?(String) ?  {kind: args, include_parent: false } : {kind: "Post", include_parent: false }.merge(args)
-    class_name = self.class.to_s.parseCamaClass
+    args =
+      if args.is_a?(String)
+        { kind: args, include_parent: false }
+      else
+        { kind: "Post", include_parent: false }.merge(args)
+      end
+    class_name = class.to_s.parseCamaClass
     case class_name
       when 'Category','PostTag'
-        self.post_type.get_field_groups(class_name)
+        post_type.get_field_groups(class_name)
       when 'Post'
-        CamaleonCms::CustomFieldGroup.where("(objectid = ? AND object_class = ?) OR (objectid = ? AND object_class = ?)", self.id || -1, class_name, self.post_type.id, "PostType_#{class_name}")
+        CamaleonCms::CustomFieldGroup
+          .where("(objectid = ? AND object_class = ?) OR (objectid = ? AND object_class = ?)", id ||
+            -1, class_name, post_type.id, "PostType_#{class_name}")
       when 'NavMenuItem'
-        self.main_menu.field_groups
+        main_menu.field_groups
       when 'PostType'
-        if args[:kind] == "all"
-          CamaleonCms::CustomFieldGroup.where(object_class: ["PostType_Post", "PostType_Post", "PostType_PostTag", "PostType"], objectid:  self.id )
+        if args[:kind] == 'all'
+          CamaleonCms::CustomFieldGroup
+            .where(object_class: w%(PostType_Post PostType_Post PostType_PostTag PostType),objectid: id)
         elsif args[:kind] == "post_type"
-          self.field_groups
+          field_groups
         else
-          CamaleonCms::CustomFieldGroup.where(object_class: "PostType_#{args[:kind]}", objectid:  self.id )
+          CamaleonCms::CustomFieldGroup.where(object_class: "PostType_#{args[:kind]}", objectid: id)
         end
       else # 'Plugin' or other classes
-        self.field_groups
+        field_groups
     end
   end
 
@@ -53,7 +68,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # return collections CustomFieldGroup
   # site: site object
   def get_user_field_groups(site)
-    site.custom_field_groups.where(object_class: self.class.to_s.parseCamaClass)
+    site.custom_field_groups.where(object_class: class.to_s.parseCamaClass)
   end
 
 
@@ -71,7 +86,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # get custom field values
   # _key: custom field key
   def get_field_values(_key, group_number = 0)
-    self.field_values.where(custom_field_slug: _key, group_number: group_number).pluck(:value)
+    field_values.where(custom_field_slug: _key, group_number: group_number).pluck(:value)
   end
   alias_method :get_fields, :get_field_values
 
@@ -92,11 +107,14 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   #   puts res[0]['my_slug1'].first ==> "val 1"
   def get_fields_grouped(field_keys)
     res = []
-    field_values.where(custom_field_slug: field_keys).order(group_number: :asc).group_by(&:group_number).each do |group_number, group_fields|
+    field_values.where(custom_field_slug: field_keys).order(group_number: :asc)
+      .group_by(&:group_number).each do |group_number, group_fields|
       group = {}
       field_keys.each do |field_key|
         group[field_key] = []
-        group_fields.each{ |field| group[field_key] << field.value if field_key == field.custom_field_slug }
+        group_fields.each do |field|
+          group[field_key] << field.value if field_key == field.custom_field_slug
+        end
       end
       res << group
     end
@@ -105,14 +123,20 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
 
   # return all values
   # {key1: "single value", key2: [multiple, values], key3: value4} if include_options = false
-  # {key1: {values: "single value", options: {a:1, b: 4}}, key2: {values: [multiple, values], options: {a=1, b=2} }} if include_options = true
+  # {key1: {values: "single value", options: {a:1, b: 4}}, key2: {values: [multiple, values],
+  # options: {a=1, b=2} }} if include_options = true
   def get_field_values_hash(include_options = false)
     fields = {}
-    self.field_values.to_a.uniq.each do |field_value|
+    field_values.to_a.uniq.each do |field_value|
       custom_field = field_value.custom_fields
-      values = custom_field.values.where(objectid: self.id).pluck(:value)
-      fields[field_value.custom_field_slug] = custom_field.cama_options[:multiple].to_s.to_bool ? values : values.first unless include_options
-      fields[field_value.custom_field_slug] = {values: custom_field.cama_options[:multiple].to_s.to_bool ? values : values.first, options: custom_field.cama_options, id: custom_field.id} if include_options
+      values = custom_field.values.where(objectid: id).pluck(:value)
+      fields[field_value.custom_field_slug] =
+        if custom_field.cama_options[:multiple].to_s.to_bool
+          values
+        else
+          values.first unless include_options
+        end
+      fields[field_value.custom_field_slug] = { values: custom_field.cama_options[:multiple].to_s.to_bool ? values : values.first, options: custom_field.cama_options, id: custom_field.id} if include_options
     end
     fields.to_sym
   end
@@ -122,10 +146,10 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # deprecated f attribute
   def get_fields_object(f=true)
     fields = {}
-    self.field_values.to_a.uniq.each do |field_value|
+    field_values.to_a.uniq.each do |field_value|
       custom_field = field_value.custom_fields
       # if custom_field.options[:show_frontend].to_s.to_bool
-      values = custom_field.values.where(objectid: self.id).pluck(:value)
+      values = custom_field.values.where(objectid: id).pluck(:value)
       fields[field_value.custom_field_slug] = custom_field.attributes.merge(options: custom_field.cama_options, values: custom_field.cama_options[:multiple].to_s.to_bool ? values : values.first)
       # end
     end
@@ -135,10 +159,10 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
 
   # add a custom field group for current model
   # values:
-    # name: name for the group
-    # slug: key for group (if slug = _default => this will never show title and description)
-    # description: description for the group (optional)
-    # is_repeat: (boolean, optional -> default false) indicate if group support multiple format (repeated values)
+  #  name: name for the group
+  #  slug: key for group (if slug = _default => this will never show title and description)
+  #  description: description for the group (optional)
+  #  is_repeat: (boolean, optional -> default false) indicate if group support multiple format (repeated values)
   # Model supported: PostType, Category, Post, Posttag, Widget, Plugin, Theme, User and Custom models pre configured
   # Note 1: If you need add fields for all post's or all categories, then you need to add the fields into the
   #     post_type.add_custom_field_group(values, kind = "Post")
@@ -153,7 +177,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
       site = _cama_get_field_site
       values[:parent_id] = site.id if site.present?
       if self.is_a?(CamaleonCms::Post) # harcoded for post to support custom field groups
-        group = CamaleonCms::CustomFieldGroup.where(object_class: "Post", objectid: self.id).create!(values)
+        group = CamaleonCms::CustomFieldGroup.where(object_class: "Post", objectid: id).create!(values)
       else
         group = get_field_groups(kind).create!(values)
       end
@@ -192,13 +216,13 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # }
   def set_field_values(datas = {})
     if datas.present?
-      self.field_values.delete_all
+      field_values.delete_all
       datas.each do |index, fields_data|
         fields_data.each do |field_key, values|
           if values[:values].present?
             order_value = -1
             ((values[:values].is_a?(Hash) || values[:values].is_a?(ActionController::Parameters)) ? values[:values].values : values[:values]).each do |value|
-              item = self.field_values.create!({custom_field_id: values[:id], custom_field_slug: field_key, value: fix_meta_value(value), term_order: order_value += 1, group_number: values[:group_number] || 0})
+              item = field_values.create!({custom_field_id: values[:id], custom_field_slug: field_key, value: fix_meta_value(value), term_order: order_value += 1, group_number: values[:group_number] || 0})
             end
           end
         end
@@ -209,7 +233,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # update new value for field with slug _key
   # Sample: my_posy.update_field_value('sub_title', 'Test Sub Title')
   def update_field_value(_key, value = nil, group_number = 0)
-    self.field_values.where(custom_field_slug: _key, group_number: group_number).first.update_column('value', value) rescue nil
+    field_values.where(custom_field_slug: _key, group_number: group_number).first.update_column('value', value) rescue nil
   end
 
   # Set custom field values for current model
@@ -222,35 +246,40 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
 
   # Set custom field values for current model (support for multiple group values)
   # key: (string required) slug of the custom field
-  # value: (array | string) array: array of values for multiple values support, string: uniq value for the custom field
+  # value: (array | string) array: array of values for multiple values support, 
+  #  string: uniq value for the custom field
   # args:
   #   field_id: (integer optional) identifier of the custom field
   #   order: order or position of the field value
   #   group_number: number of the group (only for custom field group with is_repeat enabled)
-  #   clear: (boolean, default true) if true, will remove previous values and set these values, if not will append values
+  #   clear: (boolean, default true) if true, will remove previous values and set these values,
+  #    if not will append values
   # return false if the was not saved because there is not present the field with slug: key
   # sample: my_post.set_field_value('subtitle', 'Sub Title')
-  # sample: my_post.set_field_value('subtitle', ['Sub Title1', 'Sub Title2']) # set values for a field (for fields that support multiple values)
+  # sample: my_post.set_field_value('subtitle', ['Sub Title1', 'Sub Title2']) # set values for a 
+  #  field (for fields that support multiple values)
   # sample: my_post.set_field_value('subtitle', 'Sub Title', {group_number: 1})
-  # sample: my_post.set_field_value('subtitle', 'Sub Title', {group_number: 1, group_number: 1}) # add field values for fields in group 1
+  # sample: my_post.set_field_value('subtitle', 'Sub Title', {group_number: 1, group_number: 1}) 
+  # add field values for fields in group 1
   def set_field_value(key, value, args = {})
-    args = {order: 0, group_number: 0, field_id: nil, clear: true}.merge(args)
+    args = { order: 0, group_number: 0, field_id: nil, clear: true }.merge(args)
     args[:field_id] = get_field_object(key).id rescue nil unless args[:field_id].present?
     unless args[:field_id].present?
       raise ArgumentError, "There is no custom field configured for #{key}"
     end
-    self.field_values.where({custom_field_slug: key, group_number: args[:group_number]}).delete_all if args[:clear]
-    v = {custom_field_id: args[:field_id], custom_field_slug: key, value: fix_meta_value(value), term_order: args[:order], group_number: args[:group_number]}
+    field_values.where({custom_field_slug: key, group_number: args[:group_number]}).delete_all if args[:clear]
+    v = { custom_field_id: args[:field_id], custom_field_slug: key, value: fix_meta_value(value), term_order: args[:order], group_number: args[:group_number]}
     if value.is_a?(Array)
       value.each do |val|
-        self.field_values.create!(v.merge({value: fix_meta_value(val)}))
+        field_values.create!(v.merge({value: fix_meta_value(val)}))
       end
     else
-      self.field_values.create!(v)
+      field_values.create!(v)
     end
   end
 
   private
+
   def fix_meta_value(value)
     if (value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters))
       value = value.to_json
@@ -259,9 +288,9 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   end
 
   def _destroy_custom_field_groups
-    class_name = self.class.to_s.parseCamaClass
+    class_name = class.to_s.parseCamaClass
     if ['Category','Post','PostTag'].include?(class_name)
-      CamaleonCms::CustomFieldGroup.where(objectid: self.id, object_class: class_name).destroy_all
+      CamaleonCms::CustomFieldGroup.where(objectid: id, object_class: class_name).destroy_all
     elsif ['PostType'].include?(class_name)
       get_field_groups("Post").destroy_all
       get_field_groups("Category").destroy_all
@@ -273,13 +302,13 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   end
   # return the Site Model owner of current model
   def _cama_get_field_site
-    case self.class.to_s.parseCamaClass
+    case class.to_s.parseCamaClass
       when 'Category','Post','PostTag'
-        self.post_type.site
+        post_type.site
       when 'Site'
         self
       else
-        self.site
+        site
     end
   end
 end

--- a/app/models/concerns/camaleon_cms/metas.rb
+++ b/app/models/concerns/camaleon_cms/metas.rb
@@ -3,16 +3,19 @@ module CamaleonCms::Metas extend ActiveSupport::Concern
     # options and metas auto save support
     attr_accessor :data_options
     attr_accessor :data_metas
+
     after_create  :save_metas_options, unless: :save_metas_options_skip
     before_update :fix_save_metas_options_no_changed
 
-    has_many :metas, ->(object){ where(object_class: object.class.to_s.gsub("Decorator","").gsub("CamaleonCms::", "")) }, class_name: "CamaleonCms::Meta", foreign_key: :objectid, dependent: :delete_all
+    has_many :metas, ->(object){ where(object_class: object.class.to_s.gsub("Decorator","")
+      .gsub("CamaleonCms::", "")) }, class_name: 'CamaleonCms::Meta', foreign_key: :objectid,
+      dependent: :delete_all
   end
 
   # Add meta with value or Update meta with key: key
   # return true or false
   def set_meta(key, value)
-    metas.where(key: key).update_or_create({value: fix_meta_value(value)})
+    metas.where(key: key).update_or_create({ value: fix_meta_value(value) })
     cama_set_cache("meta_#{key}", value)
   end
 
@@ -93,7 +96,7 @@ module CamaleonCms::Metas extend ActiveSupport::Concern
   # sample: set_metas({name: 'Owen', email: 'owenperedo@gmail.com'})
   def set_metas(data_metas)
     (data_metas.nil? ? {} : data_metas).each do |key, value|
-      self.set_meta(key, value)
+      set_meta(key, value)
     end
   end
 
@@ -107,8 +110,10 @@ module CamaleonCms::Metas extend ActiveSupport::Concern
     save_metas_options #unless self.changed?
   end
 
-  # save all settings for this post type received in data_options and data_metas attribute (options and metas)
-  # sample: Site.first.post_types.create({name: "owen", slug: "my_post_type", data_options: { has_category: true, default_layout: "my_layout" }})
+  # save all settings for this post type received in data_options and data_metas 
+  #  attribute (options and metas)
+  # sample: Site.first.post_types.create({name: "owen", slug: "my_post_type", 
+  #  data_options: { has_category: true, default_layout: "my_layout" }})
   def save_metas_options
     set_multiple_options(data_options)
     if data_metas.present?
@@ -119,6 +124,7 @@ module CamaleonCms::Metas extend ActiveSupport::Concern
   end
 
   private
+
   # fix to parse value
   def fix_meta_value(value)
     if (value.is_a?(Array) || value.is_a?(Hash) || value.is_a?(ActionController::Parameters))

--- a/app/models/concerns/camaleon_cms/site_default_settings.rb
+++ b/app/models/concerns/camaleon_cms/site_default_settings.rb
@@ -1,31 +1,91 @@
 module CamaleonCms::SiteDefaultSettings extend ActiveSupport::Concern
 # default structure for each new site
   def default_settings
-    default_post_type = [
-        {name: 'Post', description: 'Posts', options: {has_category: true, has_tags: true, not_deleted: true, has_summary: true, has_content: true, has_comments: true, has_picture: true, has_template: true, }},
-        {name: 'Page', description: 'Pages', options: {has_category: false, has_tags: false, not_deleted: true, has_summary: false, has_content: true, has_comments: false, has_picture: true, has_template: true, has_layout: true}}
+    default_post_type = [{
+        name: 'Post',
+        description: 'Posts',
+        options: { has_category: true, has_tags: true, not_deleted: true, has_summary: true,
+                   has_content: true, has_comments: true, has_picture: true, has_template: true
+                 }
+      },
+      {
+        name: 'Page',
+        description: 'Pages',
+        options: { has_category: false, has_tags: false, not_deleted: true, has_summary: false,
+                   has_content: true, has_comments: false, has_picture: true, has_template: true,
+                   has_layout: true
+                 }
+      }
     ]
     default_post_type.each do |pt|
-      model_pt = self.post_types.create({name: pt[:name], slug: pt[:name].to_s.parameterize, description: pt[:description], data_options: pt[:options]})
+      model_pt = post_types.create({ name: pt[:name], slug: pt[:name].to_s.parameterize,
+        description: pt[:description], data_options: pt[:options] })
     end
 
     # nav menus
-    @nav_menu = self.nav_menus.new({name: "Main Menu", slug: "main_menu"})
+    @nav_menu = nav_menus.new(name: 'Main Menu', slug: 'main_menu')
     if @nav_menu.save
-      self.post_types.all.each do |pt|
-        if pt.slug == "post"
-          title = "Sample Post"
+      post_types.all.each do |pt|
+        if pt.slug == 'post'
+          title = 'Sample Post'
           slug = 'sample-post'
-          content = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pharetra ut augue in posuere. Nulla non malesuada dui. Sed egestas tortor ut purus tempor sodales. Duis non sollicitudin nulla, quis mollis neque. Integer sit amet augue ac neque varius auctor. Vestibulum malesuada leo leo, at semper libero efficitur nec. Etiam semper nisi ac nisi ullamcorper, sed tincidunt purus elementum. Mauris ac congue nibh. Quisque pretium eget leo nec suscipit. </p> <p> Vestibulum ultrices orci ut congue interdum. Morbi dolor nunc, imperdiet vel risus semper, tempor dapibus urna. Phasellus luctus pharetra enim quis volutpat. Integer tristique urna nec malesuada ullamcorper. Curabitur dictum, lectus id ultrices rhoncus, ante neque auctor erat, ut sodales nisi odio sit amet lorem. In hac habitasse platea dictumst. Quisque orci orci, hendrerit at luctus tristique, lobortis in diam. Curabitur ligula enim, rhoncus ut vestibulum a, consequat sit amet nisi. Aliquam bibendum fringilla ultrices. Aliquam erat volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In justo mi, congue in rhoncus lobortis, facilisis in est. Nam et rhoncus purus. </p> <p> Sed sagittis auctor lectus at rutrum. Morbi ultricies felis mi, ut scelerisque augue facilisis eu. In molestie quam ex. Quisque ut sapien sed odio tempus imperdiet. In id accumsan massa. Morbi quis nunc ullamcorper, interdum enim eu, finibus purus. Vestibulum ac fermentum augue, at tempus ante. Aliquam ultrices, purus ut porttitor gravida, dui augue dignissim massa, ac tempor ante dolor at arcu. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse placerat risus est, eget varius mi ultricies in. Duis non odio ut felis dapibus eleifend. In fringilla enim lobortis placerat efficitur. </p> <p> Nulla sodales faucibus urna, quis viverra dolor facilisis sollicitudin. Aenean ac egestas nibh. Nam non tortor eget nibh scelerisque fermentum. Etiam ornare, nunc ut luctus mollis, ante dolor consectetur augue, non scelerisque odio est a nulla. Nullam cursus egestas nulla, nec commodo nibh suscipit ut. Mauris ut felis sem. Aenean at mi at nisi dictum blandit sit amet at erat. Etiam eget lobortis tellus. Curabitur in commodo arcu, at vehicula tortor. </p>"
+          content = "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer " \
+            "pharetra ut augue in posuere. Nulla non malesuada dui. Sed egestas tortor ut purus " \
+            "tempor sodales. Duis non sollicitudin nulla, quis mollis neque. Integer sit amet " \
+            "augue ac neque varius auctor. Vestibulum malesuada leo leo, at semper libero " \
+            "efficitur nec. Etiam semper nisi ac nisi ullamcorper, sed tincidunt purus " \
+            "elementum. Mauris ac congue nibh. Quisque pretium eget leo nec suscipit. </p> <p> " \
+            "Vestibulum ultrices orci ut congue interdum. Morbi dolor nunc, imperdiet vel risus " \
+            "semper, tempor dapibus urna. Phasellus luctus pharetra enim quis volutpat. Integer " \
+            "tristique urna nec malesuada ullamcorper. Curabitur dictum, lectus id ultrices " \
+            "rhoncus, ante neque auctor erat, ut sodales nisi odio sit amet lorem. In hac " \
+            "habitasse platea dictumst. Quisque orci orci, hendrerit at luctus tristique, " \
+            "lobortis in diam. Curabitur ligula enim, rhoncus ut vestibulum a, consequat sit " \
+            "amet nisi. Aliquam bibendum fringilla ultrices. Aliquam erat volutpat. Vestibulum " \
+            "ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In " \
+            "justo mi, congue in rhoncus lobortis, facilisis in est. Nam et rhoncus purus. " \
+            "</p> <p> Sed sagittis auctor lectus at rutrum. Morbi ultricies felis mi, ut " \
+            "scelerisque augue facilisis eu. In molestie quam ex. Quisque ut sapien sed odio " \
+            "tempus imperdiet. In id accumsan massa. Morbi quis nunc ullamcorper, interdum enim " \
+            "eu, finibus purus. Vestibulum ac fermentum augue, at tempus ante. Aliquam " \
+            "ultrices, purus ut porttitor gravida, dui augue dignissim massa, ac tempor ante " \
+            "dolor at arcu. Pellentesque habitant morbi tristique senectus et netus et " \
+            "malesuada fames ac turpis egestas. Suspendisse placerat risus est, eget varius " \
+            "mi ultricies in. Duis non odio ut felis dapibus eleifend. In fringilla enim " \
+            "lobortis placerat efficitur. </p> <p> Nulla sodales faucibus urna, quis viverra " \
+            "dolor facilisis sollicitudin. Aenean ac egestas nibh. Nam non tortor eget nibh " \
+            "scelerisque fermentum. Etiam ornare, nunc ut luctus mollis, ante dolor " \
+            "consectetur augue, non scelerisque odio est a nulla. Nullam cursus egestas " \
+            "nulla, nec commodo nibh suscipit ut. Mauris ut felis sem. Aenean at mi at nisi " \
+            "dictum blandit sit amet at erat. Etiam eget lobortis tellus. Curabitur in commodo " \
+            "arcu, at vehicula tortor. </p>"
         else
-          title = "Welcome"
+          title = 'Welcome'
           slug = 'welcome'
-          content = "<p style='text-align: center;'><img width='155' height='155' src='http://camaleon.tuzitio.com/media/132/logo2.png' alt='logo' /></p><p><strong>Camaleon CMS</strong>&nbsp;is a free and open-source tool and a fexible content management system (CMS) based on <a href='http://rubyonrails.org'>Ruby on Rails 4</a>&nbsp;and MySQL.&nbsp;</p> <p>With Camaleon you can do the following:</p> <ul> <li>Create instantly a lot of sites&nbsp;in the same installation</li> <li>Manage your content information in several languages</li> <li>Extend current functionality by&nbsp;plugins (MVC structure and no more echo or prints anywhere)</li> <li>Create or install different themes for each site</li> <li>Create your own structure without coding anything (adapt Camaleon as you want&nbsp;and not you for Camaleon)</li> <li>Create your store and start to sell your products using our plugins</li> <li>Avoid web attacks</li> <li>Compare the speed and enjoy the speed of your new Camaleon site</li> <li>Customize or create your themes for mobile support</li> <li>Support&nbsp;more visitors at the same time</li> <li>Manage your information with a panel like wordpress&nbsp;</li> <li>All urls are oriented for SEO</li> <li>Multiples roles of users</li> </ul>"
+          content = "<p style='text-align: center;'><img width='155' height='155' " \
+            "src='http://camaleon.tuzitio.com/media/132/logo2.png' alt='logo' /></p><p>" \
+            "<strong>Camaleon CMS</strong>&nbsp;is a free and open-source tool and a fexible " \
+            "content management system (CMS) based on <a href='http://rubyonrails.org'>" \
+            "Ruby on Rails 4</a>&nbsp;and MySQL.&nbsp;</p> <p>With Camaleon you can do the " \
+            "following:</p> <ul> <li>Create instantly a lot of sites&nbsp;in the same " \
+            "installation</li> <li>Manage your content information in several languages</li> " \
+            "<li>Extend current functionality by&nbsp;plugins (MVC structure and no more echo " \
+            "or prints anywhere)</li> <li>Create or install different themes for each " \
+            "site</li> <li>Create your own structure without coding anything (adapt Camaleon " \
+            "as you want&nbsp;and not you for Camaleon)</li> <li>Create your store and start " \
+            "to sell your products using our plugins</li> <li>Avoid web attacks</li> " \
+            "<li>Compare the speed and enjoy the speed of your new Camaleon site</li> " \
+            "<li>Customize or create your themes for mobile support</li> <li>Support&nbsp;more " \
+            "visitors at the same time</li> <li>Manage your information with a panel like " \
+            "wordpress&nbsp;</li> <li>All urls are oriented for SEO</li> <li>Multiples " \
+            "roles of users</li> </ul>"
         end
-        user = self.users.admin_scope.first
-        user = self.users.admin_scope.create({email: 'admin@local.com', username: 'admin', password: 'admin', password_confirmation: 'admin', first_name: 'Administrator'}) unless user.present?
-        post = pt.add_post({title: title, slug: slug, content: content, user_id: user.id, status: 'published'})
-        @nav_menu.append_menu_item({label: title, type: 'post', link: post.id})
+        user = users.admin_scope.first
+        user = users.admin_scope.create(email: 'admin@local.com', username: 'admin',
+          password: 'admin', password_confirmation: 'admin', first_name: 'Administrator') unless user.present?
+        post = pt.add_post({ title: title, slug: slug, content: content, user_id: user.id,
+          status: 'published' })
+        @nav_menu.append_menu_item({ label: title, type: 'post', link: post.id })
       end
     end
     get_anonymous_user
@@ -33,53 +93,59 @@ module CamaleonCms::SiteDefaultSettings extend ActiveSupport::Concern
 
   # auto create default user roles
   def set_default_user_roles(post_type = nil)
-    user_role = self.user_roles.where({slug: 'admin', term_group: -1}).first_or_create({name: 'Administrator', description: 'Default roles admin'})
+    user_role = user_roles.where(slug: 'admin', term_group: -1)
+      .first_or_create(name: 'Administrator', description: 'Default roles admin')
     if user_role.valid?
       d, m = {}, {}
-      pts = self.post_types.all.pluck(:id)
+      pts = post_types.all.pluck(:id)
       CamaleonCms::UserRole::ROLES[:post_type].each { |value| d[value[:key]] = pts }
       CamaleonCms::UserRole::ROLES[:manager].each { |value| m[value[:key]] = 1 }
-      user_role.set_meta("_post_type_#{self.id}", d || {})
-      user_role.set_meta("_manager_#{self.id}", m || {})
+      user_role.set_meta("_post_type_#{id}", d || {})
+      user_role.set_meta("_manager_#{id}", m || {})
     end
 
-    user_role = self.user_roles.where({slug: 'editor'}).first_or_create({name: 'Editor', description: 'Editor Role'})
+    user_role = user_roles.where(slug: 'editor')
+      .first_or_create({name: 'Editor', description: 'Editor Role'})
     if user_role.valid?
       d = {}
       if post_type.present?
-        d = user_role.get_meta("_post_type_#{self.id}", {})
-        CamaleonCms::UserRole::ROLES[:post_type].each { |value|
+        d = user_role.get_meta("_post_type_#{id}", {})
+        CamaleonCms::UserRole::ROLES[:post_type].each so |value|
           value_old = d[value[:key].to_sym] || []
           d[value[:key].to_sym] = value_old + [post_type.id]
-        }
+        end
       else
-        pts = self.post_types.all.pluck(:id)
+        pts = post_types.all.pluck(:id)
         CamaleonCms::UserRole::ROLES[:post_type].each { |value| d[value[:key]] = pts }
       end
-      user_role.set_meta("_post_type_#{self.id}", d || {})
+      user_role.set_meta("_post_type_#{id}", d || {})
     end
 
-    user_role = self.user_roles.where({slug: 'contributor'}).first_or_create({name: 'Contributor', description: 'Contributor Role'})
+    user_role = user_roles.where({ slug: 'contributor' })
+      .first_or_create({ name: 'Contributor', description: 'Contributor Role' })
     if user_role.valid?
       d = {}
       if post_type.present?
-        d = user_role.get_meta("_post_type_#{self.id}", {})
-        CamaleonCms::UserRole::ROLES[:post_type].each { |value|
-          value_old = d[value[:key].to_sym] || []
+        d = user_role.get_meta("_post_type_#{id}", {})
+        CamaleonCms::UserRole::ROLES[:post_type].each do |value|
+          value_old = d[value[:key].to_sym] || [] 
           d[value[:key].to_sym] = value_old + [post_type.id] if value[:key].to_s == 'edit'
-        }
+        end
       else
-        pts = self.post_types.all.pluck(:id)
-        CamaleonCms::UserRole::ROLES[:post_type].each { |value| d[value[:key]] = pts if value[:key].to_s == 'edit' }
+        pts = post_types.all.pluck(:id)
+        CamaleonCms::UserRole::ROLES[:post_type].each do |value|
+          d[value[:key]] = pts if value[:key].to_s == 'edit'
+        end
       end
-      user_role.set_meta("_post_type_#{self.id}", d || {})
+      user_role.set_meta("_post_type_#{id}", d || {})
     end
 
     unless post_type.present?
-      user_role = self.user_roles.where({slug: 'client', term_group: -1}).first_or_create({name: 'Client', description: 'Default roles client'})
+      user_role = user_roles.where(slug: 'client', term_group: -1)
+        .first_or_create(name: 'Client', description: 'Default roles client')
       if user_role.valid?
-        user_role.set_meta("_post_type_#{self.id}", {})
-        user_role.set_meta("_manager_#{self.id}", {})
+        user_role.set_meta("_post_type_#{id}", {})
+        user_role.set_meta("_manager_#{id}", {})
       end
     end
 

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -2,8 +2,12 @@ class CamaleonCms::UniqValidatorUser < ActiveModel::Validator
   def validate(record)
     users = CamaleonCms::User.all
     users = CamaleonCms::User.where(site_id: record.site_id) unless PluginRoutes.system_info["users_share_sites"]
-    record.errors[:base] << "#{I18n.t('camaleon_cms.admin.users.message.requires_different_username')}" if users.where(username: record.username).where.not(id: record.id).size > 0
-    record.errors[:base] << "#{I18n.t('camaleon_cms.admin.users.message.requires_different_email')}" if users.where(email: record.email).where.not(id: record.id).size > 0
+    if users.where(username: record.username).where.not(id: record.id).size > 0
+      record.errors[:base] << "#{I18n.t('camaleon_cms.admin.users.message.requires_different_username')}"
+    end
+    if users.where(email: record.email).where.not(id: record.id).size > 0
+      record.errors[:base] << "#{I18n.t('camaleon_cms.admin.users.message.requires_different_email')}"
+    end
   end
 end
 
@@ -12,36 +16,40 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
 
+    #scopes
+    scope :admin_scope, -> { where(role: 'admin') }
+    scope :actives, -> { where(active: 1) }
+    scope :not_actives, -> { where(active: 0) }
+
+    # relations
+    has_many :metas, ->{ where(object_class: 'User') }, class_name: 'CamaleonCms::Meta',
+      foreign_key: :objectid, dependent: :destroy
+    has_many :user_relationships, class_name: 'CamaleonCms::UserRelationship',
+      foreign_key: :user_id, dependent: :destroy#,  inverse_of: :user
+    has_many :term_taxonomies, foreign_key: :term_taxonomy_id,
+      class_name: 'CamaleonCms::TermTaxonomy', through: :user_relationships,
+      source: :term_taxonomies
+    has_many :all_posts, class_name: 'CamaleonCms::Post'
+
     validates_with CamaleonCms::UniqValidatorUser
 
     before_create { generate_token(:auth_token) }
     before_save :before_saved
     before_create :before_saved
     before_destroy :reassign_posts
-    # relations
-
-    has_many :metas, ->{ where(object_class: 'User')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-    has_many :user_relationships, class_name: "CamaleonCms::UserRelationship", foreign_key: :user_id, dependent: :destroy#,  inverse_of: :user
-    has_many :term_taxonomies, foreign_key: :term_taxonomy_id, class_name: "CamaleonCms::TermTaxonomy", through: :user_relationships, :source => :term_taxonomies
-    has_many :all_posts, class_name: "CamaleonCms::Post"
-
-    #scopes
-    scope :admin_scope, -> { where(:role => 'admin') }
-    scope :actives, -> { where(:active => 1) }
-    scope :not_actives, -> { where(:active => 0) }
 
     #vars
-    STATUS = {0 => 'Active', 1=>'Not Active'}
-    ROLE = { 'admin'=>'Administrator', 'client' => 'Client'}
+    STATUS = { 0 => 'Active', 1 =>'Not Active' }
+    ROLE = { 'admin'=>'Administrator', 'client' => 'Client' }
   end
 
   # return all posts of this user on site
   def posts(site)
-    site.posts.where(user_id: self.id)
+    site.posts.where(user_id: id)
   end
 
   def fullname
-    "#{self.first_name} #{self.last_name}".titleize
+    "#{first_name} #{last_name}".titleize
   end
 
   def admin?
@@ -49,56 +57,56 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   end
 
   def client?
-    self.role == 'client'
+    role == 'client'
   end
 
   # return the UserRole Object of this user in Site
   def get_role(site)
-    @_user_role ||= site.user_roles.where(slug: self.role).first
+    @_user_role ||= site.user_roles.where(slug: role).first
   end
 
   # assign a new site for current user
   def assign_site(site)
-    self.update_column(:site_id, site.id)
+    update_column(:site_id, site.id)
   end
 
   def sites
-    if PluginRoutes.system_info["users_share_sites"]
+    if PluginRoutes.system_info['users_share_sites']
       CamaleonCms::Site.all
     else
-      CamaleonCms::Site.where(id: self.site_id)
+      CamaleonCms::Site.where(id: site_id)
     end
   end
 
   # DEPRECATED, please use user.the_role
   def roleText
-    User::ROLE[self.role]
+    User::ROLE[role]
   end
 
   def created
-    self.created_at.strftime('%d/%m/%Y %H:%M')
+    created_at.strftime('%d/%m/%Y %H:%M')
   end
 
   def updated
-    self.updated_at.strftime('%d/%m/%Y %H:%M')
+    updated_at.strftime('%d/%m/%Y %H:%M')
   end
 
   # auth
   def generate_token(column)
     begin
       self[column] = SecureRandom.urlsafe_base64
-    end while CamaleonCms::User.exists?(column => self[column])
+    end while CamaleonCms::User.exists?(column: self[column])
   end
 
   def send_password_reset
     generate_token(:password_reset_token)
-    self.password_reset_sent_at = Time.zone.now
+    password_reset_sent_at = Time.zone.now
     save!
   end
 
   def send_confirm_email
     generate_token(:confirm_email_token)
-    self.confirm_email_sent_at = Time.zone.now
+    confirm_email_sent_at = Time.zone.now
     save!
   end
 
@@ -107,8 +115,9 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   end
 
   private
+
   def before_saved
-    self.role = PluginRoutes.system_info["default_user_role"] if self.role.blank?
+    role = PluginRoutes.system_info['default_user_role'] if role.blank?
   end
 
   # deprecated
@@ -122,10 +131,10 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   def reassign_posts
     all_posts.each do |p|
       s = p.post_type.site
-      u = s.users.admin_scope.where.not(id: self.id).first
+      u = s.users.admin_scope.where.not(id: id).first
       if u.present?
         p.update_column(:user_id, u.id)
-        p.comments.where(user_id: self.id).each do |c|
+        p.comments.where(user_id: id).each do |c|
           c.update_column(:user_id, u.id)
         end
       end


### PR DESCRIPTION
- Prefer single-quoted strings if string interpolation or special symbols not needed
- Keep a blank line before and after private
- remove redundant self 
- add spaces and order relations, scopes for easier to read
- change `where().first` into `find_by` 
- straigt return in methods without a explicit setting of locale variables
-  change `count != 0` into `any?`