### PR TITLE
Cleanup category class

### DIFF
--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -1,25 +1,28 @@
 class CamaleonCms::Category < CamaleonCms::TermTaxonomy
   alias_attribute :site_id, :term_group
   alias_attribute :post_type_id, :status
+
   default_scope { where(taxonomy: :category) }
-  has_many :metas, ->{ where(object_class: 'Category')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
-  has_many :children, class_name: "CamaleonCms::Category", foreign_key: :parent_id, dependent: :destroy
-  belongs_to :parent, class_name: "CamaleonCms::Category", foreign_key: :parent_id
-  belongs_to :post_type_parent, class_name: "CamaleonCms::PostType", foreign_key: :parent_id, inverse_of: :categories
+  scope :no_empty, -> { where('count > 0') } # return all categories that contains at least one post
+  scope :empty, -> { where(count: [0, nil]) } # return all categories that does not contain any post
+  # scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
+
+  has_many :metas, -> { where(object_class: 'Category') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :objects
+  has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id,
+    dependent: :destroy
+  belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id
+  belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id,
+    inverse_of: :categories
   belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :site_id
-
-  scope :no_empty, ->{ where("count > 0") } # return all categories that contains at least one post
-  scope :empty, ->{ where(count: [0,nil]) } # return all categories that does not contain any post
-
-  #scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
 
   before_save :set_site
   before_destroy :set_posts_in_default_category
 
   # return the post type of this category
   def post_type
-    cama_fetch_cache("post_type") do
+    cama_fetch_cache('post_type') do
       ctg = self
       begin
         pt = ctg.post_type_parent
@@ -30,10 +33,11 @@ class CamaleonCms::Category < CamaleonCms::TermTaxonomy
   end
 
   private
+
   def set_site
     pt = self.post_type
-    self.site_id = pt.site_id unless self.site_id.present?
-    self.status = pt.id unless self.status.present?
+    self.site_id = pt.site_id unless site_id.present?
+    self.status = pt.id unless status.present?
   end
 
   # rescue all posts to assign into default category if they don't have any category assigned
@@ -41,10 +45,9 @@ class CamaleonCms::Category < CamaleonCms::TermTaxonomy
     category_default = self.post_type.default_category
     return if category_default == self
     self.posts.each do |post|
-      if post.categories.where.not(id: self.id).blank?
+      if post.categories.where.not(id: id).blank?
         post.assign_category(category_default.id)
       end
     end
   end
-
 end


### PR DESCRIPTION
- Use single-quoted strings if string interpolation or special symbols are not needed
- Keep a blank line before and after private
- Calls without `self`  to get something
- Add spaces