### PR TITLE
changed aws-sdk dependency version for ActiveStorage support

### DIFF
--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'cama_meta_tag'
 
   # MEDIA MANAGER
-  s.add_dependency 'aws-sdk', '~> 2'
+  s.add_dependency 'aws-sdk', '>= 2'
 
   # development dependencies
   s.add_development_dependency 'rspec', '>= 2', '< 4'


### PR DESCRIPTION
fix dependencies conflict like this:

```
Bundler could not find compatible versions for gem "aws-sdk-core":
  In Gemfile:
    camaleon_cms was resolved to 2.4.5.10, which depends on
      aws-sdk (~> 2) was resolved to 2.0.1.pre, which depends on
        aws-sdk-resources (= 2.0.1.pre) was resolved to 2.0.1.pre, which depends on
          aws-sdk-core (= 2.0.1)

    aws-sdk-s3 was resolved to 1.0.0.rc5, which depends on
      aws-sdk-core (= 3.0.0.rc1)

```