### PR TITLE
Fix custom fields group issue on Rails 5.1.1

### DIFF
--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -120,7 +120,7 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
 
   # auto save the default field values
   def auto_save_default_values(field, options)
-    options = options.with_indifferent_access
+    # options = options.with_indifferent_access
     class_name = object_class.split("_").first
     if %w(Post Category Plugin Theme).include?(class_name) && objectid && (options[:default_value].present? || options[:default_values].present?)
       if class_name == 'Theme'

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -120,7 +120,6 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
 
   # auto save the default field values
   def auto_save_default_values(field, options)
-    # options = options.with_indifferent_access
     class_name = object_class.split("_").first
     if %w(Post Category Plugin Theme).include?(class_name) && objectid && (options[:default_value].present? || options[:default_values].present?)
       if class_name == 'Theme'


### PR DESCRIPTION
Unsupported function `with_indifferent_access` remotion on custom_field_group model