### PR TITLE
Fix 500 errors when missing theme CSS is requested

### DIFF
--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -37,7 +37,10 @@ class CamaleonCms::CamaleonController < ApplicationController
     Rails.logger.debug "Camaleon CMS - 404 url: #{request.original_url rescue nil} ==> message: #{exception.message if exception.present?} ==> #{params[:error_msg]} ==> #{caller.inspect}"
     @message = "#{message} #{params[:error_msg] || (exception.present? ? "#{exception.message}<br><br>#{caller.inspect}" : "")}"
     @message = "" if Rails.env == "production"
-    render "camaleon_cms/#{status}", :status => status
+    respond_to do |format|
+      format.html { render "camaleon_cms/#{status}", :status => status }
+      format.any { head status }
+    end
   end
 
   # generate captcha image


### PR DESCRIPTION
I've been getting a few 500 errors when my CDN requests expired theme asset files. This is caused by `CamaleonController#render_error` looking for a template to render instead of just returning a 404 header. This pull request preserves existing behavior for HTML and returns a 404 status for other request types.

This is not the only possible fix. If you'd prefer to only alter behavior for CSS, it can be done like this instead:
```ruby
respond_to do |format|
  format.css { head status }
  format.any { render "camaleon_cms/#{status}", :status => status }
end
```

But I thought better to make the change for any request type that is not rendering an HTML page.

Yet another option would be to create a blank CSS file in the directory so there's something to render.