### PR TITLE
Allow login to inactive sites

### DIFF
--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -100,7 +100,14 @@ class CamaleonCms::CamaleonController < ApplicationController
       # inactive page control
       if current_site.is_inactive?
         p = current_site.posts.find(current_site.get_option('page_inactive')).decorate
-        redirect_to(p.the_url) if params != {"controller"=>"camaleon_cms/frontend", "action"=>"post", "slug"=>p.the_slug}
+        if request.original_url.to_s.match /\A#{current_site.the_url}admin(\/|\z)/
+          if cama_current_user.present?
+            cama_logout_user
+            flash[:error] = ('Site is Inactive')
+          end
+        else
+          redirect_to(p.the_url) unless params == {"controller"=>"camaleon_cms/frontend", "action"=>"post", "slug"=>p.the_slug}
+        end
       end
 
       # maintenance page and IP's control


### PR DESCRIPTION
Fixes #682. Currently, the login page is not exempted from the redirect used on an inactive site, rendering the admin dashboard completely inaccessible. This pull request allows access to the login page. If a user with an admin role logs in, they gain site access. If a user logs in with another role, they are logged out with a message that the site is inactive.

I chose this approach because the existing code appeared designed to restrict access to inactive sites to users with an admin role, so this should fix the bug without altering other behavior.

Please note that the bug was experienced and the fix tested with the following options in system.json:
```
"share_sessions": true
"users_share_sites": true
```
The behavior was the consistent in development mode using multiple subdomains (subdomain1.localhost:5000, subdomain2.localhost:5000), and in production mode using multiple top-level domains (www.domain1.space, www.domain2.com).