### PR TITLE
fix error when using another model for authentication (ie.: devise)

### DIFF
--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -14,7 +14,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
 
     # relations
     has_many :metas, ->{ where(object_class: 'User')}, :class_name => "CamaleonCms::Meta", foreign_key: :objectid, dependent: :destroy
-    has_many :all_posts, class_name: "CamaleonCms::Post"
+    has_many :all_posts, class_name: "CamaleonCms::Post", foreign_key: :user_id
     has_many :all_comments, class_name: "CamaleonCms::PostComment"
 
     #scopes


### PR DESCRIPTION
after configured to use devise following the custom auth tutorial http://camaleon.tuzitio.com/documentation/category/139779-faqs/custom-login.html the system throws an exception when tried to remove an user using the admin panel