### PR TITLE
Use Rails cache store in Front Cache plugin

### DIFF
--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -11,7 +11,8 @@ class Plugins::FrontCache::AdminController < CamaleonCms::Apps::PluginsAdminCont
                                                    post_types: (params[:cache][:post_type]||[]),
                                                    skip_posts: (params[:cache][:skip_posts]||[]),
                                                    cache_login: params[:cache][:cache_login],
-                                                   home: params[:cache][:home]
+                                                   home: params[:cache][:home],
+                                                   preserve_cache_on_restart: params[:cache][:preserve_cache_on_restart]
                                                   })
     flash[:notice] = "#{t('plugin.front_cache.message.settings_saved')}"
     redirect_to action: :settings
@@ -20,7 +21,7 @@ class Plugins::FrontCache::AdminController < CamaleonCms::Apps::PluginsAdminCont
   def clean_cache
     flash[:notice] = "#{t('plugin.front_cache.message.cache_destroyed')}"
     front_cache_clean()
-    if Rails.version.to_s[0].to_i < 5
+    if Rails.version.to_i < 5
       redirect_to :back
     else
       redirect_back(fallback_location: '/admin/plugins')

--- a/app/apps/plugins/front_cache/config/config.json
+++ b/app/apps/plugins/front_cache/config/config.json
@@ -1,7 +1,7 @@
 {
   "title": "Front Cache",
   "descr": "Please check documentation <a href='http://camaleon.tuzitio.com/store/plugins/3'>here.</a>",
-  "version": "0.1",
+  "version": "0.2",
   "key": "front_cache",
   "position": 1,
   "helpers": [

--- a/app/apps/plugins/front_cache/views/admin/settings.html.erb
+++ b/app/apps/plugins/front_cache/views/admin/settings.html.erb
@@ -21,6 +21,11 @@
     <div class="panel-body">
         <div class="alert alert-info"><%= t('plugin.front_cache.message.please_checkpost_need_cache') %></div>
         <div class="form-group">
+            <label>Preserve cache on restart</label><br>
+            <%= check_box_tag("cache[preserve_cache_on_restart]", 1, @caches[:preserve_cache_on_restart]) %>
+        </div>
+
+        <div class="form-group">
             <label><%= t('plugin.front_cache.home_page') %></label><br>
             <%= check_box_tag("cache[home]", 1, @caches[:home]) %>
         </div>


### PR DESCRIPTION
What it does:

- Uses the Rails cache store for the Front Cache plugin instead of manually managing files. This benefits users of distributed cache stores like Memcached or Redis.
- Adds a checkbox to settings to allow preserving the cache on restart. This benefits users of Heroku and others using ephemeral file systems.
- Preserves previous behavior (for the most part). The default cache store in Rails is `:file_store`, so anyone who doesn't configure their Rails cache should experience similar performance to the previous implementation. Also, the cache will still be cleaned on restart unless the new option in settings is selected.
- Addresses #609.
- Bumps plugin version to 0.2.


What it doesn't do:

- Translate the new settings option (I don't have the language skills).
- Allow for clearing the Front Cache without clearing the whole Rails cache. I couldn't find a way of doing this that would support all common caching methods.