### PR TITLE
fix invalid key causes validate_file_format throw exception

### DIFF
--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -124,7 +124,7 @@ class CamaleonCmsUploader
   def self.validate_file_format(key, valid_formats = "*")
     return true if valid_formats == "*" || !valid_formats.present?
     valid_formats = valid_formats.gsub(' ', '').downcase.split(',') + get_file_format_extensions(valid_formats).split(',')
-    valid_formats.include?(File.extname(key).sub(".", "").split('?').first.downcase)
+    valid_formats.include?(File.extname(key).sub(".", "").split('?').first.try(:downcase))
   end
 
 


### PR DESCRIPTION
User may fill in such image url: https://unsplash.it/375/333 it will cause `validate_file_format `
 throw exception.

I think we should should fix this.

Exception info as below
```
NoMethodError in CamaleonCms::Admin::MediaController#actions

undefined method `downcase' for nil:NilClass
Extracted source (around line #127):

#125     return true if valid_formats == "*" || !valid_formats.present?
#126     valid_formats = valid_formats.gsub(' ', '').downcase.split(',') + get_file_format_extensions(valid_formats).split(',')
*127     valid_formats.include?(File.extname(key).sub(".", "").split('?').first.downcase)
#128   end
#129 
#130 
```