### PR TITLE
Do not check for precompiled assets when testing

### DIFF
--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -20,6 +20,8 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  config.assets.check_precompiled_asset = false
+
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 


### PR DESCRIPTION
Sometimes a Sprockets::Rails::Helper::AssetNotPrecompiled error appears when running the tests with the `camaleon_cms/camaleon.png` file.

Setting `config.assets.check_precompiled_asset` to `false` for test environment helps to get rid of this error.
