### PR TITLE
Create build matrix in Travis CI and clarify supported versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+AllCops:
+  DisabledByDefault: true
+  TargetRubyVersion: 2.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,27 @@
 language: ruby
-cache: bundler
+bundler_args: '-j4'
 
-rvm:
-  - 2.3
+matrix:
+  allow_failures:
+    - gemfile: gemfiles/rails_edge.gemfile
+    - rvm: ruby-head
+  include:
+    - rvm: 2.2
+      gemfile: gemfiles/rails_4_2.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails_5_0.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_5_1.gemfile
+    - rvm: 2.5
+      gemfile: gemfiles/rails_5_2.gemfile
+    - rvm: ruby-head
+      gemfile: gemfiles/rails_edge.gemfile
+  fast_finish: true
 
 script:
-  - bundle exec rails db:migrate RAILS_ENV=test
+  - gem pristine --all # workaround for bug in Bundler 1.16.x / RubyGems 2.7.x
+  - bundle update rails
+  - bundle exec rake db:migrate RAILS_ENV=test
   - bundle exec rspec
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
 script:
   - gem pristine --all # workaround for bug in Bundler 1.16.x / RubyGems 2.7.x
   - bundle update rails
+  - bundle exec rubocop
   - bundle exec rake db:migrate RAILS_ENV=test
   - bundle exec rspec
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![](https://img.shields.io/badge/Rails-4%2B-green.svg)
-![](https://img.shields.io/badge/Ruby-1.9%2B-green.svg)
+![](https://img.shields.io/badge/Rails-4.2%2B-green.svg)
+![](https://img.shields.io/badge/Ruby-2.2%2B-green.svg)
 ![](https://img.shields.io/badge/SQLITE-100%25-green.svg)
 ![](https://img.shields.io/badge/Mysql-100%25-green.svg)
 ![](https://img.shields.io/badge/Postgres-100%25-green.svg)
@@ -21,13 +21,13 @@
 [ButterCMS](https://buttercms.com/?utm_source=github&utm_medium=sponsorship-link&utm_campaign=camaleon) is an API-based CMS and blogging platform built for developers.
 
 # Requirements
-* Rails 4.1+
+* Rails 4.2+
 * MySQL 5+ or SQlite or PostgreSQL
-* Ruby 1.9+
+* Ruby 2.2+
 * Imagemagick
 
 # Installation
-* Install Ruby on Rails 4.1+
+* Install Ruby on Rails 4.2+
   [Visit here.](http://railsapps.github.io/installing-rails.html)
 * Create your rails project
 
@@ -71,7 +71,7 @@
 
 # Camaleon CMS (It adapts to your needs)
 
-Camaleon CMS is a dynamic and advanced content management system based on Ruby on Rails 4+ and Ruby 1.9+. This CMS is an alternative to Wordpress for Ruby on Rails developers to manage advanced contents easily.
+Camaleon CMS is a dynamic and advanced content management system based on Ruby on Rails 4.2+ and Ruby 2.2+. This CMS is an alternative to Wordpress for Ruby on Rails developers to manage advanced contents easily.
 Camaleon CMS is a flexible manager where you can build your custom content structure without coding anything by custom fields and custom contents type.
 
 To download or publish themes go to themes store:

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -53,4 +53,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'pry-stack_explorer'
+  s.add_development_dependency 'rubocop'
 end

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |s|
   s.description = "Camaleon CMS is a dynamic and advanced content management system based on Ruby on Rails 4+ as an alternative to Wordpress."
   s.license     = "MIT"
 
-  s.required_ruby_version = '>= 1.9.3'
-  s.requirements << 'rails >= 4.1'
-  s.requirements << 'ruby >= 1.9.3'
+  s.required_ruby_version = '>= 2.2'
+  s.requirements << 'rails >= 4.2'
+  s.requirements << 'ruby >= 2.2'
   s.requirements << 'imagemagick'
   # s.post_install_message = "Thank you for install Camaleon CMS."
 
@@ -24,12 +24,10 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'bcrypt'
-  # s.add_dependency 'json', '>= 2.0.0'
   s.add_dependency 'cancancan', '~> 2.0'
-  s.add_dependency 'draper', '>=1.3'
+  s.add_dependency 'draper', '>= 1.3'
   s.add_dependency 'meta-tags', '~> 2.0'
   s.add_dependency 'mini_magick'
-  # s.add_dependency 'mobu'
   s.add_dependency 'will_paginate'
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'
@@ -50,7 +48,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'rspec-instafail'
   s.add_development_dependency 'capybara'
-  # s.add_development_dependency 'selenium-webdriver'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'byebug'
   s.add_development_dependency 'database_cleaner'

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.2.0'
+gem 'rspec_junit_formatter'
+gem 'capybara-webkit'
+gem 'capybara-screenshot'
+gem 'puma'
+gem 'factory_bot'
+gem 'faker'
+gem 'database_cleaner'
+gem 'draper'
+gem 'transactional_capybara'
+gem 'rack_session_access'
+group :development, :test do
+  gem 'rspec-rails'
+end

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.0.0'
+gem 'rspec_junit_formatter'
+gem 'capybara-webkit'
+gem 'capybara-screenshot'
+gem 'puma'
+gem 'factory_bot'
+gem 'faker'
+gem 'database_cleaner'
+gem 'draper', '~> 3'
+gem 'transactional_capybara'
+gem 'rack_session_access'
+group :development, :test do
+  gem 'rspec-rails'
+end

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.1.0'
+gem 'rspec_junit_formatter'
+gem 'capybara-webkit'
+gem 'capybara-screenshot'
+gem 'puma'
+gem 'factory_bot'
+gem 'faker'
+gem 'database_cleaner'
+gem 'draper', '~> 3'
+gem 'transactional_capybara'
+gem 'rack_session_access'
+group :development, :test do
+  gem 'rspec-rails'
+end

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,0 +1,18 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.2.0'
+gem 'rspec_junit_formatter'
+gem 'capybara-webkit'
+gem 'capybara-screenshot'
+gem 'puma'
+gem 'factory_bot'
+gem 'faker'
+gem 'database_cleaner'
+gem 'draper', '~> 3'
+gem 'transactional_capybara'
+gem 'rack_session_access'
+group :development, :test do
+  gem 'rspec-rails'
+end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -1,0 +1,27 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', github: 'rails/rails'
+gem 'actionpack', github: 'rails/rails'
+gem 'activemodel', github: 'rails/rails'
+gem 'activesupport', github: 'rails/rails'
+gem 'railties', github: 'rails/rails'
+gem 'rspec_junit_formatter'
+gem 'capybara-webkit'
+gem 'capybara-screenshot'
+gem 'puma'
+gem 'factory_bot'
+gem 'faker'
+gem 'database_cleaner'
+gem 'draper', '~> 3', github: 'brian-kephart/draper', branch: 'rails_6'
+gem 'transactional_capybara'
+gem 'rack_session_access'
+group :development, :test do
+  gem 'rspec', github: 'rspec/rspec'
+  gem 'rspec-core', github: 'rspec/rspec-core'
+  gem 'rspec-expectations', github: 'rspec/rspec-expectations'
+  gem 'rspec-mocks', github: 'rspec/rspec-mocks'
+  gem 'rspec-rails', github: 'rspec/rspec-rails'
+  gem 'rspec-support', github: 'rspec/rspec-support'
+end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -21,6 +21,6 @@ module Dummy
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
-    config.active_record.sqlite3.represent_boolean_as_integer = true
+    config.active_record.sqlite3.represent_boolean_as_integer = true if Rails.version.to_f >= 5.2
   end
 end


### PR DESCRIPTION
This PR has three commits.

1. The first one tests all Ruby and Rails versions supported by Camaleon. This includes a test for upcoming versions. This last test is for informational purposes and is allowed to fail without the whole build failing. (It's actually failing now; RSpec doesn't get along with Rails 6 yet)

2. The second commit removes support for old Ruby/Rails versions as discussed in #813. These unsupported versions are not tested in the Travis matrix.

3. The third commit adds Rubocop as a development dependency. The reason for doing this is to check for syntax errors (all style linting is currently disabled). This is how I discovered that Camaleon is using features not present in Ruby 1.9. I have set Rubocop to target Ruby 2.2, so any syntax that is not valid in that version will cause the Travis build to fail.

Together these commits should give us more confidence that Camaleon works well on all the versions that we say it does.