### PR TITLE
Fix eager load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ bundler_args: '-j4'
 addons:
   chrome: stable
 
+services:
+  - xvfb
+
 matrix:
   allow_failures:
     - gemfile: gemfiles/rails_edge.gemfile
@@ -33,4 +36,3 @@ before_install:
   - "echo 'gem: --no-document' > ~/.gemrc"
   - "echo '--colour' > ~/.rspec"
   - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-
+gem 'rails', '6.0.0rc1'
 gem 'selenium-webdriver'
 gem 'webdrivers'
 
@@ -14,4 +14,4 @@ gem 'factory_bot'
 gem 'faker'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
-gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
+gem 'sqlite3'

--- a/README.md
+++ b/README.md
@@ -112,12 +112,12 @@ http://camaleon.tuzitio.com/store/plugins
 * Install Ruby on Rails
 * Create your rails project
 
-  ```
+  ```bash
   rails new my_project
   ```
-* Add the gem in your Gemfile 
+* Add the gem in your Gemfile
 
-  ```
+  ```ruby
   gem "camaleon_cms",  '>= 2.4.6' # (Current stable versions are 2.4.4.5, 2.4.3.10, 2.3.6, 2.2.1, 2.1.1)
   # OR
   # gem "camaleon_cms", github: 'owen2345/camaleon-cms' # latest development version
@@ -127,17 +127,27 @@ http://camaleon.tuzitio.com/store/plugins
 
 * Install required Gem and dependencies
 
-  ```
+  ```bash
   bundle install
   ```
+
+* If using Rails 6, add the following line to config/application.rb
+
+  ```ruby
+  # Additional lines shown for context
+  class Application < Rails::Application
+    config.autoloader = :classic # This is the line to add
+  end
+  ```
+
 * Camaleon CMS Installation
 
-  ```
+  ```bash
   rails generate camaleon_cms:install
   ```
 * (Optional) Before continue you can configure your CMS settings in (my_app/config/system.json), [here](config/system.json) you can see the full settings.
 * Create database structure
-  ```
+  ```bash
   rake camaleon_cms:generate_migrations
   # before running migrations you can customize copied migration files
   rake db:migrate
@@ -145,7 +155,7 @@ http://camaleon.tuzitio.com/store/plugins
 
 * Start your server
 
-  ```
+  ```bash
   rails server
   ```
 
@@ -173,12 +183,12 @@ http://camaleon.tuzitio.com/license.html
 
 ## Testing
 * Init DB
-```
+```bash
 RAILS_ENV=test bundle exec rake app:db:migrate
 RAILS_ENV=test bundle exec rake app:db:test:prepare
 ```
 * Run tests
-```
+```bash
 bundle exec rspec
 ```
 

--- a/gemfiles/rails_4_2.gemfile
+++ b/gemfiles/rails_4_2.gemfile
@@ -6,7 +6,7 @@ gem 'rails', '~> 4.2.0'
 gem 'sqlite3', '< 1.4' # Rails < 6 is incompatible with sqlite3 1.4
 gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'
-gem 'webdrivers'
+gem 'webdrivers', '< 4'
 gem 'capybara-screenshot'
 gem 'puma'
 gem 'factory_bot'

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 6.0.0beta3'
+gem 'rails', '~> 6.0.0rc1'
 gem 'sqlite3'
 gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -60,7 +60,7 @@ module CamaleonCms
       # Dir[File.join(engine_dir, "config", "routes", "*.rb")].each{|r| app.routes_reloader.paths.unshift(r) }
 
       # extra configuration for plugins
-      app.config.eager_load_paths += %W(#{app.config.root}/app/apps/**/)
+      app.config.eager_load_paths += %W(#{app.config.root}/app/apps/)
       if PluginRoutes.static_system_info['auto_include_migrations']
         PluginRoutes.all_plugins.each{ |plugin|
           app.config.paths["db/migrate"] << File.join(plugin["path"], "migrate") if Dir.exist?(File.join(plugin["path"], "migrate"));

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,6 +7,7 @@ require "camaleon_cms"
 
 module Dummy
   class Application < Rails::Application
+    config.autoloader = :classic
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true


### PR DESCRIPTION
Addresses #895 

Rails 6 introduces a new code loader called Zeitwerk. It is incompatible with some of the filenames in Camaleon, but this is fixed by adding `config.autoloader = :classic` to config.application.rb.

However, there is an error in the eager load paths specified by Camaleon as detailed in #895. Fixing this issue makes Camaleon compatible with Rails 6 as long as `config.autoloader = :classic`. I updated the README with these instructions.

Eager loading is now enabled in the test environment. Without that, the tests were passing despite production deployments being completely broken by the eager loading error.

The following testing issues are fixed as well. These are unrelated to the PR, except that they get the build passing again:
- .travis.yml is edited to handle a change in how Travis installs XVFB.
- The Webdrivers gem recently introduced some code that doesn't work on Ruby 2.2, so that version is now restricted in the Gemfile.