### PR TITLE
Use Github actions for CI build

### DIFF
--- a/.github/workflows/current_support.yml
+++ b/.github/workflows/current_support.yml
@@ -1,0 +1,82 @@
+name: Test supported versions
+on: [push, pull_request]
+
+jobs:
+  # oldest supported versions
+  ruby_2_6_rails_5_2:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_5_2.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.6
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec
+
+  ruby_2_7_rails_6_0:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_0.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 2.7
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec
+
+  ruby_3_0_rails_6_1:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.0
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/.github/workflows/experimental_support.yml
+++ b/.github/workflows/experimental_support.yml
@@ -1,0 +1,57 @@
+name: Test upcoming versions
+on: [push, pull_request]
+
+jobs:
+  # Latest Ruby, unreleased Rails
+  ruby_3_0_rails_edge:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_edge.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.0
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec
+
+  # Unreleased Ruby, latest Rails
+  ruby_head_rails_6_1:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: head
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](http://camaleon.tuzitio.com/media/132/logo2.png)
 
-[![Build Status](https://travis-ci.org/owen2345/camaleon-cms.svg?branch=master)](https://travis-ci.org/owen2345/camaleon-cms)
+![Build Status](https://github.com/owen2345/camaleon-cms/actions/workflows/current_support.yml/badge.svg)
 ![](https://img.shields.io/badge/Support-Immediate-green.svg)
 
 [Website](http://camaleon.tuzitio.com/)


### PR DESCRIPTION
Travis CI has updated their pricing tiers, and Camaleon no longer seems to be working on the free version.

This PR adds two Github actions workflows to the repo. One runs the tests for all supported versions of Ruby/Rails, and the other one runs tests for upcoming versions. These are separate so that the build for supported versions doesn't fail due to incompatibility with a future version.

I chose Github actions to replace Travis CI because it seems easiest to house the builds with the code. Github Actions doesn't seem to have total feature parity (allowed failures, etc), so if someone feels strongly about using a different tool we can look at that. For now I just want something that will run the tests since Travis stopped working, and GA will at least do that.

The Github actions builds do not include end-of-life versions of Ruby/Rails. Those are being removed soon, and at that time I also plan to remove the Travis config file. It is left for now to avoid merge conflicts at that time.