### PR TITLE
Added PNG and JPG file types to asset precompilation.

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,7 +15,7 @@ Rails.application.config.assets.precompile << Proc.new { |path|
   if File.dirname(path).start_with?('plugins/') || File.dirname(path).start_with?('themes/')
     name = File.basename(path)
     content_type = MIME::Types.type_for(name).first.content_type rescue ""
-    if (path =~ /\.(css|js|svg|ttf|woff|eot|swf|pdf)\z/ || content_type.scan(/(javascript|image\/|audio|video|font)/).any?) && !name.start_with?("_") && !path.include?('/views/')
+    if (path =~ /\.(css|js|svg|ttf|woff|eot|swf|pdf|png|jpg)\z/ || content_type.scan(/(javascript|image\/|audio|video|font)/).any?) && !name.start_with?("_") && !path.include?('/views/')
       res = true
     end
   end


### PR DESCRIPTION
When creating a new Camaleon install, one would receive errors when visiting the theme section of the admin control panel because PNG and JPG images were not being compiled. I changed the config/initializers/assets.rb to include PNG and JPG in the file types that it looks for so it will compile properly at this time. Previously, the line 
`Rails.application.config.assets.precompile += %w( themes/*/assets/* )`
was used, however this code segment was swapped for the proc which I adjusted to include those image file types. 