### PR TITLE
Cache bundle on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
+cache: bundler
+
 rvm:
   - 2.3
-  
+
 script:
   - bundle exec rails db:migrate RAILS_ENV=test
-  - bundle exec rspec  
-  
+  - bundle exec rspec
+
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - "echo '--colour' > ~/.rspec"
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start  
+  - sh -e /etc/init.d/xvfb start


### PR DESCRIPTION
This PR caches gems on Travis CI so they don't have to be downloaded each time. [More here](https://docs.travis-ci.com/user/caching#Caching-directories-(Bundler%2C-dependencies)).