### PR TITLE
convert SVGs to JPEG when editing to avoid errors

### DIFF
--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -87,7 +87,7 @@ module CamaleonCms::UploaderHelper
     w, h = thumb_size.split('x') if thumb_size.present?
     uploaded_io = File.open(uploaded_io) if uploaded_io.is_a?(String)
     path_thumb = cama_resize_and_crop(uploaded_io.path, w, h)
-    thumb = cama_uploader.add_file(path_thumb, cama_uploader.version_path(key), is_thumb: true, same_name: true)
+    thumb = cama_uploader.add_file(path_thumb, cama_uploader.version_path(key).sub('.svg', '.jpg'), is_thumb: true, same_name: true)
     FileUtils.rm_f(path_thumb)
     thumb
   end
@@ -151,6 +151,7 @@ module CamaleonCms::UploaderHelper
   end
 
   # resize and crop a file
+  # SVGs are converted to JPEGs for editing
   # Params:
   #   file: (String) File path
   #   w: (Integer) width
@@ -164,6 +165,11 @@ module CamaleonCms::UploaderHelper
   def cama_resize_and_crop(file, w, h, settings = {})
     settings = {gravity: :north_east, overwrite: true, output_name: ""}.merge(settings)
     img = MiniMagick::Image.open(file)
+    if file.end_with? '.svg'
+      img.format 'jpg'
+      file.sub! '.svg', '.jpg'
+      settings[:output_name]&.sub! 'svg', 'jpg'
+    end
     w = img[:width].to_f > w.sub('?', '').to_i ? w.sub('?', "") : img[:width] if w.present? && w.to_s.include?('?')
     h = img[:height].to_f > h.sub('?', '').to_i ? h.sub('?', "") : img[:height] if h.present? && h.to_s.include?('?')
     w_original, h_original = [img[:width].to_f, img[:height].to_f]
@@ -181,19 +187,20 @@ module CamaleonCms::UploaderHelper
       h_result = h
     end
 
-    w_offset, h_offset = cama_crop_offsets_by_gravity(settings[:gravity], [w_result, h_result], [ w, h])
+    w_offset, h_offset = cama_crop_offsets_by_gravity(settings[:gravity], [w_result, h_result], [w, h])
     img.combine_options do |i|
       i.resize(op_resize)
       i.gravity(settings[:gravity])
       i.crop "#{w.to_i}x#{h.to_i}+#{w_offset}+#{h_offset}!"
     end
 
-    img.write(file) if settings[:overwrite]
-    unless settings[:overwrite]
+    if settings[:overwrite]
+      img.write(file.sub '.svg', '.jpg')
+    else
       if settings[:output_name].present?
         img.write(file = File.join(File.dirname(file), settings[:output_name]).to_s)
       else
-        img.write(file = uploader_verify_name(File.join(File.dirname(file), "crop_#{File.basename(file)}")))
+        img.write(file = uploader_verify_name(File.join(File.dirname(file), "crop_#{File.basename(file.sub '.svg', '.jpg')}")))
       end
     end
     file

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -46,6 +46,7 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
     res['key'] = File.join(res['folder_path'], res['name'])
     res["thumb"] = (is_private_uploader? ? '/admin/media/download_private_file?file=' + version_path(key).slice(1..-1) : version_path(res['url'])) if res['file_type'] == 'image' && File.extname(file_path).downcase != '.gif'
     if res['file_type'] == 'image'
+      res["thumb"].sub! '.svg', '.jpg'
       im = MiniMagick::Image.open(file_path)
       res['dimension'] = "#{im[:width]}x#{im[:height]}"
     end
@@ -56,12 +57,12 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def add_file(uploaded_io_or_file_path, key, args = {})
     args, res = {same_name: false, is_thumb: false}.merge(args), nil
     key = search_new_key(key) unless args[:same_name]
-    
+
     if @instance # private hook to upload files by different way, add file data into result_data
       _args={result_data: nil, file: uploaded_io_or_file_path, key: key, args: args, klass: self}; @instance.hooks_run('uploader_local_before_upload', _args)
       return _args[:result_data] if _args[:result_data].present?
     end
-    
+
     add_folder(File.dirname(key)) if File.dirname(key).present?
     upload_io = uploaded_io_or_file_path.is_a?(String) ? File.open(uploaded_io_or_file_path) : uploaded_io_or_file_path
     File.open(File.join(@root_folder, key), 'wb'){|file|       file.write(upload_io.read) }


### PR DESCRIPTION
MiniMagick complains when using Camaleon's methods to resize & crop SVG images. This PR converts SVG to JPEG when editing to work around the errors.

This means that only the original image is saved as SVG. Thumbnails and other alternate versions are converted to JPEG.

Fixes #787