### PR TITLE
Add option to invalidate Front Cache rather than deleting it

### DIFF
--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -12,7 +12,9 @@ class Plugins::FrontCache::AdminController < CamaleonCms::Apps::PluginsAdminCont
                                                    skip_posts: (params[:cache][:skip_posts]||[]),
                                                    cache_login: params[:cache][:cache_login],
                                                    home: params[:cache][:home],
-                                                   preserve_cache_on_restart: params[:cache][:preserve_cache_on_restart]
+                                                   preserve_cache_on_restart: params[:cache][:preserve_cache_on_restart],
+                                                   invalidate_only: params[:cache][:invalidate_only],
+                                                   cache_counter: current_site.get_meta("front_cache_elements")[:cache_counter] || 0
                                                   })
     flash[:notice] = "#{t('plugin.front_cache.message.settings_saved')}"
     redirect_to action: :settings

--- a/app/apps/plugins/front_cache/config/locales/translation.yml
+++ b/app/apps/plugins/front_cache/config/locales/translation.yml
@@ -12,6 +12,8 @@ en:
       pages: 'Pages'
       pages_of: 'Pages of'
       skip_cache_pages: 'Skip Cache Pages'
+      preserve_cache_on_restart: 'Preserve cache on restart'
+      invalidate_only: 'Invalidate the cache instead of deleting it. (Recommended only if you use custom caching in your views. Not recommended when using FileStore, which is the Rails default cache)'
       message:
         please_checkpost_need_cache: 'Please check all posts or post types you need to cache.'
         enabled_cache_inner_content_logged_users: 'Enable cache for inner content for logged users'
@@ -31,6 +33,8 @@ es:
       pages: 'Página'
       pages_of: 'Página de'
       skip_cache_pages: 'Saltar página del Caché'
+      preserve_cache_on_restart: 'Preservar caché al reiniciar'
+      invalidate_only: 'Invalide el caché en lugar de eliminarlo. (Recomendado sólo si utiliza el almacenamiento en caché personalizado en sus vistas No se recomienda cuando se utiliza FileStore, que es la caché predeterminada de Rails)'
       message:
         please_checkpost_need_cache: 'Por favor, compruebe todos los mensajes o los tipos de correos que necesita para almacenar en caché.'
         enabled_cache_inner_content_logged_users: 'Habilitar caché de contenido interno para usuarios registrados'
@@ -51,6 +55,8 @@ nl:
       pages: "Pagina's"
       pages_of: "Inhoud van"
       skip_cache_pages: 'Cache overslaan'
+      preserve_cache_on_restart: 'Bewaar cache bij herstarten'
+      invalidate_only: 'De cache ongeldig maken, in plaats van het te verwijderen. (Alleen aanbevolen als u aangepaste caching gebruikt in uw weergaven. Niet aanbevolen bij het gebruik van FileStore, wat is de standaard cache van de Rails)'
       message:
         please_checkpost_need_cache: "Kijk alle berichten of inhoud type's na die je wil cachen."
         enabled_cache_inner_content_logged_users: 'Activeer cache voor gelogde gebruikers'
@@ -70,6 +76,8 @@ pt-BR:
       pages: 'Páginas'
       pages_of: 'Páginas de'
       skip_cache_pages: 'Saltar Cache de Páginas'
+      preserve_cache_on_restart: 'Preserve o cache no reinício'
+      invalidate_only: 'Invalide o cache em vez de excluí-lo. (Recomendado apenas se você usar cache personalizado em suas visualizações. Não recomendado quando usar FileStore, que é o cache padrão do Rails)'
       message:
         please_checkpost_need_cache: 'Por favor verifique todas as publicações ou o tipo do publicação que precisa colocar em cache.'
         enabled_cache_inner_content_logged_users: 'Permitir cache para conteúdo interno de utilizadores ligados'
@@ -89,6 +97,8 @@ pt-BR:
       pages: 'Páginas'
       pages_of: 'Páginas de'
       skip_cache_pages: 'Pular Cache de Páginas'
+      preserve_cache_on_restart: 'Preserve o cache no reinício'
+      invalidate_only: 'Invalide o cache em vez de excluí-lo. (Recomendado apenas se você usar cache personalizado em suas visualizações. Não recomendado quando usar FileStore, que é o cache padrão do Rails)'
       message:
         please_checkpost_need_cache: 'Por favor cheque todos os posts ou o tipo do post que você precisa cachear.'
         enabled_cache_inner_content_logged_users: 'Permitir cache para conteúdo interno de usuários logados'
@@ -108,6 +118,8 @@ it:
       pages: 'Pagine'
       pages_of: 'Pagine di'
       skip_cache_pages: 'Pagine da non cachare'
+      preserve_cache_on_restart: 'Conserva la cache al riavvio'
+      invalidate_only: 'Invalidate la cache invece di cancellarla. (Consigliato solo se si utilizza la cache personalizzata nelle tue viste. Non è consigliata quando si utilizza FileStore, che è la cache predefinita Rails)'
       message:
         please_checkpost_need_cache: 'Per favore, verifica tutti i tipi di messaggi o e-mail che è necessario memorizzare nella cache.'
         enabled_cache_inner_content_logged_users: 'Attiva il contenuto della cache interna per gli utenti registrati'
@@ -127,10 +139,11 @@ zh-CN:
       pages: '页面'
       pages_of: '页'
       skip_cache_pages: '跳过缓存页面'
+      preserve_cache_on_restart: '重新启动时保存缓存'
+      invalidate_only: '使缓存无效，而不是删除它。 （仅当您在视图中使用自定义缓存时才推荐使用FileStore时，建议不要使用Rails默认缓存）'
       message:
         please_checkpost_need_cache: '请检查您需要缓存位内容.'
         enabled_cache_inner_content_logged_users: '为已登录的用户启用内部内容的缓存'
         settings_saved: '设置已保存!'
         cache_destroyed: '缓存已清楚!'
       settings: '设置'
-

--- a/app/apps/plugins/front_cache/views/admin/settings.html.erb
+++ b/app/apps/plugins/front_cache/views/admin/settings.html.erb
@@ -21,11 +21,6 @@
     <div class="panel-body">
         <div class="alert alert-info"><%= t('plugin.front_cache.message.please_checkpost_need_cache') %></div>
         <div class="form-group">
-            <label>Preserve cache on restart</label><br>
-            <%= check_box_tag("cache[preserve_cache_on_restart]", 1, @caches[:preserve_cache_on_restart]) %>
-        </div>
-
-        <div class="form-group">
             <label><%= t('plugin.front_cache.home_page') %></label><br>
             <%= check_box_tag("cache[home]", 1, @caches[:home]) %>
         </div>
@@ -59,6 +54,16 @@
         <div class="form-group">
             <label><%= t('plugin.front_cache.skip_cache_pages') %></label>
             <%= select_tag("cache[skip_posts]", option_groups_from_collection_for_select(current_site.the_post_types.decorate, :the_posts, 'the_title', "id", lambda{|o| o.decorate.the_title }, @caches[:skip_posts]), "class"=> "form-control select", multiple: true, "data-live-search" => "true") %>
+        </div>
+
+        <div class="form-group">
+            <label><%= t('plugin.front_cache.preserve_cache_on_restart') %></label><br>
+            <%= check_box_tag("cache[preserve_cache_on_restart]", 1, @caches[:preserve_cache_on_restart]) %>
+        </div>
+
+        <div class="form-group">
+            <label><%= t('plugin.front_cache.invalidate_only') %></label><br>
+            <%= check_box_tag("cache[invalidate_only]", 1, @caches[:invalidate_only]) %>
         </div>
 
         <!--<div class="form-group">-->

--- a/config/locales/camaleon_cms/admin/en.yml
+++ b/config/locales/camaleon_cms/admin/en.yml
@@ -40,7 +40,7 @@ en:
         not_actived: 'Not Active'
         publish: 'Publish'
         preview: 'Preview'
-        proccess: 'Proccess'
+        proccess: 'Process'
         recover: 'Recover'
         restore: 'Restore'
         restore_selections: 'Restore Selections'


### PR DESCRIPTION
Invalidating the cache allows the user to clean the front cache plugin without losing other cache items like fragment caching. This is preferable to deleting the cache when using cache systems that automatically eject keys when the cache is full. The option is off by default to match previous behavior, and because the default Rails cache is FileStore, which does not eject keys.

This is accomplished by placing a counter in the cache paths. When the counter is incremented, the old cache keys will no longer match the new cache paths, so they remain unused until ejected by the cache system.

Other changes:

- Moved the "Preserve cache on restart" option to the bottom of the list, with the new invalidate option below it.
- Added translations for both of the above options.
- Fixed a typo in an English translation.

**NOTE** I noticed that the translation.yml file in this pull request has two sections labeled `pt-BR:`
It looks to me like one of these is supposed to say `pt`, but I can't be sure because I don't read Portugese. I can add that change to this PR if someone can tell me the correct way, otherwise I can open an issue.