### PR TITLE
fixed S3 bucket options merge error

### DIFF
--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -19,7 +19,7 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
 
   # recover all files from AWS and parse it to save into DB as cache
   def browser_files
-    bucket.objects(@aws_settings["inner_folder"].present? ? {prefix: @aws_settings["inner_folder"]} : nil).each do |file|
+    bucket.objects(@aws_settings["inner_folder"].present? ? {prefix: @aws_settings["inner_folder"]} : {}).each do |file|
       next if File.dirname(file.key).split('/').pop == 'thumb'
       cache_item(file_parse(file))
     end

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'tinymce-rails', '~> 4.3'
+  s.add_dependency 'tinymce-rails', '~> 4.2.5'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'sass-rails', '<= 5.0.7'


### PR DESCRIPTION
in block in `objectsaws-sdk-s3 (1.30.1) lib/aws-sdk-s3/bucket.rb` I got error `undefined method merge for nil:NilClass`
because the objects method in bucket.rb waiting a hash:
`   def objects(options = {})
      batches = Enumerator.new do |y|
        options = options.merge(bucket: @name)`