### PR TITLE
Restrict sqlite3 version due to Rails incompatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,4 @@ gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'transactional_capybara'
 gem 'rack_session_access'
+gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 4.2.0'
+gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 gem 'capybara-screenshot'

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 5.0.0'
+gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 gem 'capybara-screenshot'

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 5.1.0'
+gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 gem 'capybara-screenshot'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec path: '..'
 
 gem 'rails', '~> 5.2.0'
+gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
 gem 'rspec_junit_formatter'
 gem 'capybara-webkit'
 gem 'capybara-screenshot'


### PR DESCRIPTION
See this Rails issue: https://github.com/rails/rails/issues/35161

Rails is not compatible with sqlite3 version 1.4 (a fix has been made, but it's in Rails 6). This has been causing CI failures.

There are still CI failures related to a separate problem I couldn't figure out, but this gets us nearer to a working build.