### PR TITLE
fix post tag created without parent_id bug

### DIFF
--- a/app/views/camaleon_cms/admin/post_tags/_form.html.erb
+++ b/app/views/camaleon_cms/admin/post_tags/_form.html.erb
@@ -1,4 +1,4 @@
-<% @post_tag = CamaleonCms::PostTag.new if @post_tag.nil? %>
+<% @post_tag = CamaleonCms::PostTag.new(parent_id: params[:post_type_id]) if @post_tag.nil? %>
 <%= form_for @post_tag, as: "post_tag", url:{action: @post_tag.new_record? ? :create : :update} , html:{class: 'validate-post-tag cama_ajax_request'} do |f| %>
     <%= f.hidden_field :parent_id  %>
     <%= f.hidden_field :taxonomy %>


### PR DESCRIPTION
When creating a post tag in Post Tags index page, the tag would be saved but nothing showed in the list. 

After investigating the SQL generated, I found `parent_id` is empty.