### PR TITLE
Fixed Sprockets 4.0 using manifest.js

### DIFF
--- a/app/assets/config/camaleon-cms.js
+++ b/app/assets/config/camaleon-cms.js
@@ -1,0 +1,10 @@
+//= link_tree ../fonts
+//= link_tree ../images
+//= link_tree ../javascripts
+//= link_tree ../stylesheets
+//= link_tree ../../apps/themes/default/assets
+//= link_tree ../../apps/themes/camaleon_first/assets
+//= link_tree ../../apps/themes/new/assets
+//= link_tree ../../apps/plugins/visibility_post/assets/js
+//= link plugins/cama_contact_form/admin_editor.js
+//= link camaleon_cms/admin/nav_menu.js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,20 +4,3 @@
 Rails.application.config.assets.version = '1.0'
 
 Rails.application.config.tinymce.install = :compile
-
-# Add additional assets to the asset load path
-Rails.application.config.assets.precompile += %w( camaleon_cms/* )
-# Rails.application.config.assets.precompile += %w( themes/*/assets/* )
-
-# This will precompile any assets, not just JavaScript (.js, .coffee, .swf, .css, .scss)
-Rails.application.config.assets.precompile << Proc.new { |path|
-  res = false
-  if File.dirname(path).start_with?('plugins/') || File.dirname(path).start_with?('themes/')
-    name = File.basename(path)
-    content_type = MIME::Types.type_for(name).first.content_type rescue ""
-    if (path =~ /\.(css|js|svg|ttf|woff|eot|swf|pdf|png|jpg|gif)\z/ || content_type.scan(/(javascript|image\/|audio|video|font)/).any?) && !name.start_with?("_") && !path.include?('/views/')
-      res = true
-    end
-  end
-  res
-}

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,9 +1,4 @@
 //= link_tree ../images
-//= link_tree ../../../../../app/assets
 //= link_tree ../javascripts
 //= link_tree ../stylesheets
-//= link camaleon_cms/admin/nav_menu.js
-//= link plugins/cama_contact_form/admin_editor.js
-//= link_tree ../../../../../app/apps/themes/default/assets
-//= link_tree ../../../../../app/apps/themes/camaleon_first/assets
-//= link_tree ../../../../../app/apps/themes/new/assets
+//= link camaleon-cms.js

--- a/spec/dummy/app/assets/config/manifest.js
+++ b/spec/dummy/app/assets/config/manifest.js
@@ -1,0 +1,9 @@
+//= link_tree ../images
+//= link_tree ../../../../../app/assets
+//= link_tree ../javascripts
+//= link_tree ../stylesheets
+//= link camaleon_cms/admin/nav_menu.js
+//= link plugins/cama_contact_form/admin_editor.js
+//= link_tree ../../../../../app/apps/themes/default/assets
+//= link_tree ../../../../../app/apps/themes/camaleon_first/assets
+//= link_tree ../../../../../app/apps/themes/new/assets

--- a/spec/dummy/config/initializers/assets.rb
+++ b/spec/dummy/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-# Rails.application.config.assets.precompile += %w( search.js )
+Rails.application.config.assets.precompile += %w( manifest.js )


### PR DESCRIPTION
Sprockets 4.0 has removed support of Procs. All the linked assets should be specified now in the app/assets/config/manifest.js file.

Fixes https://github.com/owen2345/camaleon-cms/issues/921