### PR TITLE
add trash/restore hooks

### DIFF
--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -116,6 +116,7 @@ class CamaleonCms::Admin::PostsController < CamaleonCms::AdminController
     # @post.children.destroy_all unless @post.draft? TODO: why delete children?
     @post.update_column('status', 'trash')
     @post.update_extra_data
+    hooks_run("trashed_post", {post: @post, post_type: @post_type})
     flash[:notice] = t('camaleon_cms.admin.post.message.trash', post_type: @post_type.decorate.the_title)
     redirect_to action: :index, s: params[:s]
   end
@@ -125,6 +126,7 @@ class CamaleonCms::Admin::PostsController < CamaleonCms::AdminController
     authorize! :update, @post
     @post.update_column('status', @post.options[:status_default] || 'pending')
     @post.update_extra_data
+    hooks_run("restored_post", {post: @post, post_type: @post_type})
     flash[:notice] = t('camaleon_cms.admin.post.message.restore', post_type: @post_type.decorate.the_title)
     redirect_to action: :index, s: params[:s]
   end


### PR DESCRIPTION
I don't know how to update the documentation on http://camaleon.tuzitio.com/documentation/category/40758-modules/hooks-1.html though.

I think these are important hooks. If you cache menus for example you need to empty that cache if a post is trashed/restored.