### PR TITLE
using content slug instead of id to prevent conflict between multiple sites

### DIFF
--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -42,7 +42,7 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
   # render contents from post type
   def post_type
     begin
-      @post_type = current_site.post_types.find(params[:post_type_id]).decorate
+      @post_type = current_site.post_types.find_by_slug(params[:post_type_slug]).decorate
     rescue
       return page_not_found
     end


### PR DESCRIPTION
this fix is related to this issue: https://github.com/owen2345/camaleon-cms/issues/655