### PR TITLE
Add canonical option to seo

### DIFF
--- a/app/helpers/camaleon_cms/frontend/seo_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/seo_helper.rb
@@ -65,7 +65,8 @@ module CamaleonCms::Frontend::SeoHelper
       },
       alternate: [
         { type: 'application/rss+xml', href: cama_rss_url }
-      ]
+      ],
+      canonical: current_site.get_option('seo_canonical')
     }.merge(options.except(:object))
 
     l = current_site.get_languages


### PR DESCRIPTION
Reference
https://www.rubydoc.info/gems/meta-tags/1.2.1/MetaTags%2FViewHelper:display_meta_tags

Depends on 
https://github.com/owen2345/camaleon-cms-seo/pull/19