### PR TITLE
prevent nav menu item field 'kind' to be the empty string

### DIFF
--- a/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
@@ -102,7 +102,8 @@ class CamaleonCms::Admin::Appearances::NavMenusController < CamaleonCms::AdminCo
 
     if params[:custom_items].present? # custom menu items
       params[:custom_items].each do |index, item|
-        item = @nav_menu.append_menu_item({label: item['label'], link: item['url'], type: item['kind'] || 'external'})
+        type = item['kind'].present? ? item['kind'] : 'external'
+        item = @nav_menu.append_menu_item({label: item['label'], link: item['url'], type: type})
         items << item
       end
     end


### PR DESCRIPTION
Hey,

I noticed that adding custom menus via hook `nav_menu_custom` is not working. The reason is that the `kind` will be saved as an empty string.

`'' || true # => ''`
`''.present? # => false` 