### PR TITLE
Skip forgery check on static assets

### DIFF
--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -26,7 +26,9 @@ class CamaleonCms::CamaleonController < ApplicationController
   after_action :cama_after_actions, except: [:render_error, :captcha]
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # Skip forgery check on .js files located in /assets/ to avoid CORS errors
+  # caused by requests for non-existent files.
+  protect_from_forgery with: :exception, unless: -> { request.fullpath.match? /\A\/assets\/.*\.js\z/ }
   layout Proc.new { |controller| controller.request.xhr? ? false : 'default' }
   helper_method :current_user
 
@@ -125,7 +127,7 @@ class CamaleonCms::CamaleonController < ApplicationController
       end
     end
   end
-  
+
   unless ApplicationController.method_defined?(:current_user)
     def current_user
       cama_current_user


### PR DESCRIPTION
Fixes #742.

When ActionDispatch::Static can't locate a .js file, the request falls through to Rails. Currently, this causes an ActionController::InvalidCrossOriginRequest exception instead of a simple 404.

The simplest fix is to disable the forgery check when requesting a .js file from the /assets/ directory. Any such request that reaches the controller is for a non-existent file and will cause a 404.