### PR TITLE
767: Page not found not giving 404 status code

### DIFF
--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -148,7 +148,7 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
   # render a post
   # post_or_slug_or_id: slug_post | id post | post object
   # from_url: true/false => true (true, permit eval hooks "on_render_post")
-  def render_post(post_or_slug_or_id, from_url = false)
+  def render_post(post_or_slug_or_id, from_url = false, status = nil)
     if post_or_slug_or_id.is_a?(String) # slug
       @post = current_site.the_posts.find_by_slug(post_or_slug_or_id)
     elsif post_or_slug_or_id.is_a?(Integer) # id
@@ -192,7 +192,12 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
       layout_ = meta_layout if meta_layout.present? && lookup_context.template_exists?("layouts/#{meta_layout}")
       r = {post: @post, post_type: @post_type, layout: layout_, render: r_file}
       hooks_run("on_render_post", r) if from_url
-      render r[:render], (!r[:layout].nil? ? {layout: r[:layout]} : {})
+      
+      if status.present?
+        render r[:render], (!r[:layout].nil? ? {layout: r[:layout], status: status} : {status: status})  
+      else
+        render r[:render], (!r[:layout].nil? ? {layout: r[:layout]} : {})
+      end
     end
   end
 
@@ -202,38 +207,11 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
     if @_site_options[:error_404].present? # render a custom error page
       page_404 = current_site.posts.find(@_site_options[:error_404]) rescue ""
       if page_404.present?
-        render_custom_page_not_found(page_404)
+        render_post(page_404, false, :not_found)
         return
       end
     end
     render_error(404)
-  end
-
-  def render_custom_page_not_found(page_404, status = 404)
-    home_page = @_site_options[:home_page] rescue nil
-    if lookup_context.template_exists?("page_#{page_404.id}")
-      r_file = "page_#{page_404.id}"
-    elsif page_404.get_template(page_404.post_type).present? && lookup_context.template_exists?(page_404.get_template(page_404.post_type))
-      r_file = page_404.get_template(page_404.post_type)
-    elsif home_page.present? && page_404.id.to_s == home_page
-      r_file = "index"
-    elsif lookup_context.template_exists?("post_types/#{page_404.post_type.the_slug}/single")
-      r_file = "post_types/#{page_404.post_type.the_slug}/single"
-    elsif lookup_context.template_exists?("#{page_404.post_type.slug}")
-      r_file = "#{page_404.post_type.slug}"
-    else
-      r_file = "single"
-    end
-
-    layout_ = nil
-    meta_layout = page_404.get_layout(page_404.post_type)
-    layout_ = meta_layout if meta_layout.present? && lookup_context.template_exists?("layouts/#{meta_layout}")
-
-    @post = page_404
-    @post_type = page_404.post_type
-
-    r = { post: @post, post_type: @post_type, layout: layout_, render: r_file }
-    render r[:render], (!r[:layout].nil? ? {layout: r[:layout], status: status} : {status: status})
   end
 
   # define frontend locale


### PR DESCRIPTION
Created a new method that renders a custom 404 page, defined by the user, and with the correct status code, in this case the 404 Not Found. Resolves #767