### PR TITLE
delete file only when it exists

### DIFF
--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -82,12 +82,14 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   end
 
   def delete_folder(key)
-    FileUtils.rm_rf(File.join(@root_folder, key))
+    file = File.join(@root_folder, key)
+    FileUtils.rm(file) if File.exist? file
     reload
   end
 
   def delete_file(key)
-    FileUtils.rm(File.join(@root_folder, key))
+    file = File.join(@root_folder, key)
+    FileUtils.rm(file) if File.exist? file
     reload
   end
 


### PR DESCRIPTION
User may delete the files manually for some reason.

Then if user try to delete the file in UI, will cause the system throw exception.