### PR TITLE
Test for asset existence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ spec/dummy/**/*.sqlite3.db
 spec/dummy/**/*.sqlite3
 spec/support/fixtures/rails_tmp.png
 *.gem
+.tool-versions

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,22 +6,25 @@ Rails.application.config.assets.version = '1.0'
 Rails.application.config.tinymce.install = :copy
 
 # Add additional assets to the asset load path
-Rails.application.config.assets.precompile += %w( camaleon_cms/* )
+Rails.application.config.assets.precompile += %w[camaleon_cms/*]
 # Rails.application.config.assets.precompile += %w( themes/*/assets/* )
 
 # This will precompile any assets, not just JavaScript (.js, .coffee, .swf, .css, .scss)
 
-sprokects_4_or_newer = defined?(Sprockets::BabelProcessor)
-unless sprokects_4_or_newer
-  Rails.application.config.assets.precompile << Proc.new { |path|
+sprockets_3 = !Sprockets.const_defined?(:BabelProcessor)
+if sprockets_3
+  Rails.application.config.assets.precompile << Proc.new do |path|
     res = false
-    if File.dirname(path).start_with?('plugins/') || File.dirname(path).start_with?('themes/')
+    dirname = File.dirname(path)
+    if dirname.start_with?('plugins/') || dirname.start_with?('themes/')
       name = File.basename(path)
       content_type = MIME::Types.type_for(name).first.content_type rescue ""
-      if (path =~ /\.(css|js|svg|ttf|woff|eot|swf|pdf|png|jpg|gif)\z/ || content_type.scan(/(javascript|image\/|audio|video|font)/).any?) && !name.start_with?("_") && !path.include?('/views/')
-        res = true
+      if (path =~ /\.(css|js|svg|ttf|woff|eot|swf|pdf|png|jpg|gif)\z/ ||
+        content_type.scan(/(javascript|image\/|audio|video|font)/).any?) &&
+        !name.start_with?("_") && !path.include?('/views/')
+          res = true
       end
     end
     res
-  }
+  end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
+  config.log_level = :debug
+
   # Configure static file server for tests with Cache-Control for performance.
   config.serve_static_files   = true
   config.static_cache_control = 'public, max-age=3600'

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -1,15 +1,22 @@
+# frozen_string_literal: true
+
 include CamaleonCms::SiteHelper
 include CamaleonCms::HooksHelper
+
 FactoryBot.define do
   factory :site, class: CamaleonCms::Site do
     name { Faker::Name.unique.name }
-    slug { Capybara.current_session.server ? "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}" : 'key' }
+    slug do
+      current_session = Capybara.current_session
+      current_session.server ? "#{current_session.server.host}:#{current_session.server.port}" : 'key'
+    end
     # sequence(:slug) { |n| Capybara.current_session.server ? "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}" : "site#{n}" }
     description { Faker::Lorem.sentence }
     transient do
-      theme { PluginRoutes.all_themes.first['key'] }
+      theme { 'default' }
       skip_intro { true }
     end
+
     after(:create) do |site, evaluator|
       site_after_install(site, evaluator.theme)
       site.set_option('save_intro', true) if evaluator.skip_intro

--- a/spec/features/admin/posts_spec.rb
+++ b/spec/features/admin/posts_spec.rb
@@ -1,37 +1,60 @@
-require "rails_helper"
-describe "the signin process", js: true do
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'the signin process', js: true do
   init_site
 
-  it "create new post" do
+  it 'create new post' do
     admin_sign_in
     visit "#{cama_root_relative_path}/admin/post_type/2/posts/new"
     wait(2)
-    within("#form-post") do
+
+    within('#form-post') do
       fill_in 'post_title', :with => 'Test Title'
       page.execute_script('$("#form-post .tinymce_textarea").tinymce().setContent("Pants are pretty sweet.")')
       page.execute_script('$("#form-post input[name=\'categories[]\']:first").prop("checked", true)')
       wait(2)
+
       fill_in 'post_summary', :with => 'test summary'
-      page.execute_script("$('#form-post input[name=\"tags\"]').val('owen,dota')")
+      page.execute_script('$(\'#form-post input[name="tags"]\').val(\'owen,dota\')')
     end
     click_button 'Create'
     expect(page).to have_css('.alert-success')
   end
 
-  it "create edit post" do
+  it 'create edit post' do
     admin_sign_in
     visit "#{cama_root_relative_path}/admin/post_type/2/posts/#{@post.id}/edit"
     wait(2)
-    within("#form-post") do
+
+    within('#form-post') do
       fill_in 'post_title', :with => 'Test Title changed'
       page.execute_script('$("#form-post .tinymce_textarea").tinymce().setContent("Pants are pretty sweet. chaged")')
       fill_in 'post_summary', :with => 'test summary changed'
     end
     click_button 'Update'
     expect(page).to have_css('.alert-success')
-    
+
     # visit page in frontend
     visit @post.the_url(as_path: true)
-    expect(page).to have_content("Test Title changed")
+    expect(page).to have_content('Test Title changed')
+  end
+
+  describe 'when visibility post plugin is enabled' do
+    it 'correctly fetches the assets' do
+      plugin_install('visibility_post')
+      admin_sign_in
+      visit "#{cama_root_relative_path}/admin/post_type/2/posts/new"
+      wait(2)
+
+      within('#form-post') do
+        within('#published_from') do
+          find('span.glyphicon.glyphicon-calendar')
+        end
+
+        expect(webfont_icon_fetch_status('glyphicon glyphicon-calendar', 'glyphicons-halflings', 'woff2')).to eql(200)
+      end
+    end
   end
 end

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -1,17 +1,64 @@
-require "rails_helper"
-describe "the Site Settings", js: true do
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'the Site Settings SideBar options', js: true do
   init_site
 
-  it "Settings Form" do
-    admin_sign_in
-    visit "#{cama_root_relative_path}/admin/settings/site"
-    expect(page).to have_content("Basic Information")
-    expect(page).to have_content("Configuration")
-    within '#site_settings_form' do
-      fill_in "site_name", with: 'New site title'
-      fill_in "site_description", with: 'Site description'
-      click_button "Submit"
+  before { admin_sign_in }
+
+  describe 'General Site settings form' do
+    let(:new_site_domain) { 'New_site_domain' }
+
+    it 'is capturing main site options in the Settings Form' do
+      visit "#{cama_root_relative_path}/admin/settings/site"
+      expect(page).to have_content('Basic Information')
+      expect(page).to have_content('Configuration')
+      within '#site_settings_form' do
+        fill_in 'site_name', with: 'New site title'
+        fill_in 'site_description', with: 'Site description'
+        click_button 'Submit'
+      end
+      expect(page).to have_css('.alert-success')
     end
-    expect(page).to have_css('.alert-success')
+
+    it 'is redirecting to the new site domain' do
+      visit "#{cama_root_relative_path}/admin/settings/site"
+      within '#site_settings_form' do
+        fill_in 'site_slug', with: new_site_domain
+        click_button 'Submit'
+      end
+      expect(URI.parse(current_url).host).to eql(new_site_domain.downcase)
+    end
+  end
+
+  describe 'Theme settings form' do
+    let(:added_text) { ' Add some text' }
+
+    it 'has a Tiny MCE form' do
+      visit "#{cama_root_relative_path}/admin/settings/theme"
+
+      expect(page).to have_content('Footer message')
+      expect(webfont_icon_fetch_status('fa fa-cog', 'fontawesome-webfont', 'woff2')).to eql(200)
+
+      within '#theme_settings_form' do
+        within '.mce-edit-area' do
+          within_frame do
+            editor = page.find_by_id('tinymce')
+            expect(editor.text).to eql('Copyright © 2015 - Camaleon CMS. All rights reservated.')
+            editor.native.send_keys(added_text)
+          end
+        end
+
+        click_button 'Submit'
+      end
+
+      within '.mce-edit-area' do
+        within_frame do
+          editor = page.find_by_id('tinymce')
+          expect(editor.text).to eql("Copyright © 2015 - Camaleon CMS. All rights reservated.#{added_text}")
+        end
+      end
+    end
   end
 end

--- a/spec/features/admin/sites_spec.rb
+++ b/spec/features/admin/sites_spec.rb
@@ -1,6 +1,7 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
-# create a new site
 def create_site
   visit "#{cama_root_relative_path}/admin/settings/sites"
   expect(page).to have_content("List Sites")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,7 +33,13 @@ if defined?(Capybara::Webkit)
 
   Capybara.javascript_driver = :webkit
 else
+  # Next 2 are Chrome drivers
+  # Capybara.javascript_driver = :selenium_chrome
   Capybara.javascript_driver = :selenium_chrome_headless
+
+  # Next 2 are FireFox drivers
+  # Capybara.javascript_driver = :selenium
+  # Capybara.javascript_driver = :selenium_headless
 end
 
 # define screenshot errors name

--- a/spec/support/webfont_icon_check.rb
+++ b/spec/support/webfont_icon_check.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# require 'rails_helper'
+
+def webfont_icon_fetch_status(icon_class, filnam_distinct_part, filnam_extension)
+  icon_font_faces = page.execute_script(<<~JS, icon_class)
+    let calendarIcon = document.getElementsByClassName(arguments[0])[0];
+    let fontFamily = getComputedStyle(calendarIcon)['font-family']
+    const allCSS = [...document.styleSheets]
+      .flatMap(styleSheet => {
+        try {
+          return [...styleSheet.cssRules].map(rule => {
+              let ruleText = rule.cssText
+              if(ruleText.startsWith('@font-face') && ruleText.includes(fontFamily))
+                return ruleText
+            }
+          ).filter(Boolean)
+        } catch (e) {
+          console.log('Access to stylesheet %s is denied. Ignoring...', styleSheet.href)
+        }
+      })
+    return allCSS
+  JS
+
+  # First find is iterating through the array of font faces, 2nd - through the split chunks of found font face
+  url_str = icon_font_faces.find { |str| str.include?(filnam_distinct_part) && str.include?(filnam_extension) }.split
+                           .find { |str| str.include?(filnam_distinct_part) && str.include?(filnam_extension) }
+                           .delete_prefix('url("')
+                           .chomp('")')
+
+  page.execute_script(<<~JS)
+          let xhr = new XMLHttpRequest();
+          xhr.open('GET', '#{url_str}', false);
+          xhr.send();
+          return xhr.status;
+  JS
+end


### PR DESCRIPTION
To avoid failures when changing something regarding the assets, I have created a method for fetching the asset path from DOM from the font-face, and then making an AJAX request trying to fetch the asset.

Works with FontAwesome and Glyphicons. 

Doesn't work with Tiny MCE webfont because of the same reason as native Bootstrap's Glyphicons - Sprockets doesn't correctly process relative URL paths. We should definitely re-work the bundling system to get rid of Sprockets (Propshaft or Webpack or whatever else).

Also, had to change Site's factory `theme` attribute to a hard-coded `default` string because previously used `PluginRoutes.all_themes.first` has changed ordering in Ruby 3.0, and is returning `camaleon_first` instead of `default`.
