### PR TITLE
Contrib dev

### DIFF
--- a/app/controllers/camaleon_cms/admin/settings/post_types_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/post_types_controller.rb
@@ -18,6 +18,8 @@ class CamaleonCms::Admin::Settings::PostTypesController < CamaleonCms::Admin::Se
 
   def update
     if @post_type.update(@data_term)
+      custom_fields_data = params.require(:field_options).permit!
+      @post_type.set_field_values(custom_fields_data)
       flash[:notice] = t('camaleon_cms.admin.post_type.message.updated')
       redirect_to action: :index
     else

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_post_types.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_post_types.html.erb
@@ -1,5 +1,6 @@
 <div class="group-input-fields-content" data-callback-render="">
   <select name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control input-value <%= 'is_translate' if field.options[:translate].to_s.to_bool %> <%= "required" if field.options[:required].to_s.to_bool %>" >
+    <option value=""></option>
     <% current_site.the_post_types.decorate.each do |ptype|  %>
         <option value="<%= ptype.id %>"><%= ptype.the_title %></option>
     <% end %>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
@@ -34,6 +34,13 @@
                             <%= f.label t('camaleon_cms.admin.settings.where_display_group') %><br>
                             <select id="select_assign_group" name="custom_field_group[assign_group]" class="form-control required">
                                 <option value="">&nbsp;</option>
+
+                                <optgroup label="<%= t('camaleon_cms.admin.settings.in_post_type_settings_of', default: 'In Post Type settings of') %>">
+                                  <% current_site.post_types.each do |pt| pt = pt.decorate; value = "PostType,#{pt.id}" %>
+                                      <option value="<%= value %>"><%= pt.the_title %></option>
+                                  <% end  %>
+                                </optgroup>
+
                                 <optgroup label="<%= t('camaleon_cms.admin.settings.posts_in') %>">
                                     <% current_site.post_types.each do |pt| pt = pt.decorate; value = "PostType_Post,#{pt.id}" %>
                                         <option value="<%= value %>" data-help="<%= "#{t('camaleon_cms.admin.settings.tooltip.add_custom_field_posts')}"+ pt.the_title %>"><%= pt.the_title %></option>

--- a/app/views/camaleon_cms/admin/settings/post_types/_form.html.erb
+++ b/app/views/camaleon_cms/admin/settings/post_types/_form.html.erb
@@ -149,7 +149,7 @@
                     </div>
                 </div>
                 <% if groups.present? %>
-                    <div id="post_type_setting_custom">
+                    <div role="tabpanel" class="tab-pane" id="post_type_setting_custom">
                         <%= render partial: "camaleon_cms/admin/settings/custom_fields/render", locals: {record: @post_type, field_groups: groups} %>
                     </div>
                 <% end %>

--- a/config/locales/camaleon_cms/admin/de.yml
+++ b/config/locales/camaleon_cms/admin/de.yml
@@ -393,6 +393,7 @@ de:
         permission_login_facebook: 'Login via Facebook erlauben?'
         permission_login_google: 'Login via Google+ erlauben?'
         posts_in: 'Posts in'
+        in_post_type_settings_of: 'In den Post Type Einstellungen von'
         settings: 'Einstellungen'
         tooltip:
           add_custom_field_posts: 'Füge selbsterstelltes Feld hinzu in Posts von '

--- a/config/locales/camaleon_cms/admin/en.yml
+++ b/config/locales/camaleon_cms/admin/en.yml
@@ -393,6 +393,7 @@ en:
         permission_login_facebook: 'Permission to Login with Facebook'
         permission_login_google: 'Permission to Login with Google+'
         posts_in: 'Posts in'
+        in_post_type_settings_of: 'In Post Type settings of'
         settings: 'Settings'
         tooltip:
           add_custom_field_posts: 'Add Custom Field in Posts of '


### PR DESCRIPTION
This makes it possible to add custom field groups to post_types themselves, not to their posts. The custom field group appears in the post type settings.