### PR TITLE
Set up Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,41 @@
 language: ruby
-rvm:
-  - 2.3
-  
+cache: bundler
+bundler_args: '-j4'
+
+matrix:
+  allow_failures:
+    - gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.6
+  include:
+    # - rvm: 1.9
+    #   gemfile: rails_4_1.gemfile
+    # - rvm: 1.9
+    #   gemfile: rails_4_2.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_4_1.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_4_2.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_5_0.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_5_1.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/rails_5_2.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails_edge.gemfile
+    - rvm: 2.6
+      gemfile: gemfiles/rails_edge.gemfile
+  fast_finish: true
+
 script:
-  - bundle exec rails db:migrate RAILS_ENV=test
-  - bundle exec rspec  
-  
+  - bundle update rails
+  - bundle exec rake db:migrate RAILS_ENV=test
+  - bundle exec rspec
+
 before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - "echo '--colour' > ~/.rspec"
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start  
+  - sh -e /etc/init.d/xvfb start

--- a/gemfiles/rails_4_1.gemfile
+++ b/gemfiles/rails_4_1.gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', '~> 4.1.0'
+gem 'rake', '< 12.3'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'
@@ -11,7 +13,7 @@ gem 'factory_bot'
 gem 'faker'
 gem 'database_cleaner'
 # gem 'poltergeist'
-gem 'draper', '~> 3'
+gem 'draper'
 gem 'transactional_capybara'
 gem 'rack_session_access'
 group :development, :test do

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', '~> 4.2.0'
+gem 'rake', '< 12.3'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'
@@ -11,7 +13,7 @@ gem 'factory_bot'
 gem 'faker'
 gem 'database_cleaner'
 # gem 'poltergeist'
-gem 'draper', '~> 3'
+gem 'draper'
 gem 'transactional_capybara'
 gem 'rack_session_access'
 group :development, :test do

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', '~> 5.0.0'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', '~> 5.1.0'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', '~> 5.2.0'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
 
+gem 'rails', git: 'https://github.com/rails/rails.git'
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 # gem 'selenium-webdriver'


### PR DESCRIPTION
This commit creates a build matrix so Travis CI can run the test suite against different versions of Ruby and Rails.

Travis can build each combination of Ruby and Rails versions, but that seems excessive. I chose instead to build each version of Rails using the minimum required version of Ruby for that version. Unfortunately, I could not get Travis to build using less than Ruby 2.2 because dependencies failed to install, so Rails 4.1 and 4.2 are tested with Ruby 2.2 instead of 1.9.

Ruby versions below 2.3 are currently unmaintained, so I favor dropping support for them moving forward. If Camaleon continues to support versions down to 1.9, someone else will have to figure out how to build it. RVM won't even install 1.9 on my local machine, so I can't sort out the dependencies. 😳

I also added in builds for the current development version of Rails so we can look for conflicts before the new version is released. This version is built with:
- the minimum required version of Ruby (2.4),
- the current release of Ruby (2.5), and
- the current preview release of Ruby (2.6).

Travis builds will still pass if the jobs using unreleased versions of Ruby or Rails fail. Only officially released versions must pass.