### PR TITLE
Added hooks for media support

### DIFF
--- a/app/apps/plugins/attack/attack_helper.rb
+++ b/app/apps/plugins/attack/attack_helper.rb
@@ -13,7 +13,7 @@ module Plugins::Attack::AttackHelper
   def attack_on_active(plugin)
     current_site.set_meta("attack_config", {get: {sec: 20, max: 10},
                                             post: {sec: 20, max: 5},
-                                            msg: "#{t('plugin.attack.form.request_limit_exceeded')}",
+                                            msg: "#{I18n.t('plugin.attack.form.request_limit_exceeded')}",
                                             ban: 5,
                                             cleared: Time.now
                                           })

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -74,6 +74,8 @@ module CamaleonCms::UploaderHelper
     cama_uploader_generate_thumbnail(uploaded_io.path, res['key'], settings[:thumb_size]) if settings[:generate_thumb] && res['thumb'].present?
 
     FileUtils.rm_f(uploaded_io.path) if settings[:remove_source]
+
+    hooks_run('after_upload', settings)
     res
   end
 

--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -93,7 +93,7 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
   def delete_file(key)
     key = "#{@aws_settings["inner_folder"]}/#{key}" if @aws_settings["inner_folder"].present?
     bucket.object(key.split('/').clean_empty.join('/')).delete rescue ''
-    hooks_run('after_delete', key)
+    @instance.hooks_run('after_delete', key)
     
     reload
   end

--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -93,6 +93,8 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
   def delete_file(key)
     key = "#{@aws_settings["inner_folder"]}/#{key}" if @aws_settings["inner_folder"].present?
     bucket.object(key.split('/').clean_empty.join('/')).delete rescue ''
+    hooks_run('after_delete', key)
+    
     reload
   end
 

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -96,7 +96,7 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def delete_file(key)
     file = File.join(@root_folder, key)
     FileUtils.rm(file) if File.exist? file
-    hooks_run('after_delete', key)
+    @instance.hooks_run('after_delete', key)
     
     reload
   end

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -96,6 +96,8 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def delete_file(key)
     file = File.join(@root_folder, key)
     FileUtils.rm(file) if File.exist? file
+    hooks_run('after_delete', key)
+    
     reload
   end
 


### PR DESCRIPTION
2 Hooks added (`after_upload` and `after_delete`) to support further customization when uploading or deleting a file. 
This can be useful when adding database management or other custom action after these actions ocurr.

Additionally fixed a bug on attack plugin to be able to run `plugin_install('attack')`