### PR TITLE
Use default page if no other pages exist

### DIFF
--- a/app/apps/themes/camaleon_first/views/index.html.erb
+++ b/app/apps/themes/camaleon_first/views/index.html.erb
@@ -3,7 +3,7 @@
     <div class="container" >
         <div class="row">
             <div class="col-lg-8 col-lg-offset-2">
-                <% home_page = (current_site.the_post(current_theme.get_field("home_page")) || current_site.the_posts("page").first).decorate %>
+                <% home_page = theme_home_page.decorate %>
                 <h1><%= home_page.the_title %></h1>
                 <div><%= raw home_page.the_content %></div>
             </div><!-- /col-lg-8 -->

--- a/app/helpers/camaleon_cms/theme_helper.rb
+++ b/app/helpers/camaleon_cms/theme_helper.rb
@@ -71,7 +71,7 @@ module CamaleonCms::ThemeHelper
       f.split(k).last.split("/").first
     end
   end
-  
+
   # returns file system path to theme asset
   # theme_name: theme name, if nil, then will use current theme
   # asset: asset file name, if asset is present return full path to this asset
@@ -82,5 +82,14 @@ module CamaleonCms::ThemeHelper
       theme_path = theme.settings['path']
     end
     "#{theme_path}/assets/#{asset}"
+  end
+
+  # Returns a default message if no pages exist
+  def theme_home_page
+    current_site.the_post(current_theme.get_field("home_page")) ||
+      current_site.the_posts("page").first ||
+      CamaleonCms::Post.new(title: 'Hello World!',
+                          content: 'Please add a page.',
+                           status: 'published')
   end
 end


### PR DESCRIPTION
A new install may have no posts/pages in the database. If this is the case, display a basic "Hello World" page. [fixes #911]