### PR TITLE
Cleanup and improvements in custom fields classes

### DIFF
--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -1,26 +1,35 @@
 class CamaleonCms::CustomField < ActiveRecord::Base
-  self.primary_key = :id
   include CamaleonCms::Metas
-  has_many :metas, ->{ where(object_class: 'CustomField')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}custom_fields"
-  default_scope {order("#{CamaleonCms::CustomField.table_name}.field_order ASC")}
-  # status: nil -> visible on list group fields
-  # attr_accessible :object_class, :objectid, :description, :parent_id, :count, :name, :slug, :field_order, :status, :is_repeat
-  validates :name, :object_class, presence: true
-  has_many :values, :class_name => "CamaleonCms::CustomFieldsRelationship", :foreign_key => :custom_field_id, dependent: :destroy
-  belongs_to :custom_field_group, class_name: "CamaleonCms::CustomFieldGroup"
-  belongs_to :parent, class_name: "CamaleonCms::CustomField", :foreign_key => :parent_id
-  alias_attribute :label, :name
-  validates_uniqueness_of :slug, scope: [:parent_id, :object_class], unless: lambda{|o| o.is_a?(CamaleonCms::CustomFieldGroup) }
 
-  scope :configuration, -> {where(parent_id: -1)}
-  scope :visible_group, -> {where(status: nil)}
+  self.primary_key = :id
+  self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}custom_fields"
+
+  alias_attribute :label, :name
+
+  default_scope { order("#{CamaleonCms::CustomField.table_name}.field_order ASC") }
+  scope :configuration, -> { where(parent_id: -1) }
+  scope :visible_group, -> { where(status: nil) }
+
+  # status: nil -> visible on list group fields
+  # attr_accessible :object_class, :objectid, :description, :parent_id, :count, :name, :slug,
+  # :field_order, :status, :is_repeat
+  has_many :metas, -> { where(object_class: 'CustomField') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :values, class_name: 'CamaleonCms::CustomFieldsRelationship',
+    foreign_key: :custom_field_id, dependent: :destroy
+  belongs_to :custom_field_group, class_name: 'CamaleonCms::CustomFieldGroup'
+  belongs_to :parent, class_name: 'CamaleonCms::CustomField', foreign_key: :parent_id
+
+  validates :name, :object_class, presence: true
+  validates_uniqueness_of :slug, scope: [:parent_id, :object_class],
+    unless: ->(o) { o.is_a?(CamaleonCms::CustomFieldGroup) }
 
   before_validation :before_validating
 
   private
+
   def before_validating
-    self.slug = self.name if self.slug.blank?
+    self.slug = name if slug.blank?
     self.slug = self.slug.to_s.parameterize
   end
 end

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -130,7 +130,7 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
       end
       (options[:default_values] || [options[:default_value]] || []).each do |value|
         owner.field_values.create!(custom_field_id: field.id, custom_field_slug: field.slug,
-          value: fix_meta_value(value)}) if owner.present?
+          value: fix_meta_value(value)) if owner.present?
       end
     end
   end

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -2,25 +2,37 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
   self.primary_key = :id
   # attrs required: name, slug, description
   alias_attribute :site_id, :parent_id
-  default_scope { where.not(object_class: '_fields').reorder("#{CamaleonCms::CustomField.table_name}.field_order ASC") }
 
-  has_many :metas, ->{ where(object_class: 'CustomFieldGroup')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-  has_many :fields, -> {where(object_class: '_fields')}, :class_name => "CamaleonCms::CustomField", foreign_key: :parent_id, dependent: :destroy
-  belongs_to :site, :class_name => "CamaleonCms::Site", foreign_key: :parent_id
+  default_scope { where.not(object_class: '_fields')
+    .reorder("#{CamaleonCms::CustomField.table_name}.field_order ASC") }
+
+  has_many :metas, -> { where(object_class: 'CustomFieldGroup') }, class_name: 'CamaleonCms::Meta',
+    foreign_key: :objectid, dependent: :destroy
+  has_many :fields, -> { where(object_class: '_fields') }, class_name: 'CamaleonCms::CustomField',
+    foreign_key: :parent_id, dependent: :destroy
+  belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+
   validates_uniqueness_of :slug, scope: [:object_class, :objectid, :parent_id]
+
   before_validation :before_validating
 
   # add fields to group
   # item:
   # -  sample:  {"name"=>"Label", "slug"=>"my_slug", "description"=>"my description (optional)"}
-  # -  options (textbox sample):  {"field_key":"text_box","multiple":"1","required":"1","translate":"1"}
-  #   * field_key (string) | translate (boolean) | default_value (unique value) | default_values (array - multiple values for this field) | label_eval (boolean) | multiple_options (array)
-  #   * multiple_options (used for select, radio and checkboxes ): [{"title"=>"Option Title", "value"=>"2", "default"=>"1"}, {"title"=>"abcde", "value"=>"3"}]
-  #   * label_eval: (Boolean, default false), true => will evaluate the label and description of current field using (eval('my_label')) to have translatable|dynamic labels
-  #****** check all options for each case in Admin::CustomFieldsHelper ****
-  # SAMPLE: my_model.add_field({"name"=>"Sub Title", "slug"=>"subtitle"}, {"field_key"=>"text_box", "translate"=>true, default_value: "Get in Touch"})
+  # -  options (textbox sample):  {"field_key":"text_box","multiple":"1","required":"1",
+  #     "translate":"1"}
+  #   * field_key (string) | translate (boolean) | default_value (unique value) |
+  #      default_values (array - multiple values for this field) | label_eval (boolean) |
+  #      multiple_options (array)
+  #   * multiple_options (used for select, radio and checkboxes ): [{"title"=>"Option Title",
+  #      "value"=>"2", "default"=>"1"}, {"title"=>"abcde", "value"=>"3"}]
+  #   * label_eval: (Boolean, default false), true => will evaluate the label and description of
+  #       current field using (eval('my_label')) to have translatable|dynamic labels
+  # ****** check all options for each case in Admin::CustomFieldsHelper ****
+  # SAMPLE: my_model.add_field({"name"=>"Sub Title", "slug"=>"subtitle"}, {"field_key"=>"text_box",
+  #   "translate"=>true, default_value: "Get in Touch"})
   def add_manual_field(item, options)
-    c = get_field(item[:slug] || item["slug"])
+    c = get_field(item[:slug] || item['slug'])
     return c if c.present?
 
     field_item = self.fields.new(item)
@@ -34,19 +46,21 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
 
   # return a field with slug = slug from current group
   def get_field(slug)
-    self.fields.where(slug: slug).first
+    self.fields.find_by(slug: slug)
   end
 
   # only used by form on admin panel (protected)
   # return array of failed_fields and full_fields [[failed fields], [all fields]]
   def add_fields(items, item_options)
-    self.fields.where.not(id: items.map{|k, obj| obj['id'] }.uniq).destroy_all
-    cache_fields, order_index, errors_saved = [], 0, []
+    self.fields.where.not(id: items.map { |_k, obj| obj['id'] }.uniq).destroy_all
+    cache_fields = []
+    order_index = 0
+    errors_saved = []
     if items.present?
-      items.each do |i,item|
+      items.each do |i, item|
         item[:field_order] = order_index
         options = item_options[i] || {}
-        if item[:id].present? && (field_item = self.fields.where(id: item[:id]).first).present?
+        if item[:id].present? && (field_item = self.fields.find_by(id: item[:id])).present?
           saved = field_item.update(item)
           cache_fields << field_item
         else
@@ -67,30 +81,30 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
 
   # generate the caption for this group
   def get_caption
-    caption = ""
+    caption = ''
     begin
-      case self.object_class
-        when "PostType_Post"
-          caption = "Fields for Contents in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+      case object_class
+        when 'PostType_Post'
+          caption = "Fields for Contents in <b>#{self.site.post_types.find(objectid).decorate.the_title}</b>"
         when 'PostType_Category'
-          caption = "Fields for Categories in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+          caption = "Fields for Categories in <b>#{self.site.post_types.find(objectid).decorate.the_title}</b>"
         when 'PostType_PostTag'
-          caption = "Fields for Post tags in <b>#{self.site.post_types.find(self.objectid).decorate.the_title}</b>"
+          caption = "Fields for Post tags in <b>#{self.site.post_types.find(objectid).decorate.the_title}</b>"
         when 'Widget::Main'
-          caption = "Fields for Widget <b>(#{CamaleonCms::Widget::Main.find(self.objectid).name.translate})</b>"
+          caption = "Fields for Widget <b>(#{CamaleonCms::Widget::Main.find(objectid).name.translate})</b>"
         when 'Theme'
-          caption = "Field settings for Theme <b>(#{self.site.themes.find(self.objectid).name rescue self.objectid})</b>"
+          caption = "Field settings for Theme <b>(#{self.site.themes.find(objectid).name rescue objectid})</b>"
         when 'NavMenu'
-          caption = "Field settings for Menus <b>(#{CamaleonCms::NavMenu.find(self.objectid).name})</b>"
+          caption = "Field settings for Menus <b>(#{CamaleonCms::NavMenu.find(objectid).name})</b>"
         when 'Site'
-          caption = "Field settings the site"
+          caption = 'Field settings the site'
         when 'PostType'
-          caption = "Fields for all <b>Post_Types</b>"
+          caption = 'Fields for all <b>Post_Types</b>'
         when 'Post'
-          p = CamaleonCms::Post.find(self.objectid).decorate
+          p = CamaleonCms::Post.find(objectid).decorate
           caption = "Fields for content <b>(#{p.the_title})</b>"
         else # 'Plugin' or other class
-          caption = "Fields for <b>#{self.object_class}</b>"
+          caption = "Fields for <b>#{object_class}</b>"
       end
     rescue => e
       Rails.logger.info "----------#{e.message}----#{self.attributes}"
@@ -99,22 +113,24 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
   end
 
   private
+
   def before_validating
-    self.slug = "_group-#{self.name.to_s.parameterize}" unless self.slug.present?
+    self.slug = "_group-#{name.to_s.parameterize}" unless slug.present?
   end
 
   # auto save the default field values
   def auto_save_default_values(field, options)
     options = options.with_indifferent_access
-    class_name = self.object_class.split("_").first
-    if ["Post", "Category", "Plugin", "Theme"].include?(class_name) && self.objectid.present? && (options[:default_value].present? || options[:default_values].present?)
-      if class_name == "Theme"
-        owner = "CamaleonCms::#{class_name}".constantize.where(id: self.objectid).first # owner model
+    class_name = object_class.split("_").first
+    if %w(Post Category Plugin Theme).include?(class_name) && objectid && (options[:default_value].present? || options[:default_values].present?)
+      if class_name == 'Theme'
+        owner = "CamaleonCms::#{class_name}".constantize.find(objectid) # owner model
       else
-        owner = "CamaleonCms::#{class_name}".constantize.find(self.objectid) rescue "CamaleonCms::#{class_name}".constantize.where(slug: self.objectid).first # owner model
+        owner = "CamaleonCms::#{class_name}".constantize.find(objectid) rescue "CamaleonCms::#{class_name}".constantize.find_by(slug: objectid) # owner model
       end
       (options[:default_values] || [options[:default_value]] || []).each do |value|
-        owner.field_values.create!({custom_field_id: field.id, custom_field_slug: field.slug, value: fix_meta_value(value)}) if owner.present?
+        owner.field_values.create!(custom_field_id: field.id, custom_field_slug: field.slug,
+          value: fix_meta_value(value)}) if owner.present?
       end
     end
   end

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -1,9 +1,12 @@
 class CamaleonCms::CustomFieldsRelationship < ActiveRecord::Base
-  self.table_name = "#{PluginRoutes.static_system_info["db_prefix"]}custom_fields_relationships"
-  # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class, :custom_field_slug, :group_number
-  default_scope {order("#{CamaleonCms::CustomFieldsRelationship.table_name}.term_order ASC")}
+  self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}custom_fields_relationships"
+
+  # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class,
+  # :custom_field_slug, :group_number
+  default_scope { order("#{CamaleonCms::CustomFieldsRelationship.table_name}.term_order ASC") }
+
   # relations
-  belongs_to :custom_fields, :class_name => "CamaleonCms::CustomField", foreign_key: :custom_field_id
+  belongs_to :custom_fields, class_name: 'CamaleonCms::CustomField', foreign_key: :custom_field_id
 
   # validates :objectid, :custom_field_id, presence: true
   validates :custom_field_id, presence: true # error on clone model
@@ -11,8 +14,8 @@ class CamaleonCms::CustomFieldsRelationship < ActiveRecord::Base
   after_save :set_parent_slug
 
   private
-  def set_parent_slug
-    #self.update_column('custom_field_slug', self.custom_fields.slug)
-  end
 
+  def set_parent_slug
+    # self.update_column('custom_field_slug', self.custom_fields.slug)
+  end
 end


### PR DESCRIPTION
- Use single-quoted strings if string interpolation or special symbols are not needed
- Change single line lambda syntax in `-> { }` lambda literal syntax
- Add spaces
- Calls without '.self' to get something
- Keep a blank line before and after private
- Replace `where().first` with `find_by()`
- Array Syntax 
- Remove `.present?` call because is not necessary
  - `objectid` is an Integer