### PR TITLE
Remove TinyMCE test workaround that breaks plugin tests

### DIFF
--- a/app/views/layouts/camaleon_cms/admin.html.erb
+++ b/app/views/layouts/camaleon_cms/admin.html.erb
@@ -16,7 +16,6 @@
         var tinymce_global_settings = {language_url: "<%= asset_path("camaleon_cms/admin/tinymce/langs/#{current_locale}.js") %>", custom_css: [], custom_toolbar: [], post_render: [], init: [], setups: [], settings: []};
         var I18n_data = <%= I18n.backend.respond_to?(:translations) ? I18n.backend.send(:translations)[current_locale.to_sym][:camaleon_cms][:admin][:js].to_json.html_safe : !!(I18n.backend.backends[1] && I18n.backend.backends[1].backends[1]) ? I18n.backend.backends[1].backends[1].send(:translations)[current_locale.to_sym][:camaleon_cms][:admin][:js].to_json.html_safe : "{}" rescue "{}" %>
     </script>
-    <%= render file: Rails.root.join('..', '..', 'spec/support/custom_admin') if Rails.env.test? %>
     <%= javascript_include_tag "camaleon_cms/admin/admin-manifest" %>
 
     <%= javascript_include_tag "camaleon_cms/admin/jquery_validate/#{current_locale}.js" if current_locale != 'en' %>

--- a/spec/support/custom_admin.html.erb
+++ b/spec/support/custom_admin.html.erb
@@ -1,2 +1,0 @@
-<!--<style>.fa::before{ content: "i" !important; } </style>-->
-<script>window['URL'] = '';</script> <!--FIX for undefined URL on tinymce-->


### PR DESCRIPTION
Fixes #817 by removing old test workaround that is no longer needed.