### PR TITLE
remove deprecated method 'render :text'

### DIFF
--- a/app/apps/plugins/attack/attack_helper.rb
+++ b/app/apps/plugins/attack/attack_helper.rb
@@ -40,7 +40,7 @@ module Plugins::Attack::AttackHelper
   def attack_app_before_load()
     cache_ban = Rails.cache.read(cama_get_session_id)
     if cache_ban.present? # render banned message if it was banned
-      render text: cache_ban, layout: false
+      render html: cache_ban.html_safe, layout: false
       return
     end
 
@@ -67,7 +67,7 @@ module Plugins::Attack::AttackHelper
       if r.count > config[:post][:max].to_i
         Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
         # send an email to administrator with request info (ip, browser, if logged then send user info
-        render text: config[:msg]
+        render html: config[:msg].html_safe
         return
       end
 
@@ -76,7 +76,7 @@ module Plugins::Attack::AttackHelper
       r = q.where(created_at: config[:get][:sec].to_i.seconds.ago..Time.now)
       if r.count > config[:get][:max].to_i
         Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
-        render text: config[:msg]
+        render html: config[:msg].html_safe
         return
       end
     end

--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -20,7 +20,11 @@ class Plugins::FrontCache::AdminController < CamaleonCms::Apps::PluginsAdminCont
   def clean_cache
     flash[:notice] = "#{t('plugin.front_cache.message.cache_destroyed')}"
     front_cache_clean()
-    redirect_to :back
+    if Rails.version.to_s[0].to_i < 5
+      redirect_to :back
+    else
+      redirect_back(fallback_location: '/admin/plugins')
+    end
   end
 
 end

--- a/app/apps/plugins/front_cache/front_cache_helper.rb
+++ b/app/apps/plugins/front_cache/front_cache_helper.rb
@@ -14,7 +14,7 @@ module Plugins::FrontCache::FrontCacheHelper
       Rails.logger.info "Camaleon CMS - readed cache: #{front_cache_plugin_get_path(cache_key)}"
       response.headers['PLUGIN_FRONT_CACHE'] = 'TRUE'
       args = {data: front_cache_get(cache_key).gsub("{{form_authenticity_token}}", form_authenticity_token)}; hooks_run('front_cache_reading_cache', args)
-      render text: args[:data]
+      render html: args[:data].html_safe
       return
     end
 

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -19,7 +19,7 @@ class CamaleonCms::Admin::MediaController < CamaleonCms::AdminController
     crop_path = cama_crop_image(path_image, params[:ic_w], params[:ic_h], params[:ic_x], params[:ic_y])
     res = upload_file(crop_path, {remove_source: true})
     CamaleonCms::User.find(params[:saved_avatar]).set_meta('avatar', res["url"]) if params[:saved_avatar].present? # save current crop image as avatar
-    render text: res["url"]
+    render html: res["url"].html_safe
   end
 
   # download private files


### PR DESCRIPTION
Fixes #624. Replaced the deprecated method throughout the repo, so please check the code in attack_helper.rb and media_controller.rb.