### PR TITLE
Allow latest TinyMCE

### DIFF
--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -38,12 +38,12 @@ function cama_get_tinymce_settings(settings){
                 ed.content = ed.content.replace(/(<p><\/p>)/gi,'<br />');
             });
 
-            editor.addMenuItem('append_line', {
+            editor.ui.registry.addMenuItem('append_line', {
                 text: 'New line at the end',
                 context: 'insert',
                 onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-');  }
             });
-            editor.addMenuItem('add_line', {
+            editor.ui.registry.addMenuItem('add_line', {
                 text: 'New line',
                 context: 'insert',
                 onclick: function () { editor.insertContent('<p>-New line-</p>');  }

--- a/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
+++ b/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
@@ -14,13 +14,13 @@ tinymce.PluginManager.add('filemanager', function(editor) {
             }
         });
     }
-    editor.addButton('filemanager', {
+    editor.ui.registry.addButton('filemanager', {
         icon: 'browse',
         tooltip: 'Insert file',
         onclick: openmanager,
         stateSelector: 'img:not([data-mce-object])'
     });
-    editor.addMenuItem('filemanager', {
+    editor.ui.registry.addMenuItem('filemanager', {
         icon: 'browse',
         text: 'Insert file',
         onclick: openmanager,

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'tinymce-rails', '~> 4.3'
+  s.add_dependency 'tinymce-rails', '~> 5.1', '>= 5.1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'coffee-rails'
   s.add_dependency 'sass-rails'

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,8 +3,6 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-Rails.application.config.tinymce.install = :copy
-
 # Add additional assets to the asset load path
 Rails.application.config.assets.precompile += %w( camaleon_cms/* )
 # Rails.application.config.assets.precompile += %w( themes/*/assets/* )


### PR DESCRIPTION
Fixes #929. TinyMCE was not compiling with Sprockets 4 because of an [issue in the tinymce-rails gem](https://github.com/spohlenz/tinymce-rails/issues/264).

The current gemspec locks to version 4 of tinymce-rails, so to get the fix we need to bump to version 5, which required a few other changes.

There are a few deprecation warnings with the new version. These have not been addressed. (see image)
<img width="1679" alt="Screen Shot 2020-01-05 at 10 45 41 PM" src="https://user-images.githubusercontent.com/21235090/71795740-329bc980-300d-11ea-8a24-0f0a1760428d.png">

Tests pass, except where affected by #930. For a build that includes the patch for that issue submitted in #931, see [here](https://travis-ci.com/brian-kephart/camaleon-cms/builds/143191248). That build includes one failure as the result of a segmentation fault in a version of the sassc-rails gem, unrelated to this issue.