### PR TITLE
Rails 6.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
     - rvm: 2.7
       gemfile: gemfiles/rails_6_0.gemfile
       env: DISABLE_DATABASE_ENVIRONMENT_CHECK=TRUE
+    - rvm: 2.7
+      gemfile: gemfiles/rails_6_1.gemfile
+      env: DISABLE_DATABASE_ENVIRONMENT_CHECK=TRUE
     - rvm: ruby-head
       gemfile: gemfiles/rails_edge.gemfile
   fast_finish: true

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -8,7 +8,7 @@ module CamaleonCms
     has_many :posts, foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type
     has_many :comments, through: :posts
     has_many :posts_through_categories, foreign_key: :objectid, through: :term_relationships, source: :object
-    has_many :posts_draft, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id, dependent: :destroy, source: :drafts, inverse_of: :post_type
+    has_many :posts_draft, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type
     has_many :field_group_taxonomy, -> {where('object_class LIKE ?', 'PostType_%')}, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy
 
     belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,17 +1,16 @@
 source 'https://rubygems.org'
 
-gemspec
+gemspec path: '..'
+
 gem 'rails', '~> 6.1.0rc1'
-gem 'sassc', '!= 2.3.0' # this version segfaults
+gem 'sqlite3'
+gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'
 gem 'webdrivers'
-
 gem 'capybara-screenshot'
-
-gem 'rspec_junit_formatter'
-
 gem 'puma'
 gem 'factory_bot'
 gem 'faker'
 gem 'draper', '~> 3'
 gem 'rack_session_access'
+gem 'cancancan', '~> 3.0'

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,7 +1,19 @@
 require File.expand_path('../boot', __FILE__)
 
-require 'rails/all'
-
+require "rails"
+# Pick the frameworks you want:
+require "active_model/railtie"
+# require "active_job/railtie"
+require "active_record/railtie"
+# require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+# require "action_mailbox/engine"
+# require "action_text/engine"
+require "action_view/railtie"
+# require "action_cable/engine"
+require "sprockets/railtie"
+require "rails/test_unit/railtie"
 Bundler.require(*Rails.groups)
 require "camaleon_cms"
 


### PR DESCRIPTION
Fixes #977 

This PR is basic Rails 6.1 support. There were a couple of changes necessary.

First, instead of requiring all Rails frameworks in the dummy app, only the necessary frameworks are required. This is because Rails started raising some errors when it couldn't locate config for Active Storage, which Camaleon doesn't use anyway.

Second, there is a change to one of the model associations in post_type.rb. Apparently the `:source` option is only valid if there is also a `:through` option, and Rails 6.1 raises an exception on what was previously a no-op. I removed the option (since it apparently didn't do anything anyway), but I wonder if maybe that relationship should be scoped? Please check this part carefully before merging. See the issue linked above for more info.