### PR TITLE
Fixed NoMethodError undefined method 'paginate' for comments

### DIFF
--- a/app/controllers/camaleon_cms/admin/comments_controller.rb
+++ b/app/controllers/camaleon_cms/admin/comments_controller.rb
@@ -1,3 +1,4 @@
+require 'will_paginate/array'
 class CamaleonCms::Admin::CommentsController < CamaleonCms::AdminController
   include CamaleonCms::CommentHelper
   add_breadcrumb I18n.t("camaleon_cms.admin.sidebar.comments"), :cama_admin_comments_url


### PR DESCRIPTION
Visiting the comments after initializing the new project. Getting 
```NoMethodError (undefined method `paginate' for []:Array):```

![action controller exception caught 2017-06-01 20-38-14](https://cloud.githubusercontent.com/assets/3229362/26686352/49d9aa8e-470a-11e7-8b10-01db8d54ebe0.png)
