### PR TITLE
Replaces deprecated fields, field_values and field_groups associations

### DIFF
--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -128,7 +128,7 @@ class CamaleonCms::CustomFieldGroup < CamaleonCms::CustomField
         owner = "CamaleonCms::#{class_name}".constantize.find(objectid) rescue "CamaleonCms::#{class_name}".constantize.find_by(slug: objectid) # owner model
       end
       (options[:default_values] || [options[:default_value]] || []).each do |value|
-        owner.field_values.create!(custom_field_id: field.id, custom_field_slug: field.slug,
+        owner.custom_field_values.create!(custom_field_id: field.id, custom_field_slug: field.slug,
           value: fix_meta_value(value)) if owner.present?
       end
     end

--- a/app/views/camaleon_cms/default_theme/single.json.jbuilder
+++ b/app/views/camaleon_cms/default_theme/single.json.jbuilder
@@ -6,7 +6,7 @@ json.urls @post.the_urls
 
 json.partial! partial: 'partials/cama_comments_entry', locals:{ post: @post }
 
-json.fields @post.the_fields_grouped(@post.field_values.pluck(:custom_field_slug))
+json.fields @post.the_fields_grouped(@post.custom_field_values.pluck(:custom_field_slug))
 
 json.categories @post.categories.decorate do |category|
   json.partial! partial: 'partials/cama_category_entry', locals:{ category: category }


### PR DESCRIPTION
Hi @owen2345,

Association fields, field_values and field_groups have a comment marking them as deprecated and to use the custom_fields, custom_field_values and custom_field_groups instead.
This pull request tries to do that. With it in place, it allows us to improve performance in situations like when we use try to use different custom fields for a post or multiple posts

Nevertheless, there are still places where the old association is still being used because it failed the tests.
I'm not sure if nothing else will break with this change.

Thank you,
Filipe