### PR TITLE
Fix query builder bug when params[:q] specified

### DIFF
--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -28,7 +28,7 @@ class CamaleonCms::Admin::PostsController < CamaleonCms::AdminController
     if params[:q].present?
       params[:q] = (params[:q] || '').downcase
       posts_all = posts_all.where(
-        "LOWER(#{CamaleonCms::Post.table_name}.title) LIKE ? OR LOWER(#{CamaleonCms::Post.table_name}.slug LIKE ?)", 
+        "LOWER(#{CamaleonCms::Post.table_name}.title) LIKE ? OR LOWER(#{CamaleonCms::Post.table_name}.slug) LIKE ?",
         "%#{params[:q]}%", 
         "%#{params[:q]}%"
       )  


### PR DESCRIPTION
# Background
While developing a rails app with camaleon_cms I encountered a bug: https://github.com/owen2345/camaleon-cms/issues/866

I guess it occurs only with postgresql, because I wrote a tmp test inside camaleon_cms gem(which uses sqllite in dummy app) and it wasn't failing.

# The problem
The problem was wrong place of closing parenthesis of postgres function LOWER.
When it was after "?" sign, it was causing exception in PG query runner.

It was the query before fix:
```sql

SELECT COUNT(DISTINCT "cama_posts"."id")
FROM "cama_posts"
       LEFT OUTER JOIN "cama_posts" "parents_cama_posts" ON "parents_cama_posts"."id" = "cama_posts"."post_parent"
    AND "parents_cama_posts"."post_class" = 'Post'
       LEFT OUTER JOIN "cama_term_taxonomy" ON "cama_term_taxonomy"."id" = "cama_posts"."taxonomy_id" AND
                                               "cama_term_taxonomy"."taxonomy" = 'post_type'
WHERE "cama_posts"."post_class" = 'Post'
  AND "cama_posts"."taxonomy_id" = 2
  AND (LOWER(cama_posts.title) LIKE '%abcd%' OR LOWER(cama_posts.slug LIKE '%abcd%'))
  AND "cama_posts"."status" = 'published'
```

# The fix:
Move closing parenthesis of PG LOWER func to the of slug column.
```sql
AND (LOWER(cama_posts.title) LIKE '%abcd%' OR LOWER(cama_posts.slug) LIKE '%abcd%')
```

More description details about the issue you can find here: https://github.com/owen2345/camaleon-cms/issues/866
