### PR TITLE
Removes ability to set belongs_to_required_by_default to false

### DIFF
--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -13,7 +13,7 @@ module CamaleonCms
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy
     belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, required: false
-    belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories required: false
+    belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories, required: false
     belongs_to :site, required: false
 
     before_save :set_site

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -12,9 +12,9 @@ module CamaleonCms
 
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy
-    belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id
-    belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories
-    belongs_to :site
+    belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, required: false
+    belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories required: false
+    belongs_to :site, required: false
 
     before_save :set_site
     before_destroy :set_posts_in_default_category

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -17,8 +17,8 @@ module CamaleonCms
     has_many :metas, -> { where(object_class: 'CustomField') }, foreign_key: :objectid, dependent: :destroy
     has_many :values, class_name: 'CamaleonCms::CustomFieldsRelationship',
       foreign_key: :custom_field_id, dependent: :destroy
-    belongs_to :custom_field_group
-    belongs_to :parent, class_name: 'CamaleonCms::CustomField', foreign_key: :parent_id
+    belongs_to :custom_field_group, required: false
+    belongs_to :parent, class_name: 'CamaleonCms::CustomField', foreign_key: :parent_id, required: false
 
     validates :name, :object_class, presence: true
     validates_uniqueness_of :slug, scope: [:parent_id, :object_class],

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -10,7 +10,7 @@ module CamaleonCms
     has_many :metas, -> { where(object_class: 'CustomFieldGroup') }, foreign_key: :objectid, dependent: :destroy
     has_many :fields, -> { where(object_class: '_fields') }, class_name: 'CamaleonCms::CustomField',
       foreign_key: :parent_id, dependent: :destroy
-    belongs_to :site, foreign_key: :parent_id
+    belongs_to :site, foreign_key: :parent_id, required: false
 
     validates_uniqueness_of :slug, scope: [:object_class, :objectid, :parent_id]
 

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -7,7 +7,7 @@ module CamaleonCms
     default_scope { order("#{CamaleonCms::CustomFieldsRelationship.table_name}.term_order ASC") }
 
     # relations
-    belongs_to :custom_field
+    belongs_to :custom_field, required: false
 
     # validates :objectid, :custom_field_id, presence: true
     validates :custom_field_id, presence: true # error on clone model

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -2,7 +2,7 @@ module CamaleonCms
   class Media < ActiveRecord::Base
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}media"
 
-    belongs_to :site
+    belongs_to :site, required: false
     validates :name, uniqueness: {
       scope: [:site_id, :is_folder, :folder_path, :is_public],
       message: 'Duplicates not allowed'

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -5,7 +5,7 @@ module CamaleonCms
 
     cama_define_common_relationships('NavMenu')
     has_many :children, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent
-    belongs_to :site, foreign_key: :parent_id, inverse_of: :nav_menus
+    belongs_to :site, foreign_key: :parent_id, inverse_of: :nav_menus, required: false
 
     # add menu item for current menu
     # value: (Hash) is a hash object that contains label, type, link

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -10,8 +10,8 @@ module CamaleonCms
     default_scope { where(taxonomy: :nav_menu_item).order(id: :asc) }
 
     cama_define_common_relationships('NavMenuItem')
-    belongs_to :parent, class_name: "CamaleonCms::NavMenu", inverse_of: :children
-    belongs_to :parent_item, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, inverse_of: :children
+    belongs_to :parent, class_name: "CamaleonCms::NavMenu", inverse_of: :children, required: false
+    belongs_to :parent_item, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, inverse_of: :children, required: false
     has_many :children, class_name: "CamaleonCms::NavMenuItem", foreign_key: :parent_id, dependent: :destroy, inverse_of: :parent_item
 
     before_create :set_parent_site

--- a/app/models/camaleon_cms/plugin.rb
+++ b/app/models/camaleon_cms/plugin.rb
@@ -7,7 +7,7 @@ module CamaleonCms
 
     attr_accessor :error
     cama_define_common_relationships('Plugin')
-    belongs_to :site, foreign_key: :parent_id
+    belongs_to :site, foreign_key: :parent_id, required: false
 
     default_scope { where(taxonomy: :plugin) }
     scope :active, -> { where(term_group: 1) }

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -18,9 +18,9 @@ module CamaleonCms
     has_many :drafts, ->{where(status: 'draft_child')}, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy
     has_many :children, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy, primary_key: :id
 
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
-    belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent
-    belongs_to :post_type, foreign_key: :taxonomy_id, inverse_of: :posts
+    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false
+    belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, required: false
+    belongs_to :post_type, foreign_key: :taxonomy_id, inverse_of: :posts, required: false
 
     scope :visible_frontend, -> {where(status: 'published')}
     scope :public_posts, -> {visible_frontend.where(visibility: ['public', '']) } #public posts (not passwords, not privates)

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -11,9 +11,9 @@ module CamaleonCms
 
     cama_define_common_relationships('PostComment')
     has_many :children, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, dependent: :destroy
-    belongs_to :post
-    belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent
-    belongs_to :user, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
+    belongs_to :post, required: false
+    belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, required: false
+    belongs_to :user, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false
 
     default_scope {order("#{CamaleonCms::PostComment.table_name}.created_at DESC")}
 

--- a/app/models/camaleon_cms/post_relationship.rb
+++ b/app/models/camaleon_cms/post_relationship.rb
@@ -5,8 +5,8 @@ class CamaleonCms::PostRelationship < ActiveRecord::Base
   # attr_accessible :objectid, :term_taxonomy_id, :term_order
   default_scope ->{ order(term_order: :asc) }
 
-  belongs_to :post_type, :class_name => "CamaleonCms::PostType", foreign_key: :term_taxonomy_id, inverse_of: :post_relationships
-  belongs_to :post, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, foreign_key: :objectid, inverse_of: :post_relationships, dependent: :destroy
+  belongs_to :post_type, :class_name => "CamaleonCms::PostType", foreign_key: :term_taxonomy_id, inverse_of: :post_relationships, required: false
+  belongs_to :post, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, foreign_key: :objectid, inverse_of: :post_relationships, dependent: :destroy, required: false
 
   # callbacks
   after_create :update_count

--- a/app/models/camaleon_cms/post_tag.rb
+++ b/app/models/camaleon_cms/post_tag.rb
@@ -4,7 +4,7 @@ module CamaleonCms
 
     cama_define_common_relationships('PostTag')
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
-    belongs_to :post_type, foreign_key: :parent_id, inverse_of: :post_tags
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
+    belongs_to :post_type, foreign_key: :parent_id, inverse_of: :post_tags, required: false
+    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false
   end
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -11,8 +11,8 @@ module CamaleonCms
     has_many :posts_draft, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type
     has_many :field_group_taxonomy, -> {where('object_class LIKE ?', 'PostType_%')}, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy
 
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
-    belongs_to :site, foreign_key: :parent_id
+    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false
+    belongs_to :site, foreign_key: :parent_id, required: false
 
     scope :visible_menu, -> {where(term_group: nil)}
     scope :hidden_menu, -> {where(term_group: -1)}

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -3,8 +3,8 @@ module CamaleonCms
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_relationships"
     default_scope ->{ order(term_order: :asc) }
 
-    belongs_to :term_taxonomy, inverse_of: :term_relationships
-    belongs_to :object, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :term_relationships
+    belongs_to :term_taxonomy, inverse_of: :term_relationships, required: false
+    belongs_to :object, ->{ order("#{CamaleonCms::Post.table_name}.id DESC") }, class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :term_relationships, required: false
 
     # callbacks
     after_create :update_count

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -19,8 +19,8 @@ module CamaleonCms
     # relations
     has_many :term_relationships, class_name: "CamaleonCms::TermRelationship", foreign_key: :term_taxonomy_id, dependent: :destroy
     # has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
-    belongs_to :parent, class_name: "CamaleonCms::TermTaxonomy", foreign_key: :parent_id
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
+    belongs_to :parent, class_name: "CamaleonCms::TermTaxonomy", foreign_key: :parent_id, required: false
+    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false
 
     # return all children taxonomy
     # sample: sub categories of a category

--- a/app/models/camaleon_cms/theme.rb
+++ b/app/models/camaleon_cms/theme.rb
@@ -3,7 +3,7 @@ module CamaleonCms
     # attrs:
     #   slug => plugin key
     cama_define_common_relationships('Theme')
-    belongs_to :site, class_name: "CamaleonCms::Site", foreign_key: :parent_id
+    belongs_to :site, class_name: "CamaleonCms::Site", foreign_key: :parent_id, required: false
 
     default_scope { where(taxonomy: :theme) }
 

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -4,7 +4,7 @@ module CamaleonCms
 
     default_scope { where(taxonomy: :user_roles) }
     cama_define_common_relationships('UserRole')
-    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, required: false
 
     def roles_post_type
       self.get_meta('_post_type')

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -16,7 +16,7 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
     cama_define_common_relationships('User')
     has_many :all_posts, class_name: "CamaleonCms::Post", foreign_key: :user_id
     has_many :all_comments, class_name: 'CamaleonCms::PostComment'
-    belongs_to :site, class_name: 'CamaleonCms::Site'
+    belongs_to :site, class_name: 'CamaleonCms::Site', optional: true
 
     #scopes
     scope :admin_scope, -> { where(:role => 'admin') }

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -27,7 +27,6 @@ module CamaleonCms
       g.test_framework :rspec
     end
     config.before_initialize do |app|
-      app.config.active_record.belongs_to_required_by_default = false if PluginRoutes.isRails5? || PluginRoutes.isRails6?
       if app.respond_to?(:console)
         app.console do
           # puts "******** Camaleon CMS: ********"


### PR DESCRIPTION
This change affects rails apps that rely on Rails 5 and 6 standards.

Currently when you design a rails app you expect to have a validation on `belongs_to` relationship. When adding Camaleon CMS you lose this, breaking the original code and it is not possible to override adding the setting back again in an initializers,

Given that this change on rails settings has been implemented for a while and that we should avoid to override rails settings in  a gem I would suggest to remove this line.

Running Camaleon tests it passes and the CMS seems to work fine without this setting.