### PR TITLE
improving the theme's card appearance in the index page

### DIFF
--- a/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
+++ b/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
@@ -290,3 +290,70 @@ label.error, span.error{
   color: #a94442;
   font-size: 11px;
 }
+
+
+//************** Appearance
+
+// themes: index page
+.theme-card {
+  border: 1px 
+  solid #ddd; 
+  border-radius: 0;
+  position: relative;
+
+  .panel-body-image {
+    padding: 0;
+
+    .theme-image {
+      width: 100%; 
+      height: 260px;
+      background-size: cover;
+    }
+
+    &:hover {
+      & + .theme-description {
+        display: block;
+      }
+    }
+  }
+
+  .theme-description {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 260px;
+    background: #1e282bcc;
+    color: #fff;
+    font-size: 1.8rem;
+    padding: 30px;
+    display: none;
+
+    &:hover {
+      display: block;
+    }
+  }
+
+  .panel-footer {
+    background-color: #fafafa; 
+    border: 0; 
+    border-radius: 0; 
+    box-shadow: inset 0 1px 0 rgba(0,0,0,.1);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  
+
+    .theme-name {
+      font-size: 1.6rem;
+      width: 50%;
+      text-align: left;
+      font-weight: 600;
+    }
+
+    .theme-actions {
+      .btn {
+        font-size: 1.1rem;
+      }
+    }
+  }
+}

--- a/app/views/camaleon_cms/admin/appearances/themes/index.html.erb
+++ b/app/views/camaleon_cms/admin/appearances/themes/index.html.erb
@@ -20,32 +20,35 @@
                             <% next if theme[:domain].present? && !(theme[:domain].split(",").include?(current_site.the_slug) || theme[:domain].split(",").include?(dom)) %>
                             <%= raw "<div class='clearfix'></div>" if index%3==0 && index > 1 %>
                             <div class="col-md-4">
-                                <div class="panel panel-default">
+                                <div class="panel panel-default theme-card">
                                     <div class="panel-body panel-body-image">
-                                        <div class="theme-image text-center">
-                                            <img class="img-responsive" style="width: 100%; height: 180px;" src="<%= asset_path(theme_asset_path(theme[:thumb].to_s, theme[:key])) %>" alt="<%= theme[:name] %>">
+                                        <% image_url = asset_path(theme_asset_path(theme[:thumb].to_s, theme[:key])) %>
+                                        <div class="theme-image text-center" style=" background-image: url(<%= image_url %>);" >
                                         </div>
-                                        <a href="#" class="panel-body-inform">
-                                            <span class="fa fa-desktop"></span>
-                                        </a>
                                     </div>
-                                    <div class="panel-body" style="min-height: 120px;">
-                                        <h3><%= theme[:name] %></h3>
+                                    <div class="panel-body theme-description">
+                                        <h3></h3>
                                         <div><%= raw theme[:description] %></div>
                                     </div>
                                     <div class="panel-footer text-muted text-right">
-                                        <% if current_theme.slug == theme[:key] && params[:set].nil? %>
-                                            <% r = {links: []}; hook_run(theme, "theme_options", r) %>
-                                            <% r[:links] << link_to(raw('&nbsp;&nbsp;Import Data (data.json)&nbsp;'), admin_plugins_export_content_settings_path(file: ["app", "apps", 'themes', theme[:key], 'data.json'].join("/"))) if current_site.plugin_installed?('export_content') && File.exist?(File.join(theme["path"], "data.json")) %>
-                                            <% r[:links] << link_to('Settings', cama_admin_settings_theme_path, class: "btn btn-primary") if File.exist?(current_theme.settings_file) %>
+                                        <span class="theme-name">
+                                            <%= theme[:name] %>
+                                        </span>
+                                        <div class="theme-actions">
+                                            <% if current_theme.slug == theme[:key] && params[:set].nil? %>
+                                                <% r = {links: []}; hook_run(theme, "theme_options", r) %>
+                                                <% r[:links] << link_to(raw('&nbsp;&nbsp;Import Data (data.json)&nbsp;'), admin_plugins_export_content_settings_path(file: ["app", "apps", 'themes', theme[:key], 'data.json'].join("/"))) if current_site.plugin_installed?('export_content') && File.exist?(File.join(theme["path"], "data.json")) %>
+                                                <% r[:links] << link_to('Settings', cama_admin_settings_theme_path, class: "btn btn-primary") if File.exist?(current_theme.settings_file) %>
 
-                                            <% r[:links] << link_to(raw('&nbsp;&nbsp;Import Data (data.json)&nbsp;'), "#", {'onclick' => "alert('You need to install import/export plugin to import sample data.'); return false;"}) if !current_site.plugin_installed?('export_content') && File.exist?(File.join(theme["path"], "data.json")) %>
-                                            <%= raw r[:links].join(" | ") %>
-                                            <span class="btn btn-success"><%= t('camaleon_cms.admin.button.actived').upcase %></span>
-                                        <% else %>
-                                            <a href="<%= current_site.the_url(ccc_theme_preview: theme[:key])%>" title="<%= t('camaleon_cms.admin.button.preview') %>" class="btn btn-info preview_link"><%= t('camaleon_cms.admin.button.preview') %></a>
-                                            <a href="<%= cama_admin_appearances_themes_path(set: theme[:key]) %>" class="btn btn-primary"><%= t('camaleon_cms.admin.button.select')%></a>
-                                        <% end %>
+                                                <% r[:links] << link_to(raw('&nbsp;&nbsp;Import Data (data.json)&nbsp;'), "#", {'onclick' => "alert('You need to install import/export plugin to import sample data.'); return false;"}) if !current_site.plugin_installed?('export_content') && File.exist?(File.join(theme["path"], "data.json")) %>
+                                                <%= raw r[:links].join(" | ") %>
+                                                <span class="btn btn-success"><%= t('camaleon_cms.admin.button.actived').upcase %></span>
+                                            <% else %>
+                                                <a href="<%= current_site.the_url(ccc_theme_preview: theme[:key])%>" title="<%= t('camaleon_cms.admin.button.preview') %>" class="btn btn-info preview_link"><%= t('camaleon_cms.admin.button.preview') %></a>
+                                                <a href="<%= cama_admin_appearances_themes_path(set: theme[:key]) %>" class="btn btn-primary"><%= t('camaleon_cms.admin.button.select')%></a>
+                                            <% end %>
+                                        </div>
+                                        
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
### Description
The appearance of the card of the theme's in the index page is currently a little ugly and this PR pretend to improve it visually.

It just changes the HTML and CSS file.

1. The theme image is right now a background image of the card and his size is cover to avoid the stretching.
2. The description of the theme is showing when the user puts the mouse above the theme's image.
3. The theme's name is the footer of the card.

### Evidence

_Desktop version:_
![Screen Recording 2019-07-01 at 01 44 AM](https://user-images.githubusercontent.com/5903138/60416192-ca25e880-9ba2-11e9-9678-95b0d41cc32b.gif)

_Mobile version:_
![Screen Recording 2019-07-01 at 01 53 AM](https://user-images.githubusercontent.com/5903138/60416301-1a04af80-9ba3-11e9-847d-be2f212622ac.gif)
