### PR TITLE
Loosen CanCanCan version restriction

### DIFF
--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["spec/**/*"]
 
   s.add_dependency 'bcrypt'
-  s.add_dependency 'cancancan', '~> 2.0'
+  s.add_dependency 'cancancan', '>= 2.0', '< 4'
   s.add_dependency 'draper', '>= 1.3'
   s.add_dependency 'meta-tags', '~> 2.0'
   s.add_dependency 'mini_magick'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -14,6 +14,7 @@ gem 'faker'
 gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
+gem 'cancancan', '~> 3.0'
 group :development, :test do
   gem 'rspec-rails'
 end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -14,6 +14,7 @@ gem 'faker'
 gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
+gem 'cancancan', '~> 3.0'
 group :development, :test do
   gem 'rspec-rails'
 end


### PR DESCRIPTION
CanCanCan just released version 3.0. Here's a [summary of the breaking changes](https://medium.com/@coorasse/hello-cancancan-3-0-d6f444312e6f?sk=3503e2e0de742803c2b26eb95dde3dd2#fbe6).

I don't see anything in the code that should break as a result of this update and the tests are passing locally. I added the new version to the CI gemfiles for Rails 6.0 and Rails edge to get test coverage.