### PR TITLE
fix: failure on file importing

### DIFF
--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -239,7 +239,7 @@ module CamaleonCms::UploaderHelper
     uploaded_io = File.open(uploaded_io) if uploaded_io.is_a?(String)
     return {error: "#{ct("file_format_error")} (#{args[:formats]})"} unless cama_uploader.class.validate_file_format(_tmp_name || uploaded_io.path, args[:formats])
     return {error: "#{ct("file_size_exceeded", default: "File size exceeded")} (#{number_to_human_size(args[:maximum])})"} if args[:maximum].present? && args[:maximum] < (uploaded_io.size rescue File.size(uploaded_io))
-    name = args[:name] || uploaded_io&.original_filename || uploaded_io.path.split("/").last
+    name = args[:name] || uploaded_io.try(:original_filename) || uploaded_io.path.split("/").last
     name = "#{File.basename(name, File.extname(name)).parameterize}#{File.extname(name)}"
     path ||= uploader_verify_name(File.join(tmp_path, name))
     File.open(path, "wb"){|f| f.write(uploaded_io.read) } unless saved

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -160,7 +160,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # return: CustomFieldGroup object
   # kind: argument only for PostType model: (Post | Category | PostTag), default => Post. If kind = "" this will add group for all post_types
   def add_custom_field_group(values, kind = "Post")
-    values = values.with_indifferent_access
+    values = values.to_h.with_indifferent_access
     group = get_field_groups(kind).where(slug: values[:slug]).first
     unless group.present?
       site = _cama_get_field_site


### PR DESCRIPTION
# commit 857cc9c
The uploaded_io could be a File object, it will raise NoMethodError when using 'uploaded_io&.original_filename'

<img width="1440" alt="螢幕快照 2020-07-11 上午12 28 46" src="https://user-images.githubusercontent.com/2975954/87179617-9d59f480-c311-11ea-8a09-743e3a2c2498.png">


# commit 14ff3e8
Because ActionController::Parameters no longer inherit from HashWithIndifferentAccess in Rails 5, it should call :to_h before using :with_indifferent_access. 

reference: [https://blog.bigbinary.com/2016/07/25/parameters-no-longer-inherit-from-hash-with-indifferent-access-in-rails-5.html](url)

<img width="1437" alt="螢幕快照 2020-07-11 上午1 02 47" src="https://user-images.githubusercontent.com/2975954/87180528-46edb580-c313-11ea-8902-b94029fd4e02.png">

