### PR TITLE
Fixed the themes preview error 

### DIFF
--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -243,8 +243,7 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
     lookup_context.prefixes.delete_if{|t| t =~ /themes\/(.*)\/views/i || t == "camaleon_cms/default_theme" || t == "themes/#{current_site.id}/views" }
 
     lookup_context.prefixes.append("themes/#{current_site.id}/views") if Dir.exist?(Rails.root.join('app', 'apps', 'themes', current_site.id.to_s).to_s)
-    lookup_context.prefixes.append("themes/#{current_theme.name}/views")
-    lookup_context.prefixes.append("themes/#{current_theme.name}/views/layouts")
+    lookup_context.prefixes.append("themes/#{current_theme.slug}/views")
     lookup_context.prefixes.append("camaleon_cms/default_theme")
 
     lookup_context.prefixes = lookup_context.prefixes.uniq

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -244,6 +244,7 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
 
     lookup_context.prefixes.append("themes/#{current_site.id}/views") if Dir.exist?(Rails.root.join('app', 'apps', 'themes', current_site.id.to_s).to_s)
     lookup_context.prefixes.append("themes/#{current_theme.name}/views")
+    lookup_context.prefixes.append("themes/#{current_theme.name}/views/layouts")
     lookup_context.prefixes.append("camaleon_cms/default_theme")
 
     lookup_context.prefixes = lookup_context.prefixes.uniq

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -243,7 +243,7 @@ class CamaleonCms::FrontendController < CamaleonCms::CamaleonController
     lookup_context.prefixes.delete_if{|t| t =~ /themes\/(.*)\/views/i || t == "camaleon_cms/default_theme" || t == "themes/#{current_site.id}/views" }
 
     lookup_context.prefixes.append("themes/#{current_site.id}/views") if Dir.exist?(Rails.root.join('app', 'apps', 'themes', current_site.id.to_s).to_s)
-    lookup_context.prefixes.append("themes/#{current_site.get_theme_slug}/views")
+    lookup_context.prefixes.append("themes/#{current_theme.name}/views")
     lookup_context.prefixes.append("camaleon_cms/default_theme")
 
     lookup_context.prefixes = lookup_context.prefixes.uniq


### PR DESCRIPTION
Fix for the [#925](https://github.com/owen2345/camaleon-cms/issues/925) issue.

On the common site visit, the `current_theme` is instantiated using `current_site.get_theme.decorate` method chain.

If the FrontendController receives the `ccc_theme_preview` param, the current_theme is instantiated from this param's value, but it is not used, because the `current_site.get_theme_slug` is being appended to the `lookup_context.prefixes`.

So, given the correct behaviour of different methods of `current_theme` instantiation, the fix was to append `current_theme.name` instead of `current_site.get_theme_slug`  to the `lookup_context.prefixes`.