### PR TITLE
Rack 2.0.8 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rails', '6.0.0'
+gem 'rails', '~> 6.0.0', '>= 6.0.2.1'
 gem 'selenium-webdriver'
 gem 'webdrivers'
 

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -141,7 +141,7 @@ module CamaleonCms::SessionHelper
   # return the session id
   def cama_get_session_id
     session[:autor] = "Owen Peredo Diaz" unless request.session_options[:id].present?
-    request.session_options[:id]
+    request.session_options[:id].inspect
   end
 
   private

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 6.0.0'
+gem 'rails', '~> 6.0.0', '>= 6.0.2.1'
 gem 'sqlite3'
 gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'


### PR DESCRIPTION
Addresses incompatibility with Rack 2.0.8. Fixes #930, see that issue for details.

Without this change, the test suite fails with Rack 2.0.8.

The bump to the Rails version is solely for the updated Rack dependency.

Please note that this will invalidate existing cache keys created by the attacks plugin.

Previously:
```ruby
cama_get_session_id
# => "some_session_id"
```

After this PR:
```ruby
cama_get_session_id
# => "\"some_session_id\""
```