### PR TITLE
Ruby 3.1 support

### DIFF
--- a/.github/workflows/experimental_support.yml
+++ b/.github/workflows/experimental_support.yml
@@ -55,3 +55,31 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+  # TODO: Move this job to current support once Github Actions supports Ruby 3.1.0-preview1.
+  # TODO: Update this job to Ruby 3.1 stable and Rails 7.0 stable when they are released.
+  ruby_3_1_rails_6_1:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.1.0-preview1
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -41,6 +41,14 @@ Gem::Specification.new do |s|
   s.add_dependency 'cama_contact_form', '>= 0.0.28'
   s.add_dependency 'cama_meta_tag'
 
+  # TODO: These gems were moved from default gems to bundled gems in Ruby 3.1.
+  #       They are dependencies of the Mail gem, which as of version 2.7.1 has
+  #       not been updated to explicitly require them. Once that gem is updated,
+  #       these can be removed from the gemspec. https://github.com/mikel/mail/issues/1461
+  s.add_dependency 'net-smtp'
+  s.add_dependency 'net-pop'
+  s.add_dependency 'net-imap'
+
   # MEDIA MANAGER
   s.add_dependency 'aws-sdk-s3', '~> 1'
 

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -106,7 +106,7 @@ end
 
 def confirm_dialog
   if page.driver.class.to_s == 'Capybara::Selenium::Driver'
-    page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertPresentError
+    page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoSuchAlertError
   elsif page.driver.class.to_s == 'Capybara::Webkit::Driver'
     sleep 1 # prevent test from failing by waiting for popup
 


### PR DESCRIPTION
This commit adds a CI job for Ruby 3.1, which was released in preview today. Unfortunately, Github Actions hasn't added Ruby 3.1.0-preview1 yet, so the job doesn't pass CI yet. However, the spec passes locally in Ruby 3.1, and the ruby-head CI job passes as well (for the first time EVER, I think). So we have plenty of evidence that Camaleon will work just fine in Ruby 3.1.

The gems added to the gemspec are dependencies of the Mail gem. Ruby 3.1 still bundles these gems but no longer requires them by default, so for the first time they must be explicitly added. Presumably the Mail gem will receive an update at some point so that Camaleon no longer needs to include these gems in the gemspec.

Lastly, references to a deprecated Selenium exception are updated to get the tests passing.