### PR TITLE
Bump non-digest-assets gem to 2.0.0 version and refactor its initializer

### DIFF
--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'draper', '>= 1.3'
   s.add_dependency 'meta-tags', '~> 2.0'
   s.add_dependency 'mini_magick'
-  s.add_dependency 'non-digest-assets'
+  s.add_dependency 'non-digest-assets', '~> 2.0'
   s.add_dependency 'will_paginate'
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'

--- a/config/initializers/non_digest_assets.rb
+++ b/config/initializers/non_digest_assets.rb
@@ -1,3 +1,3 @@
 require 'non-digest-assets'
 
-NonDigestAssets.whitelist += [/glyphicons*/]
+NonDigestAssets.asset_selectors += [/glyphicons*/]


### PR DESCRIPTION
There were warnings of deprecating `whitelist`, and now, in version `2.0.0`, it [has been removed](https://github.com/mvz/non-digest-assets/pull/54)

Changed non_digest_assets initializer to use `asset_selectors` instead of removed `whitelist` class variable.
