### PR TITLE
Use non-digest-assets gem for using 3rd party assets

### DIFF
--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'draper', '>= 1.3'
   s.add_dependency 'meta-tags', '~> 2.0'
   s.add_dependency 'mini_magick'
+  s.add_dependency 'non-digest-assets'
   s.add_dependency 'will_paginate'
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'

--- a/config/initializers/non_digest_assets.rb
+++ b/config/initializers/non_digest_assets.rb
@@ -1,1 +1,3 @@
+require 'non-digest-assets'
+
 NonDigestAssets.whitelist += [/glyphicons*/]

--- a/config/initializers/non_digest_assets.rb
+++ b/config/initializers/non_digest_assets.rb
@@ -1,0 +1,1 @@
+NonDigestAssets.whitelist += [/glyphicons*/]


### PR DESCRIPTION
This is for fixing https://github.com/owen2345/camaleon-cms/issues/967

There was a [large discussion on rails-sprockets regarding the non-digest assets](https://github.com/rails/sprockets-rails/issues/49) and [many solutions have been proposed](https://github.com/rails/sprockets-rails#but-what-if-i-want-sprockets-to-generate-non-digest-assets)

Using the `non-digest-assets` gem seems to be the most correct and easy, also not affecting application's performance. I have tested it on production and it is working OK.


