### PR TITLE
Summary before content as logic

### DIFF
--- a/app/views/camaleon_cms/admin/posts/form.html.erb
+++ b/app/views/camaleon_cms/admin/posts/form.html.erb
@@ -29,16 +29,16 @@
                         <%= f.label t('camaleon_cms.admin.table.title') %> <em class="text-danger">*</em><br>
                         <%= f.text_field :title, :class => "form-control required translatable required_all_langs title-post" %>
                     </div>
-                    <% if @post.manage_content?(@post_type) %>
-                        <div class="form-group">
-                            <%= f.label t('camaleon_cms.admin.sidebar.content') %> <em class="text-danger">*</em><br>
-                            <%= f.text_area :content, :class => "form-control tinymce_textarea required translatable", :height => '520px', :style => "width: 100%" %>
-                        </div>
-                    <% end %>
                     <% if @post.manage_summary?(@post_type) %>
                         <div class="form-group">
                             <label for="post_summary"><%= t('camaleon_cms.admin.post_type.summary') %></label><br>
                             <textarea name="meta[summary]" id="post_summary" class="form-control translatable" cols="30" rows="5"><%= @post.get_meta("summary", "") %></textarea>
+                        </div>
+                    <% end %>
+                    <% if @post.manage_content?(@post_type) %>
+                        <div class="form-group">
+                            <%= f.label t('camaleon_cms.admin.sidebar.content') %> <em class="text-danger">*</em><br>
+                            <%= f.text_area :content, :class => "form-control tinymce_textarea required translatable", :height => '520px', :style => "width: 100%" %>
                         </div>
                     <% end %>
                     <%= _hook_args = {html: "", f: f, post: @post, post_type: @post_type}; hooks_run("post_form_custom_html", _hook_args); raw(_hook_args[:html]); %>


### PR DESCRIPTION
When editing a page/post, the `summary` should come prior to the `content` as it should be (or intended to be) used as an introduction text for what comes ahead.