### PR TITLE
Force draper require so it can find #decorate on CamaleonCms::Site

### DIFF
--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'bcrypt'
 require 'cancancan'
+require 'draper'
 require 'meta-tags'
 require 'mini_magick'
 # require 'mobu'
@@ -19,7 +20,6 @@ require 'cama_meta_tag'
 $camaleon_engine_dir = File.expand_path("../../../", __FILE__)
 require File.join($camaleon_engine_dir, "lib", "plugin_routes").to_s
 Dir[File.join($camaleon_engine_dir, "lib", "ext", "**", "*.rb")].each{ |f| require f }
-require 'draper' if PluginRoutes.isRails4?
 
 module CamaleonCms
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Rails 6.0.3.2 with Ruby 2.7.1

When I got my local instance up and running in development mode, then tried to create a new site, it raised the error

```undefined method 'decorate' for #<CamaleonCms::Site>```

Source was that it couldn't find the `#decorate` method on `app/controllers/camaleon_cms/admin/installers_controller.rb:15 in 'save'` because Draper was not loaded.