### PR TITLE
Remove duplicated gems and restrict Rubocop version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,10 @@ gem 'chromedriver-helper'
 gem 'capybara-screenshot'
 
 gem 'rspec_junit_formatter'
-gem 'rspec-rails'
 
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
 gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -53,5 +53,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'database_cleaner'
   s.add_development_dependency 'pry-rescue'
   s.add_development_dependency 'pry-stack_explorer'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '~> 0.68.1'
 end

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -11,9 +11,5 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper'
 gem 'rack_session_access'
-group :development, :test do
-  gem 'rspec-rails'
-end

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -11,9 +11,5 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
-group :development, :test do
-  gem 'rspec-rails'
-end

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -11,9 +11,5 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
-group :development, :test do
-  gem 'rspec-rails'
-end

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -11,9 +11,5 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
-group :development, :test do
-  gem 'rspec-rails'
-end

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -11,10 +11,6 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
 gem 'cancancan', '~> 3.0'
-group :development, :test do
-  gem 'rspec-rails'
-end

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -11,10 +11,6 @@ gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
-gem 'database_cleaner'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
 gem 'cancancan', '~> 3.0'
-group :development, :test do
-  gem 'rspec-rails'
-end


### PR DESCRIPTION
Remove duplicated `rspec-rails` and `database_cleaner` gems from gemfiles - they are specified in the gemspec.

Restrict `rubocop` to 0.68.x version, because the 0.69 version has no support for Ruby 2.2.x