### PR TITLE
Cast parameters to hash to avoid error in rails 5

### DIFF
--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -52,7 +52,7 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
   # only used by form on admin panel (protected)
   # return array of failed_fields and full_fields [[failed fields], [all fields]]
   def add_fields(items, item_options)
-    self.fields.where.not(id: items.map { |_k, obj| obj['id'] }.uniq).destroy_all
+    self.fields.where.not(id: items.to_h.map { |_k, obj| obj['id'] }.uniq).destroy_all
     cache_fields = []
     order_index = 0
     errors_saved = []


### PR DESCRIPTION
This is just a quick fix in a specific file, similar errors might be lurking in other places.
Acording to [this post in SO](https://stackoverflow.com/a/34951198)  

> in Rails 5 ActionController::Parameters now returns an Object instead of a Hash

on Object has no map method