### PR TITLE
fix restoring of drafts

### DIFF
--- a/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
@@ -48,7 +48,7 @@ class CamaleonCms::Admin::Posts::DraftsController < CamaleonCms::Admin::PostsCon
     post_data = params.require(:post).permit!
     post_data.delete(:created_at) unless params[:post][:created_at].present?
     post_data.delete(:updated_at) unless params[:post][:updated_at].present?
-    post_data[:status] = 'draft'
+    post_data[:status] = 'draft_child'
     post_data[:post_parent] = params[:post_id]
     post_data[:user_id] = cama_current_user.id unless post_data[:user_id].present?
     post_data[:data_tags] = params[:tags].to_s

--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -35,14 +35,15 @@ class CamaleonCms::Admin::PostsController < CamaleonCms::AdminController
     @lists_tab = params[:s]
     add_breadcrumb I18n.t("camaleon_cms.admin.post_type.#{params[:s]}") if params[:s].present?
     case params[:s]
-      when "published", "pending", "draft", "trash"
-        @posts = @posts.where(status:  params[:s])
-
+      when "published", "pending", "trash"
+        @posts = @posts.send(params[:s])
+      when "draft"
+        @posts = @posts.drafts
       when "all"
         @posts = @posts.no_trash
     end
 
-    @btns = {published: "#{t('camaleon_cms.admin.post_type.published')} (#{posts_all.where(status: "published").size})", all: "#{t('camaleon_cms.admin.post_type.all')} (#{posts_all.no_trash.size})", pending: "#{t('camaleon_cms.admin.post_type.pending')} (#{posts_all.where(status: "pending").size})", draft: "#{t('camaleon_cms.admin.post_type.draft')} (#{posts_all.where(status: "draft").size})", trash: "#{t('camaleon_cms.admin.post_type.trash')} (#{posts_all.where(status: "trash").size})"}
+    @btns = {published: "#{t('camaleon_cms.admin.post_type.published')} (#{posts_all.published.size})", all: "#{t('camaleon_cms.admin.post_type.all')} (#{posts_all.no_trash.size})", pending: "#{t('camaleon_cms.admin.post_type.pending')} (#{posts_all.pending.size})", draft: "#{t('camaleon_cms.admin.post_type.draft')} (#{posts_all.drafts.size})", trash: "#{t('camaleon_cms.admin.post_type.trash')} (#{posts_all.trash.size})"}
     r = {posts: @posts, post_type: @post_type, btns: @btns, all_posts: posts_all, render: 'index', per_page: per_page }
     hooks_run("list_post", r)
     per_page = 9999999 if @post_type.manage_hierarchy?
@@ -91,13 +92,21 @@ class CamaleonCms::Admin::PostsController < CamaleonCms::AdminController
   end
 
   def update
-    @post = @post.parent if @post.draft? && @post.parent.present?
-    authorize! :update, @post
-    @post.drafts.destroy_all
     post_data = get_post_data
+    if @post.draft_child? && @post.parent.present?
+      # This is a draft (as a child of the original post)
+      original_parent = @post.parent.parent
+      post_data[:post_parent] = original_parent.present? ? original_parent.id : nil
+      @post = @post.parent
+    elsif @post.draft?
+      # This is a normal draft (post whose status was set to 'draft')
+      @post.status = 'published' if post_data[:status].blank?
+    end
+    authorize! :update, @post
     r = {post: @post, post_type: @post_type}; hooks_run("update_post", r)
     @post = r[:post]
     if @post.update(post_data)
+      @post.drafts.destroy_all
       @post.set_metas(params[:meta])
       @post.set_field_values(params[:field_options])
       @post.set_options(params[:options])

--- a/app/decorators/camaleon_cms/post_decorator.rb
+++ b/app/decorators/camaleon_cms/post_decorator.rb
@@ -150,7 +150,7 @@ class CamaleonCms::PostDecorator < CamaleonCms::ApplicationDecorator
       when "published"
         color = "info"
         status = I18n.t('camaleon_cms.admin.post_type.published', default: 'Published')
-      when "draft"
+      when "draft", "draft_child"
         color = "warning"
         status = I18n.t('camaleon_cms.admin.table.draft', default: 'Draft')
       when "trash"

--- a/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
+++ b/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
@@ -43,7 +43,7 @@
                         <option class="" value="published" <%= (@post[:status] == "published") ? "selected": "" %> ><%= t('camaleon_cms.admin.post_type.published')%></option>
                     <% end  %>
                     <option value="pending" <%= (@post[:status] == "pending") ? "selected": "" %>><%= t('camaleon_cms.admin.table.pending')%></option>
-                    <option value="draft" <%= (@post[:status] == "draft") ? "selected": "" %>><%= t('camaleon_cms.admin.table.draft')%></option>
+                    <option value="draft" <%= (@post[:status] == "draft" || @post[:status] == "draft_child") ? "selected": "" %>><%= t('camaleon_cms.admin.table.draft')%></option>
                 </select>
             </div>
             <!-- templates -->


### PR DESCRIPTION
Hey, I noticed that the functionality to create drafts and restore them is broken when you also manage the page hierarchy. This is because the `post_parent` field is used for both purposes. The problem is that there is no distinction between a normal draft that is just a post with status 'draft' and child drafts that are basically a copy of the original post and have that original post as their parent.

### How to reproduce

- Create a post
- Create another post and set the first post as the parent
- Now in the second post click "Save Draft"
- Go to the created draft and restore it. You will get an error "Parent Post Recursive"

The same happens if you set a post's status to 'draft'. When you want to restore that post you get the same error AND that post will be DELETED!!!

### Solution

So my suggestion is to distinguish between normal drafts and child drafts. Child drafts (newly created posts) need to "overwrite" their parent when being restored but normal drafts just need to set the status to 'published'.