### PR TITLE
Rails 7.0 support

### DIFF
--- a/.github/workflows/current_support.yml
+++ b/.github/workflows/current_support.yml
@@ -1,64 +1,8 @@
 name: Test supported versions
 on: [push, pull_request]
 
-# There should be a job for every supported version of Ruby/Rails, but not
-# every possible combination. Usually each year's new Ruby and Rails are tested
-# together. Any deviation from that pattern should be marked.
-
 jobs:
-  ruby_2_6_rails_5_2:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_5_2.gemfile
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: 2.6
-
-      - name: Run linters
-        run: bundle exec rubocop
-
-      - name: Migrate DB
-        run: bundle exec rake app:db:migrate
-
-      - name: Prepare DB
-        run: bundle exec rake app:db:test:prepare
-
-      - name: Run tests
-        run: bundle exec rspec
-
-  ruby_2_7_rails_6_0:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_0.gemfile
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: 2.7
-
-      - name: Run linters
-        run: bundle exec rubocop
-
-      - name: Migrate DB
-        run: bundle exec rake app:db:migrate
-
-      - name: Prepare DB
-        run: bundle exec rake app:db:test:prepare
-
-      - name: Run tests
-        run: bundle exec rspec
-
-  ruby_3_0_rails_6_1:
+  lint:
     runs-on: ubuntu-latest
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
@@ -75,20 +19,20 @@ jobs:
       - name: Run linters
         run: bundle exec rubocop
 
-      - name: Migrate DB
-        run: bundle exec rake app:db:migrate
-
-      - name: Prepare DB
-        run: bundle exec rake app:db:test:prepare
-
-      - name: Run tests
-        run: bundle exec rspec
-
-  # included by request. https://github.com/owen2345/camaleon-cms/pull/1003#issuecomment-940798515
-  ruby_2_7_rails_6_1:
+  spec:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [2.6, 2.7, 3.0]
+        gemfile: [rails_5_2, rails_6_0, rails_6_1, rails_7_0]
+        exclude:
+          - ruby: 2.6
+            gemfile: rails_7_0
+          - ruby: 3.0
+            gemfile: rails_5_2
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -97,10 +41,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7
-
-      - name: Run linters
-        run: bundle exec rubocop
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Migrate DB
         run: bundle exec rake app:db:migrate
@@ -108,5 +49,5 @@ jobs:
       - name: Prepare DB
         run: bundle exec rake app:db:test:prepare
 
-      - name: Run tests
+      - name: Run spec
         run: bundle exec rspec

--- a/.github/workflows/experimental_support.yml
+++ b/.github/workflows/experimental_support.yml
@@ -2,11 +2,20 @@ name: Test upcoming versions
 on: [push, pull_request]
 
 jobs:
-  # Latest Ruby, unreleased Rails
-  ruby_3_0_rails_edge:
+  spec:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: 3.0
+            gemfile: rails_edge
+          - ruby: 3.1.0-preview1
+            gemfile: rails_7_0
+          - ruby: head
+            gemfile: rails_7_0
     env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_edge.gemfile
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -15,10 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.0
-
-      - name: Run linters
-        run: bundle exec rubocop
+          ruby-version: ${{ matrix.ruby }}
 
       - name: Migrate DB
         run: bundle exec rake app:db:migrate
@@ -26,60 +32,5 @@ jobs:
       - name: Prepare DB
         run: bundle exec rake app:db:test:prepare
 
-      - name: Run tests
-        run: bundle exec rspec
-
-  # Unreleased Ruby, latest Rails
-  ruby_head_rails_6_1:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: head
-
-      - name: Run linters
-        run: bundle exec rubocop
-
-      - name: Migrate DB
-        run: bundle exec rake app:db:migrate
-
-      - name: Prepare DB
-        run: bundle exec rake app:db:test:prepare
-
-      - name: Run tests
-        run: bundle exec rspec
-
-  # TODO: Move this job to current support once Github Actions supports Ruby 3.1.0-preview1.
-  # TODO: Update this job to Ruby 3.1 stable and Rails 7.0 stable when they are released.
-  ruby_3_1_rails_6_1:
-    runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Setup Ruby and install gems
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-          ruby-version: 3.1.0-preview1
-
-      - name: Run linters
-        run: bundle exec rubocop
-
-      - name: Migrate DB
-        run: bundle exec rake app:db:migrate
-
-      - name: Prepare DB
-        run: bundle exec rake app:db:test:prepare
-
-      - name: Run tests
+      - name: Run spec
         run: bundle exec rspec

--- a/.github/workflows/experimental_support.yml
+++ b/.github/workflows/experimental_support.yml
@@ -55,3 +55,31 @@ jobs:
 
       - name: Run tests
         run: bundle exec rspec
+
+  # TODO: Move this job to current support once Github Actions supports Ruby 3.1.0-preview1.
+  # TODO: Update this job to Ruby 3.1 stable and Rails 7.0 stable when they are released.
+  ruby_3_1_rails_6_1:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails_6_1.gemfile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby and install gems
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: 3.1.0-preview1
+
+      - name: Run linters
+        run: bundle exec rubocop
+
+      - name: Migrate DB
+        run: bundle exec rake app:db:migrate
+
+      - name: Prepare DB
+        run: bundle exec rake app:db:test:prepare
+
+      - name: Run tests
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,8 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'rails', '~> 6.1.0'
+gem 'rails', '~> 7.0.0.rc1'
+gem 'non-digest-assets', github: 'mvz/non-digest-assets'
 gem 'sassc', '!= 2.3.0' # this version segfaults
 gem 'selenium-webdriver'
 gem 'webdrivers'

--- a/app/apps/plugins/attack/config/custom_models.rb
+++ b/app/apps/plugins/attack/config/custom_models.rb
@@ -1,8 +1,6 @@
 # custom class for site
-Rails.application.config.to_prepare do
-  CamaleonCms::Site.class_eval do
-    has_many :attack, class_name: "Plugins::Attack::Models::Attack"
-  end
+CamaleonCms::Site.class_eval do
+  has_many :attack, class_name: "Plugins::Attack::Models::Attack"
 end
 
 class Plugins::Attack::Config::CustomModels; end

--- a/app/apps/plugins/attack/models/attack.rb
+++ b/app/apps/plugins/attack/models/attack.rb
@@ -1,3 +1,3 @@
 class Plugins::Attack::Models::Attack < ActiveRecord::Base
-  belongs_to :site
+  belongs_to :site, class_name: "CamaleonCms::Site"
 end

--- a/app/helpers/camaleon_cms/hooks_helper.rb
+++ b/app/helpers/camaleon_cms/hooks_helper.rb
@@ -1,6 +1,6 @@
 module CamaleonCms::HooksHelper
   include CamaleonCms::PluginsHelper
-  
+
   # execute hooks for plugin_key with action name hook_key
   # non public method
   # plugin: plugin configuration (config.json)
@@ -24,7 +24,7 @@ module CamaleonCms::HooksHelper
       _hook.call(params)
     end
   end
-  
+
   # skip hook function with name: hook_function_name
   def hook_skip(hook_function_name)
     @_hooks_skip << hook_function_name

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -41,10 +41,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'cama_contact_form', '>= 0.0.28'
   s.add_dependency 'cama_meta_tag'
 
-  # TODO: These gems were moved from default gems to bundled gems in Ruby 3.1.
-  #       They are dependencies of the Mail gem, which as of version 2.7.1 has
-  #       not been updated to explicitly require them. Once that gem is updated,
-  #       these can be removed from the gemspec. https://github.com/mikel/mail/issues/1461
+  # TODO:
+  # These gems were moved from default gems to bundled gems in Ruby 3.1.
+  # They are dependencies of the Mail gem, which as of version 2.7.1 has
+  # not been updated to explicitly require them. Once that gem is updated,
+  # these can be removed from the gemspec. https://github.com/mikel/mail/issues/1461
   s.add_dependency 'net-smtp'
   s.add_dependency 'net-pop'
   s.add_dependency 'net-imap'

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -41,6 +41,14 @@ Gem::Specification.new do |s|
   s.add_dependency 'cama_contact_form', '>= 0.0.28'
   s.add_dependency 'cama_meta_tag'
 
+  # TODO: These gems were moved from default gems to bundled gems in Ruby 3.1.
+  #       They are dependencies of the Mail gem, which as of version 2.7.1 has
+  #       not been updated to explicitly require them. Once that gem is updated,
+  #       these can be removed from the gemspec. https://github.com/mikel/mail/issues/1461
+  s.add_dependency 'net-smtp'
+  s.add_dependency 'net-pop'
+  s.add_dependency 'net-imap'
+
   # MEDIA MANAGER
   s.add_dependency 'aws-sdk-s3', '~> 1'
 

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -13,25 +13,35 @@ module ActionView
             prefixes = (self.prefixes + prefixes).uniq if prefixes.is_a?(Array)
           end
         end
-        @view_paths.find(*args_for_lookup(name, prefixes, partial, keys, options))
+        @view_paths.find(*cama_args_for_lookup(name, prefixes, partial, keys, options))
       end
       alias :find_template :find
-    end
-  end
-end
 
-module ActionView
-  class LookupContext #:nodoc:
-    module ViewPaths
       # fix to add camaleon prefixes on verify template exist
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         if use_camaleon_partial_prefixes.present?
           prefixes = [""] unless prefixes.present?
           prefixes = (prefixes+self.prefixes).uniq if prefixes.is_a?(Array)
         end
-        @view_paths.exists?(*args_for_lookup(name, prefixes, partial, keys, options))
+        @view_paths.exists?(*cama_args_for_lookup(name, prefixes, partial, keys, options))
       end
       alias :template_exists? :exists?
+
+      private
+
+      # Rails 7 removed a private API method used by Camaleon. This method
+      # re-implements it or delegates to it, depending on Rails version.
+      def cama_args_for_lookup(name, prefixes, partial, keys, details_options)
+        if Rails.version.to_i < 7
+          args_for_lookup(name, prefixes, partial, keys, details_options)
+        else
+          # Re-implement the :args_for_lookup method from Rails < 7
+          name, prefixes = normalize_name(name, prefixes)
+          prefixes = prefixes.map { |prefix| prefix.start_with?("/") ? prefix[1..-1] : prefix }
+          details, details_key = detail_args_for(details_options)
+          [name, prefixes, partial || false, details, details_key, keys]
+        end
+      end
     end
   end
 end

--- a/config/initializers/custom_initializers.rb
+++ b/config/initializers/custom_initializers.rb
@@ -1,10 +1,12 @@
 # load all custom initializers of plugins or themes
-PluginRoutes.all_apps.each do |ap|
-  if ap["path"].present?
-    f = File.join(ap["path"], "config", "initializer.rb")
-    eval(File.read(f)) if File.exist?(f)
+Rails.application.config.to_prepare do |_config|
+  PluginRoutes.all_apps.each do |ap|
+    if ap["path"].present?
+      f = File.join(ap["path"], "config", "initializer.rb")
+      eval(File.read(f)) if File.exist?(f)
 
-    f = File.join(ap["path"], "config", "custom_models.rb")
-    eval(File.read(f)) if File.exist?(f)
+      f = File.join(ap["path"], "config", "custom_models.rb")
+      eval(File.read(f)) if File.exist?(f)
+    end
   end
 end

--- a/config/initializers/model_alias.rb
+++ b/config/initializers/model_alias.rb
@@ -1,18 +1,21 @@
-module Cama
-end
 Rails.application.config.to_prepare do
+  module Cama
+  end
+
+  Cama::Site = CamaleonCms::Site
+  Cama::Post = CamaleonCms::Post
+  Cama::Category = CamaleonCms::Category
+  Cama::PostTag = CamaleonCms::PostTag
+  Cama::PostType = CamaleonCms::PostType
+  Cama::TermTaxonomy = CamaleonCms::TermTaxonomy
+  Cama::TermRelationship = CamaleonCms::TermRelationship
+
   if PluginRoutes.static_system_info['user_model'].present?
     CamaleonCms::User = PluginRoutes.static_system_info['user_model'].constantize
     CamaleonCms::User.class_eval do
       include CamaleonCms::UserMethods
     end
   end
+
   Cama::User = CamaleonCms::User unless defined? Cama::User
 end
-Cama::Site = CamaleonCms::Site
-Cama::Post = CamaleonCms::Post
-Cama::Category = CamaleonCms::Category
-Cama::PostTag = CamaleonCms::PostTag
-Cama::PostType = CamaleonCms::PostType
-Cama::TermTaxonomy = CamaleonCms::TermTaxonomy
-Cama::TermRelationship = CamaleonCms::TermRelationship

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', github: 'rails/rails'
+gem 'rails', '~> 7.0.0.rc1'
 gem 'sqlite3'
 gem 'rspec_junit_formatter'
 gem 'selenium-webdriver'

--- a/spec/helpers/email_helper_spec.rb
+++ b/spec/helpers/email_helper_spec.rb
@@ -4,13 +4,13 @@ describe "CamaleonCms::EmailHelper" do
   before(:each){get_current_test_site()}
   describe "#send_email (old way)" do
     it "returns empty" do
-      expect(helper.send_email('test@gmail.com', 'Test Email', 'test content', 'owenperedo@gmail.com')).to be_a_kind_of(ActionMailer::DeliveryJob)
+      expect(helper.send_email('test@gmail.com', 'Test Email', 'test content', 'owenperedo@gmail.com')).to be_a_kind_of(Rails.version.to_i >=7 ? ActionMailer::MailDeliveryJob : ActionMailer::DeliveryJob)
     end
   end
 
   describe "#send_email (new way)" do
     it "returns empty" do
-      expect(helper.cama_send_email('test@gmail.com', 'Test Email', {content: 'test content', from: 'owenperedo@gmail.com'})).to be_a_kind_of(ActionMailer::DeliveryJob)
+      expect(helper.cama_send_email('test@gmail.com', 'Test Email', {content: 'test content', from: 'owenperedo@gmail.com'})).to be_a_kind_of(Rails.version.to_i >=7 ? ActionMailer::MailDeliveryJob : ActionMailer::DeliveryJob)
     end
   end
 end

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -106,7 +106,7 @@ end
 
 def confirm_dialog
   if page.driver.class.to_s == 'Capybara::Selenium::Driver'
-    page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoAlertPresentError
+    page.driver.browser.switch_to.alert.accept rescue Selenium::WebDriver::Error::NoSuchAlertError
   elsif page.driver.class.to_s == 'Capybara::Webkit::Driver'
     sleep 1 # prevent test from failing by waiting for popup
 


### PR DESCRIPTION
This PR adds Rails 7.0 support. Rails 7.0 is still in the alpha release stage, so this shouldn't be merged until there's a release candidate. I'm opening the PR for comments right now. It is built on top of #1010, so that PR should be merged first or closed in favor of this one.

The biggest changes are in some initialization code. Rails 7 changes autoloading behavior on boot, so that's what caused most of the changes to the framework code. There was also a monkey patch for an Action View method that is removed in Rails 7, so that is dealt with as well.

Rails 7.0 is added to the CI build. Since I was adding jobs to the build, I also switched to a matrix approach. Previously, on Travis CI, only four jobs would run concurrently, so it made sense to use fewer jobs in the build. Now with Github Actions, the jobs all run concurrently, so there's no penalty for testing all combinations.