### PR TITLE
generate random character when slugify empty

### DIFF
--- a/app/assets/javascripts/camaleon_cms/admin/_post.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_post.js
@@ -110,6 +110,10 @@ function cama_init_post(obj) {
             var slug_tmp = null;
             $input_slug.slugify($this, {
                     change: function (slug) {
+                        if (slug == "") {
+                            # generate 5-length random character slug when slugify result is empty
+                            slug = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+                        }
                         slug_tmp = slug;
                         set_slug(slug);
                     }


### PR DESCRIPTION
If the title to be created is not digits nor latin character(a-z, A-z), for example Chinese or Japannese, it would fail to generate slug and leave empty. The content would fail to save.

This is somewhat easy to ignore for non-pro users. So I suggest maybe it should generate 5-length random character slug when slugify result is empty