### PR TITLE
Canonical URL field in General Site -> Seo Settings tab

### DIFF
--- a/app/views/camaleon_cms/admin/settings/_seo_settings.html.erb
+++ b/app/views/camaleon_cms/admin/settings/_seo_settings.html.erb
@@ -8,6 +8,10 @@
         <%= text_area :options, :keywords, :class => "form-control translatable", :value => @site.get_option("keywords") %>
     </div>
     <div class="form-group">
+      <label for=""><%= t('camaleon_cms.admin.settings.seo_canonical') %></label><br>
+      <%= text_field :options, :seo_canonical, class: "form-control translatable", value: @site.get_option(:seo_canonical) %>
+    </div>
+    <div class="form-group">
         <label for=""><%= t('camaleon_cms.admin.settings.author') %></label><br>
         <%= text_field :options, :seo_author, :class => "form-control", :value => @site.get_option("seo_author") %>
     </div>

--- a/config/locales/camaleon_cms/admin/ar.yml
+++ b/config/locales/camaleon_cms/admin/ar.yml
@@ -366,6 +366,7 @@ ar:
         email_cc: "Email CC"
         twitter_card: "Twitter Card"
         author: "Author Name"
+        seo_canonical: Canonical URL
         seo_setting: "Seo Settings"
         email_settings: "Email Settings (SMTP)"
         filesystem_type: "Filesystem type"

--- a/config/locales/camaleon_cms/admin/de.yml
+++ b/config/locales/camaleon_cms/admin/de.yml
@@ -365,6 +365,7 @@ de:
         email_cc: 'Email-CC'
         twitter_card: 'Twitter Card'
         author: 'Name des Autors'
+        seo_canonical: "Kanonische URL der Seite"
         seo_setting: 'SEO-Einstellungen'
         email_settings: 'Email-Einstellungen (SMTP)'
         filesystem_type: 'Typ des Dateisystems'

--- a/config/locales/camaleon_cms/admin/en.yml
+++ b/config/locales/camaleon_cms/admin/en.yml
@@ -397,6 +397,7 @@ en:
         post_tags_in: Post Tags In
         twitter_card: "Twitter Card"
         author: "Author Name"
+        seo_canonical: Canonical URL
         seo_setting: "Seo Settings"
         email_settings: "Email Settings (SMTP)"
         filesystem_type: "Filesystem type"

--- a/config/locales/camaleon_cms/admin/es.yml
+++ b/config/locales/camaleon_cms/admin/es.yml
@@ -336,6 +336,7 @@ es:
         email_cc: "Correo copia"
         twitter_card: "Etiqueta Twitter"
         author: "Nombre de Autor"
+        seo_canonical: "URL canónica de la página"
         seo_setting: "Posicionamiento Web."
         email_settings: "Configuración de Correo (SMTP)"
         media_settings: "Configuración de Multimedia"

--- a/config/locales/camaleon_cms/admin/fr.yml
+++ b/config/locales/camaleon_cms/admin/fr.yml
@@ -348,6 +348,7 @@ fr:
         email_cc: "Email CC"
         twitter_card: "Twitter Card"
         author: "Nom auteur"
+        seo_canonical: "l'URL canonique de la page"
         seo_setting: "Paramètres SEO"
         email_settings: "Paramètres Email (SMTP)"
         filesystem_type: "Type de système de fichiers"

--- a/config/locales/camaleon_cms/admin/it.yml
+++ b/config/locales/camaleon_cms/admin/it.yml
@@ -357,6 +357,7 @@ it:
         email_cc: "Email CC"
         twitter_card: "Twitter Card"
         author: "Mittente"
+        seo_canonical: "URL canonico della pagina"
         seo_setting: "Impostazioni Seo"
         email_settings: "Impostazioni email (SMTP)"
 

--- a/config/locales/camaleon_cms/admin/nl.yml
+++ b/config/locales/camaleon_cms/admin/nl.yml
@@ -345,6 +345,7 @@ nl:
         email_cc: "E-mail CC"
         twitter_card: "Twitter kaart"
         author: "Naam auteur"
+        seo_canonical: "De canonieke URL van de pagina"
         seo_setting: "SEO instellingen"
         email_settings: "E-mail instellingen (SMTP)"
         filesystem_type: "Type bestandsysteem"

--- a/config/locales/camaleon_cms/admin/pt-BR.yml
+++ b/config/locales/camaleon_cms/admin/pt-BR.yml
@@ -342,6 +342,7 @@ pt-BR:
         email_cc: "Cópia"
         twitter_card: "Twitter Card"
         author: "Nome do autor"
+        seo_canonical: "URL canônico da página"
         seo_setting: "Configurações SEO"
         email_settings: "Configurações de Email (SMTP)"
         filesystem_type: "Tipo de sistema de arquivos"

--- a/config/locales/camaleon_cms/admin/pt.yml
+++ b/config/locales/camaleon_cms/admin/pt.yml
@@ -340,6 +340,7 @@ pt:
         email_cc: "Cópia"
         twitter_card: "Twitter Card"
         author: "Nome do autor"
+        seo_canonical: "URL canônico da página"
         seo_setting: "Configurações SEO"
         email_settings: "Configurações de Email (SMTP)"
         filesystem_type: "Tipo de sistema de arquivos"

--- a/config/locales/camaleon_cms/admin/ru.yml
+++ b/config/locales/camaleon_cms/admin/ru.yml
@@ -356,6 +356,7 @@ ru:
         email_cc: "Email CC"
         twitter_card: "Twitter Card"
         author: "Имя автора"
+        seo_canonical: "Канонический адрес (URL) страницы"
         seo_setting: "Настройки Seo"
         email_settings: "Настройки Email (SMTP)"
         filesystem_type: "Тип файловой системы"

--- a/config/locales/camaleon_cms/admin/uk.yml
+++ b/config/locales/camaleon_cms/admin/uk.yml
@@ -353,6 +353,7 @@ uk:
         email_cc: "Email CC"
         twitter_card: "Twitter Card"
         author: "Ім'я автора"
+        seo_canonical: "Канонічний адресу URL сторінки"
         seo_setting: "Налаштування Seo"
         email_settings: "Налаштування Email (SMTP)"
         filesystem_type: "Тип файлової системи"

--- a/config/locales/camaleon_cms/admin/zh-CH.yml
+++ b/config/locales/camaleon_cms/admin/zh-CH.yml
@@ -376,6 +376,7 @@ zh-CN:
         email_cc: "抄送"
         twitter_card: "Twitter 卡片"
         author: "作者名"
+        seo_canonical: Canonical URL
         seo_setting: "SEO 设置"
         email_settings: "邮件设置 (SMTP)"
         filesystem_type: "文件系统"


### PR DESCRIPTION
`seo_canonical` option has been introduced in this commit https://github.com/owen2345/camaleon-cms/commit/53d016d5253bc037e7b280d55239f99ea02015fb, but there was no Admin UI for setting it.

Added `text_field` for `seo_canonical` option on the `General Site` -> `Seo Settings` tab and translations for the `seo_canonical` key.
