### PR TITLE
Feature/improve custom fields performance (WIP)

### DIFF
--- a/app/decorators/camaleon_cms/category_decorator.rb
+++ b/app/decorators/camaleon_cms/category_decorator.rb
@@ -39,7 +39,7 @@ class CamaleonCms::CategoryDecorator < CamaleonCms::TermTaxonomyDecorator
     if _parent.present?
       _parent.decorate.generate_breadcrumb(add_post_type, true)
     else
-      object.post_type_parent.decorate.generate_breadcrumb(add_post_type, true)
+      object.post_type.decorate.generate_breadcrumb(add_post_type, true)
     end
     h.breadcrumb_add(self.the_title, is_parent ? self.the_url : nil)
   end

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -4,7 +4,7 @@ module CamaleonCms::Admin::PostTypeHelper
   #taxonomy -> (categories || post_tags)
   def post_type_html_inputs(post_type, taxonomy="categories", name ="categories", type="checkbox", values=[], class_cat="categorychecklist" , required = false)
     categories = post_type.send(taxonomy)
-    categories = categories.eager_load(:children, :post_type_parent, :parent) if taxonomy == "categories" || taxonomy == "children"
+    categories = categories.eager_load(:children, :post_type, :parent) if taxonomy == "categories" || taxonomy == "children"
     post_type_taxonomy_html_(categories,taxonomy, name, type, values, class_cat, required)
   end
 

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -13,7 +13,7 @@ module CamaleonCms
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy
     belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, required: false
-    belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories, required: false
+    belongs_to :post_type, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, inverse_of: :categories, required: false
     belongs_to :site, required: false
 
     before_save :set_site
@@ -21,14 +21,7 @@ module CamaleonCms
 
     # return the post type of this category
     def post_type
-      cama_fetch_cache('post_type') do
-        ctg = self
-        begin
-          pt = ctg.post_type_parent
-          ctg = ctg.parent
-        end while ctg
-        pt
-      end
+      parent ? path.first.post_type : super
     end
 
     private

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -6,7 +6,6 @@ module CamaleonCms
     default_scope { where(taxonomy: :category) }
     scope :no_empty, -> { where('count > 0') } # return all categories that contains at least one post
     scope :empty, -> { where(count: [0, nil]) } # return all categories that does not contain any post
-    # scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
 
     cama_define_common_relationships('Category')
 
@@ -22,6 +21,12 @@ module CamaleonCms
     # return the post type of this category
     def post_type
       parent ? path.first.post_type : super
+    end
+
+    def path
+      cama_fetch_cache('path') do
+        (parent&.path || []) + [self]
+      end
     end
 
     private

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -235,6 +235,16 @@ module CamaleonCms
       (post_type.get_option('cama_post_decorator_class', 'CamaleonCms::PostDecorator') rescue 'CamaleonCms::PostDecorator').constantize
     end
 
+    def get_field_groups
+      CamaleonCms::CustomFieldGroup.where("(objectid = ? AND object_class = 'Post') OR
+                                             (objectid = ? AND object_class = 'PostType_Post')",
+                                          self.id || -1, self.post_type_id)
+    end
+
+    def add_custom_field_group(values)
+      custom_field_groups.create!(values)
+    end
+
     private
     # calculate a post order when it is empty
     def fix_post_order

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -3,6 +3,7 @@ module CamaleonCms
     include CamaleonCms::CategoriesTagsForPosts
 
     alias_attribute :post_type_id, :taxonomy_id
+    alias_attribute :parent_id, :post_parent
     default_scope ->{ where(post_class: 'Post').order(post_order: :asc, created_at: :desc) }
     cama_define_common_relationships('Post')
 

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -3,7 +3,7 @@ module CamaleonCms
     alias_attribute :site_id, :parent_id
     default_scope { where(taxonomy: :post_type) }
     cama_define_common_relationships('PostType')
-    has_many :categories, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type_parent
+    has_many :categories, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type
     has_many :post_tags, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type
     has_many :posts, foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type
     has_many :comments, through: :posts

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -154,6 +154,21 @@ module CamaleonCms
       get_option('has_parent_structure', false)
     end
 
+    # @param kind (Post|Category|PostTag|all|self)
+    # Sample: mypost_type.get_field_groups(kind: 'Post') => return custom field groups for posts
+    # Sample: mypost_type.get_field_groups(kind: 'Category') => return custom field groups for categories
+    # Sample: mypost_type.get_field_groups(kind: 'PostTag') => return custom field groups for post-tags
+    def get_field_groups(kind: 'Post')
+      if kind == 'all'
+        field_types = %w[PostType_Post PostType_Category PostType_PostTag PostType]
+        CamaleonCms::CustomFieldGroup.where(object_class: field_types, objectid:  self.id )
+      elsif %w[post_type self].include?(kind)
+        self.custom_field_groups
+      else
+        CamaleonCms::CustomFieldGroup.where(object_class: "PostType_#{args[:kind]}", objectid:  self.id )
+      end
+    end
+
     private
     # skip save_metas_options callback after save changes (inherit from taxonomy) to call from here manually
     def save_metas_options_skip

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -52,7 +52,7 @@ module CamaleonCms
 
     # all main categories for this site
     def categories
-      CamaleonCms::Category.includes(:post_type_parent).where(post_type_parent: post_types.pluck(:id))
+      CamaleonCms::Category.includes(:post_type).where(post_type: post_types.pluck(:id))
     end
 
     # return all languages configured by the admin

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -9,53 +9,19 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
     has_many :field_groups, ->(object){where(object_class: object.class.to_s.parseCamaClass)}, :class_name => "CamaleonCms::CustomFieldGroup", foreign_key: :objectid
   end
 
-
   # get custom field groups for current object
   # only: Post_type, Post, Category, PostTag, Widget, Site and a Custom model pre configured
-  # return collections CustomFieldGroup
-  # args: (Hash, used only for PostType Objects)
-    # kind: (Post (Default) | Category | PostTag | PostType).
-      # If kind = "Post" this will return all groups for all posts from current post type
-      # If kind = "Category" this will return all groups for all categories from current post type
-      # If kind = "PostTag" this will return all groups for all posttags from current post type
-      # If kind = "all" this will return all groups from current post type
-      # If kind = "post_type" this will return groups for all post_types
   # Sample: mypost.get_field_groups() ==> return fields for posts from parent posttype
   # Sample: mycat.get_field_groups() ==> return fields for categories from parent posttype
   # Sample: myposttag.get_field_groups() ==> return fields for posttags from parent posttype
-  # Sample: mypost_type.get_field_groups({kind: 'Post'}) => return custom fields for posts
-  # Sample: mypost_type.get_field_groups({kind: 'Category'}) => return custom fields for posts
-  # Sample: mypost_type.get_field_groups({kind: 'PostTag'}) => return custom fields for posts
-  def get_field_groups(args = {})
-    args = args.is_a?(String) ?  {kind: args, include_parent: false } : {kind: "Post", include_parent: false }.merge(args)
+  # @return collections CustomFieldGroup
+  def get_field_groups(_args = {})
     class_name = self.class.to_s.parseCamaClass
     case class_name
       when 'Category','PostTag'
-        self.post_type.get_field_groups(class_name)
-      when 'Post'
-        if self.term_relationships.size.zero? && args[:cat_ids].nil?
-          CamaleonCms::CustomFieldGroup.where("(objectid = ? AND object_class = ?) OR (objectid = ? AND object_class = ?)", self.id || -1, class_name, self.post_type.id, "PostType_#{class_name}")
-        else
-          cat_ids = self.categories.map(&:id)
-          cat_ids += args[:cat_ids] unless args[:cat_ids].nil?
-          cat_ids += CamaleonCms::Category.find(cat_ids).map {|category| _category_parents_ids(category)}.flatten.uniq
-          CamaleonCms::CustomFieldGroup.where("(objectid = ? AND object_class = ?) OR
-                                               (objectid = ? AND object_class = ?) OR
-                                               (objectid IN (?) AND object_class = ?)",
-                                              self.id || -1, class_name,
-                                              self.post_type.id, "PostType_#{class_name}",
-                                              cat_ids, "Category_#{class_name}")
-        end
+        self.post_type.get_field_groups(kind: class_name)
       when 'NavMenuItem'
         self.main_menu.custom_field_groups
-      when 'PostType'
-        if args[:kind] == "all"
-          CamaleonCms::CustomFieldGroup.where(object_class: ["PostType_Post", "PostType_Post", "PostType_PostTag", "PostType"], objectid:  self.id )
-        elsif args[:kind] == "post_type"
-          self.custom_field_groups
-        else
-          CamaleonCms::CustomFieldGroup.where(object_class: "PostType_#{args[:kind]}", objectid:  self.id )
-        end
       else # 'Plugin' or other classes
         self.field_groups
     end
@@ -160,18 +126,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # return: CustomFieldGroup object
   # kind: argument only for PostType model: (Post | Category | PostTag), default => Post. If kind = "" this will add group for all post_types
   def add_custom_field_group(values, kind = "Post")
-    values = values.with_indifferent_access
-    group = get_field_groups(kind).where(slug: values[:slug]).first
-    unless group.present?
-      site = _cama_get_field_site
-      values[:parent_id] = site.id if site.present?
-      if self.is_a?(CamaleonCms::Post) # harcoded for post to support custom field groups
-        group = CamaleonCms::CustomFieldGroup.where(object_class: "Post", objectid: self.id).create!(values)
-      else
-        group = get_field_groups(kind).create!(values)
-      end
-    end
-    group
+    get_field_groups(kind: kind).create!(values)
   end
   alias_method :add_field_group, :add_custom_field_group
 
@@ -180,7 +135,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
   # more details in add_manual_field(item, options) from custom field groups
   # kind: argument only for PostType model: (Post | Category | PostTag), default => Post
   def add_custom_field_to_default_group(item, options, kind = "Post")
-    g = get_field_groups(kind).where(slug: "_default").first
+    g = get_field_groups(kind: kind).where(slug: "_default").first
     g = add_custom_field_group({name: "Default Field Group", slug: "_default"}, kind) unless g.present?
     g.add_manual_field(item, options)
   end
@@ -191,9 +146,6 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
     CamaleonCms::CustomField.where(
       slug: slug,
       parent_id: get_field_groups.pluck(:id),
-    ).first || CamaleonCms::CustomField.where(
-      slug: slug,
-      parent_id: get_field_groups({include_parent: true})
     ).first
   end
 
@@ -278,9 +230,7 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
     if ['Category','Post','PostTag'].include?(class_name)
       CamaleonCms::CustomFieldGroup.where(objectid: self.id, object_class: class_name).destroy_all
     elsif ['PostType'].include?(class_name)
-      get_field_groups("Post").destroy_all
-      get_field_groups("Category").destroy_all
-      get_field_groups("PostTag").destroy_all
+      get_field_groups(kind: 'all').destroy_all
     elsif ["NavMenuItem"].include?(class_name) # menu items doesn't include field groups
     else
       get_field_groups().destroy_all if get_field_groups.present?
@@ -295,16 +245,6 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
         self
       else
         self.site
-    end
-  end
-
-  def _category_parents_ids(category)
-    @parents ||= []
-    if category.parent.nil?
-      return @parents
-    else
-      @parents << category.parent.id
-      _category_parents_ids(category.parent)
     end
   end
 end

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -27,14 +27,6 @@ module CamaleonCms::CustomFieldsRead extend ActiveSupport::Concern
     end
   end
 
-  # get custom field groups for current user
-  # return collections CustomFieldGroup
-  # site: site object
-  def get_user_field_groups(site)
-    site.custom_field_groups.where(object_class: self.class.to_s.parseCamaClass)
-  end
-
-
   # get custom field value
   # _key: custom field key
   # if value is not present, then return default

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -97,6 +97,10 @@ module CamaleonCms::UserMethods extend ActiveSupport::Concern
   end
     # end auth
 
+  def get_field_groups(site)
+    site.custom_field_groups.where(object_class: self.class.to_s.parseCamaClass)
+  end
+
   private
   def cama_before_validation
     self.role = PluginRoutes.system_info["default_user_role"] if self.role.blank?

--- a/app/views/camaleon_cms/admin/users/form.html.erb
+++ b/app/views/camaleon_cms/admin/users/form.html.erb
@@ -95,7 +95,7 @@
                                 <textarea name="meta[slogan]" class="form-control"><%= @user.get_meta("slogan") %></textarea>
                             </div>
                         </div>
-                        <%= render partial: "camaleon_cms/admin/settings/custom_fields/render", locals: {record: @user, field_groups: @user.get_user_field_groups(current_site) } %>
+                        <%= render partial: "camaleon_cms/admin/settings/custom_fields/render", locals: {record: @user, field_groups: @user.get_field_groups(current_site) } %>
                     </div>
                     <div class="panel-footer">
                         <a class="btn btn-default" role="back" href="<%= url_for action: :index %>"><%= t('camaleon_cms.admin.button.back')%></a>


### PR DESCRIPTION
## Improve the performance when manipulating custom field values and custom field groups

- [x] feat: unify post_type reference name 
- [x] feat: improve the way to calculate the post-type of a category
- [x] feat: add the ability to calc the category tree path
- [x] feat: improve the way to fetch and create custom field groups for posts
- [x] feat: improve the way to fetch field groups for post-types
- [x] feat: refactor custom fields finder and creator to remove related to Post and PostTypes (moved their own place)
