### PR TITLE
fix I18n.backend translations

### DIFF
--- a/app/views/layouts/camaleon_cms/admin.html.erb
+++ b/app/views/layouts/camaleon_cms/admin.html.erb
@@ -14,7 +14,7 @@
         var CURRENT_LOCALE = '<%= current_locale %>';
         var ADMIN_TRANSLATIONS = <%= raw current_site.get_languages.to_json %>;
         var tinymce_global_settings = {language_url: "<%= asset_path("camaleon_cms/admin/tinymce/langs/#{current_locale}.js") %>", custom_css: [], custom_toolbar: [], post_render: [], init: [], setups: [], settings: []};
-        var I18n_data = <%= I18n.backend.send(:translations)[current_locale.to_sym][:camaleon_cms][:admin][:js].to_json.html_safe rescue "{}" %>
+        var I18n_data = <%= I18n.backend.respond_to?(:translations) ? I18n.backend.send(:translations)[current_locale.to_sym][:camaleon_cms][:admin][:js].to_json.html_safe : !!(I18n.backend.backends[1] && I18n.backend.backends[1].backends[1]) ? I18n.backend.backends[1].backends[1].send(:translations)[current_locale.to_sym][:camaleon_cms][:admin][:js].to_json.html_safe : "{}" rescue "{}" %>
     </script>
     <%= javascript_include_tag "camaleon_cms/admin/admin-manifest" %>
 


### PR DESCRIPTION
https://github.com/owen2345/camaleon-cms/issues/593

Please help to fix, otherwise I18n_data will always be empty hash.