### PR TITLE
Zeitwerk compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rails', '6.0.0rc1'
+gem 'rails', '6.0.0'
 gem 'selenium-webdriver'
 gem 'webdrivers'
 

--- a/README.md
+++ b/README.md
@@ -131,15 +131,6 @@ http://camaleon.tuzitio.com/store/plugins
   bundle install
   ```
 
-* If using Rails 6, add the following line to config/application.rb
-
-  ```ruby
-  # Additional lines shown for context
-  class Application < Rails::Application
-    config.autoloader = :classic # This is the line to add
-  end
-  ```
-
 * Camaleon CMS Installation
 
   ```bash

--- a/app/apps/plugins/attack/config/custom_models.rb
+++ b/app/apps/plugins/attack/config/custom_models.rb
@@ -4,3 +4,5 @@ Rails.application.config.to_prepare do
     has_many :attack, class_name: "Plugins::Attack::Models::Attack"
   end
 end
+
+class Plugins::Attack::Config::CustomModels; end

--- a/app/apps/plugins/front_cache/config/initializer.rb
+++ b/app/apps/plugins/front_cache/config/initializer.rb
@@ -3,3 +3,5 @@ if(CamaleonCms::Site.any? rescue false)
     site.set_option("refresh_cache", true)
   end
 end
+
+class Plugins::FrontCache::Config::Initializer; end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -7,7 +7,7 @@ require "camaleon_cms"
 
 module Dummy
   class Application < Rails::Application
-    config.autoloader = :classic
+    config.autoloader = :zeitwerk
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
Rails 6 comes bundled with a new code loader, Zeitwerk. This loader relies on the convention of filenames matching class names. This PR defines a few empty classes to comply with this convention so that Zeitwerk may be used. Please note that the build will not pass until/unless https://github.com/owen2345/camaleon-cms-seo/pull/8 is merged, since that plugin has its own Zeitwerk compatibility issue. I have run the spec locally and deployed to production using that PR.