### PR TITLE
WIP: Migrate to TinyMCE 5

### DIFF
--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -24,7 +24,7 @@ function build_custom_field_group(field_values, group_id, fields_data, is_repeat
         group_panel_body.sortable({ handle: ".move.fa-arrows", items: ' > .custom_sortable_grouped',
             update: function(){ group_panel.trigger('update_custom_group_number'); },
             start: function (e, ui) { // fix tinymce
-                $(ui.item).find('.mce-panel').each(function () {
+                $(ui.item).find('.tox-tinymce').each(function () {
                     tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'));
                 });
             },
@@ -97,7 +97,7 @@ function cama_build_custom_field(panel, field_data, values){
         panel.delegate('.actions .fa-times', "click", function () { if(confirm(I18n("msg.delete_item"))) $(this).closest('.editor-custom-fields').remove(); return false; });
         $sortable.sortable({ handle: ".fa-arrows", items: ' > .editor-custom-fields',
             start: function (e, ui) { // fix tinymce
-                $(ui.item).find('.mce-panel').each(function () {
+                $(ui.item).find('.tox-tinymce').each(function () {
                     tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'));
                 });
             },

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -1,8 +1,8 @@
-function cama_get_tinymce_settings(settings){
-    if(!settings) settings = {};
+function cama_get_tinymce_settings(settings) {
+    if (!settings) settings = {};
     var def = {
         selector: ".tinymce_textarea",
-        plugins: "advlist autolink lists link image charmap print preview hr anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table contextmenu directionality emoticons template paste textcolor colorpicker textpattern filemanager",
+        plugins: "advlist autolink lists link image charmap print preview hr anchor pagebreak searchreplace wordcount visualblocks visualchars code fullscreen insertdatetime media nonbreaking save table directionality emoticons template paste textpattern filemanager",
         menubar: "edit insert view format table tools",
         image_advtab: true,
         statusbar: true,
@@ -12,17 +12,17 @@ function cama_get_tinymce_settings(settings){
         convert_urls: false,
         //forced_root_block: '',
         extended_valid_elements: 'i[*],div[*],p[*],li[*],a[*],ol[*],ul[*],span[*]',
-        toolbar: "bold italic | alignleft aligncenter alignright alignjustify | fontselect fontsizeselect | bullist numlist | outdent indent | undo redo | link unlink image media | forecolor backcolor | styleselect template "+tinymce_global_settings["custom_toolbar"].join(","),
+        toolbar: "bold italic | alignleft aligncenter alignright alignjustify | fontselect fontsizeselect | bullist numlist | outdent indent | undo redo | link unlink image media | forecolor backcolor | styleselect template " + tinymce_global_settings["custom_toolbar"].join(","),
         image_caption: true,
         language: CURRENT_LOCALE,
         relative_urls: false,
         remove_script_host: false,
-        browser_spellcheck : true,
+        browser_spellcheck: true,
         language_url: tinymce_global_settings["language_url"],
-        file_browser_callback: function(field_name, url, type, win) {
+        file_browser_callback: function (field_name, url, type, win) {
             $.fn.upload_filemanager({
                 formats: type,
-                selected: function(file, response){
+                selected: function (file, response) {
                     $('#' + field_name).val(file.url);
                 }
             });
@@ -31,39 +31,39 @@ function cama_get_tinymce_settings(settings){
         setup: function (editor) {
             editor.on('blur', function () {
                 tinymce.triggerSave();
-                $('textarea#'+editor.id).trigger('change');
+                $('textarea#' + editor.id).trigger('change');
             });
-            
+
             editor.on('PostProcess', function (ed) {
-                ed.content = ed.content.replace(/(<p><\/p>)/gi,'<br />');
+                ed.content = ed.content.replace(/(<p><\/p>)/gi, '<br />');
             });
 
             editor.ui.registry.addMenuItem('append_line', {
                 text: 'New line at the end',
                 context: 'insert',
-                onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-');  }
+                onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-'); }
             });
             editor.ui.registry.addMenuItem('add_line', {
                 text: 'New line',
                 context: 'insert',
-                onclick: function () { editor.insertContent('<p>-New line-</p>');  }
+                onclick: function () { editor.insertContent('<p>-New line-</p>'); }
             });
 
             // eval all extra setups
-            for(var ff in tinymce_global_settings["setups"]) tinymce_global_settings["setups"][ff](editor);
+            for (var ff in tinymce_global_settings["setups"]) tinymce_global_settings["setups"][ff](editor);
 
-            editor.on('postRender', function(e) {
+            editor.on('postRender', function (e) {
                 editor.settings.onPostRender(editor);
                 // eval all extra setups
-                for(var ff in tinymce_global_settings["post_render"]) tinymce_global_settings["post_render"][ff](editor);
+                for (var ff in tinymce_global_settings["post_render"]) tinymce_global_settings["post_render"][ff](editor);
             });
 
-            editor.on('init', function(e) {
-                for(var ff in tinymce_global_settings["init"]) tinymce_global_settings["init"][ff](editor);
+            editor.on('init', function (e) {
+                for (var ff in tinymce_global_settings["init"]) tinymce_global_settings["init"][ff](editor);
             });
         },
-        onPostRender: function(editor){}
+        onPostRender: function (editor) { }
     };
-    for(var ff in tinymce_global_settings["settings"]) tinymce_global_settings["settings"][ff](settings, def);
+    for (var ff in tinymce_global_settings["settings"]) tinymce_global_settings["settings"][ff](settings, def);
     return $.extend({}, def, settings);
 }

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -38,12 +38,12 @@ function cama_get_tinymce_settings(settings){
                 ed.content = ed.content.replace(/(<p><\/p>)/gi,'<br />');
             });
 
-            editor.addMenuItem('append_line', {
+            editor.ui.registry.addMenuItem('append_line', {
                 text: 'New line at the end',
                 context: 'insert',
                 onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-');  }
             });
-            editor.addMenuItem('add_line', {
+            editor.ui.registry.addMenuItem('add_line', {
                 text: 'New line',
                 context: 'insert',
                 onclick: function () { editor.insertContent('<p>-New line-</p>');  }

--- a/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
+++ b/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
@@ -14,13 +14,13 @@ tinymce.PluginManager.add('filemanager', function(editor) {
             }
         });
     }
-    editor.addButton('filemanager', {
+    editor.ui.registry.addButton('filemanager', {
         icon: 'browse',
         tooltip: 'Insert file',
         onclick: openmanager,
         stateSelector: 'img:not([data-mce-object])'
     });
-    editor.addMenuItem('filemanager', {
+    editor.ui.registry.addMenuItem('filemanager', {
         icon: 'browse',
         text: 'Insert file',
         onclick: openmanager,

--- a/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
+++ b/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
@@ -16,32 +16,39 @@
 //************** Main content
 #admin_content {
   min-height: 400px;
+
   .panel {
-    &.panel-toggled > .panel-body {
+    &.panel-toggled>.panel-body {
       display: none;
     }
+
     .panel-heading {
       //overflow: hidden;
       position: relative;
+
       .panel-controls {
         float: right;
         list-style: outside none none;
         position: absolute;
         right: 26px;
         top: 5px;
+
         li {
           float: left;
+
           a {
             @include link_round();
           }
         }
       }
-      > .btn{
+
+      >.btn {
         position: absolute;
         right: 26px;
         top: 14px;
       }
     }
+
     .panel-footer {
       overflow: hidden;
     }
@@ -53,16 +60,21 @@
     font-size: 12px;
     vertical-align: middle;
   }
+
   // reset label inputs
   label {
-    input[type="radio"], input[type="checkbox"] {
+
+    input[type="radio"],
+    input[type="checkbox"] {
       margin-right: 4px;
     }
   }
+
   // category lists
   .categorychecklist {
     padding-left: 10px;
     list-style: none;
+
     ul {
       padding-left: 25px;
       list-style: none;
@@ -73,6 +85,7 @@
     .sl-slug-edit {
       margin-top: 4px;
     }
+
     .gallery-item-remove {
       position: absolute;
       margin-top: -22px;
@@ -84,12 +97,14 @@
     .inner {
       padding-top: 30px;
     }
+
     a {
       position: absolute;
       top: 4px;
       right: 5px;
       @include link_round(25);
       background: rgba(250, 250, 250, 0.4);
+
       &.edit_link {
         left: 5px;
         right: auto;
@@ -102,49 +117,57 @@
     padding: 0;
     margin: 0;
     white-space: nowrap;
-    & > * {
+
+    &>* {
       background-color: #fafafa;
       border: 1px solid #ddd;
       color: #777;
       padding: 6px 12px;
       margin: 0 -2px;
     }
+
     em {
       background-color: #337ab7;
       border-color: #337ab7;
       color: #fff;
       cursor: default;
     }
+
     span {
       cursor: not-allowed;
     }
   }
+
   form {
-    .form-group > .trans_panel{
+    .form-group>.trans_panel {
       margin-top: -25px;
     }
   }
 }
 
 //************** sidebar left
-#sidebar-menu{
+#sidebar-menu {
   z-index: 2;
 }
 
 //************** reset modals
-.modal, #admin_content {
+.modal,
+#admin_content {
   .btn_upload {
     cursor: pointer;
   }
+
   .input-append.date .input-group-addon {
     padding: 7px 0;
     width: 30px;
   }
-  .input-group.color{
+
+  .input-group.color {
     .input-group-addon {
       background-color: #ccc;
     }
-    .over_field + span{
+
+    .over_field+span {
       padding: 5px;
       position: absolute;
       right: 0;
@@ -158,10 +181,12 @@
     .nav-tabs .has-error {
       color: #a94442;
     }
+
     .tab-pane .has-error {
       border: 1px solid #a94442;
     }
   }
+
   .trans_panel {
     //fix for multilanguage tabs
     //margin-top: -25px;
@@ -170,28 +195,35 @@
   // custom fields render in forms
   .item-custom-field {
     margin-bottom: 15px;
-    > label {
+
+    >label {
       display: block;
-      .shortcode_field input{
+
+      .shortcode_field input {
         min-width: 250px;
       }
     }
-    .actions{
+
+    .actions {
       overflow: hidden;
       width: 67px;
       float: left;
+
       .fa {
         @include link_round;
       }
-      & + .group-input-fields-content {
+
+      &+.group-input-fields-content {
         margin-left: 75px;
       }
     }
   }
-  .custom_sortable_grouped .header-field-grouped{
+
+  .custom_sortable_grouped .header-field-grouped {
     padding: 5px;
     margin-bottom: 3px;
-    .fa{
+
+    .fa {
       @include link_round;
       display: inline-block;
       float: none;
@@ -200,23 +232,21 @@
 }
 
 //************** Main Header && intro js custom
-#main-header{
+#main-header {
   z-index: 4;
-  &.introjs-fixParent{
+
+  &.introjs-fixParent {
     width: 100%;
+
     .navbar {
       width: 100%;
     }
   }
+
   .logo img {
     max-width: 100%;
     max-height: 100%;
   }
-}
-
-//************** fix tinymce fullscreen
-div.mce-fullscreen{
-  z-index: 10;
 }
 
 #tab-information {
@@ -232,10 +262,11 @@ div.mce-fullscreen{
 }
 
 //************** custom loading style
-#cama_custom_loading{
+#cama_custom_loading {
   position: relative;
   z-index: 999999;
-  .back_spinner{
+
+  .back_spinner {
     position: fixed;
     z-index: 99998;
     width: 100%;
@@ -244,7 +275,8 @@ div.mce-fullscreen{
     background-color: #2D95BF;
     background-color: rgba(60, 141, 188, 0.2);
   }
-  .loader_spinner{
+
+  .loader_spinner {
     z-index: 99999;
     position: fixed;
     left: 50%;
@@ -259,7 +291,7 @@ div.mce-fullscreen{
 }
 
 // copy paste code style
-input.code_style{
+input.code_style {
   background-color: #f9f2f4;
   border-radius: 4px;
   color: #c7254e;
@@ -270,23 +302,28 @@ input.code_style{
 }
 
 // fix tab content padding
-.tab-content > .tab-pane{
+.tab-content>.tab-pane {
   padding-top: 5px;
 }
-.content-upload-plugin{
+
+.content-upload-plugin {
   min-height: 45px;
   position: relative;
-  .rm-file{
+
+  .rm-file {
     position: absolute;
     top: 100%;
     margin-top: -22px;
   }
-  img{
+
+  img {
     max-height: 100px;
     max-width: 200px;
   }
 }
-label.error, span.error{
+
+label.error,
+span.error {
   color: #a94442;
   font-size: 11px;
 }
@@ -296,8 +333,7 @@ label.error, span.error{
 
 // themes: index page
 .theme-card {
-  border: 1px 
-  solid #ddd; 
+  border: 1px solid #ddd;
   border-radius: 0;
   position: relative;
 
@@ -305,13 +341,13 @@ label.error, span.error{
     padding: 0;
 
     .theme-image {
-      width: 100%; 
+      width: 100%;
       height: 260px;
       background-size: cover;
     }
 
     &:hover {
-      & + .theme-description {
+      &+.theme-description {
         display: block;
       }
     }
@@ -334,14 +370,14 @@ label.error, span.error{
   }
 
   .panel-footer {
-    background-color: #fafafa; 
-    border: 0; 
-    border-radius: 0; 
-    box-shadow: inset 0 1px 0 rgba(0,0,0,.1);
+    background-color: #fafafa;
+    border: 0;
+    border-radius: 0;
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, .1);
     display: flex;
     justify-content: space-between;
     align-items: center;
-  
+
 
     .theme-name {
       font-size: 1.6rem;

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'tinymce-rails', '< 5'
+  s.add_dependency 'tinymce-rails', '~> 5.1', '>= 5.1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'sass-rails'
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,8 +3,6 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-Rails.application.config.tinymce.install = :copy
-
 # Add additional assets to the asset load path
 Rails.application.config.assets.precompile += %w[camaleon_cms/*]
 # Rails.application.config.assets.precompile += %w( themes/*/assets/* )

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -42,7 +42,7 @@ describe 'the Site Settings SideBar options', js: true do
       expect(webfont_icon_fetch_status('fa fa-cog', 'fontawesome-webfont', 'woff2')).to eql(200)
 
       within '#theme_settings_form' do
-        within '.mce-edit-area' do
+        within '.tox-edit-area' do
           within_frame do
             editor = page.find_by_id('tinymce')
             expect(editor.text).to eql('Copyright © 2015 - Camaleon CMS. All rights reservated.')
@@ -53,7 +53,7 @@ describe 'the Site Settings SideBar options', js: true do
         click_button 'Submit'
       end
 
-      within '.mce-edit-area' do
+      within '.tox-edit-area' do
         within_frame do
           editor = page.find_by_id('tinymce')
           expect(editor.text).to eql("Copyright © 2015 - Camaleon CMS. All rights reservated.#{added_text}")


### PR DESCRIPTION
This PR revives an old branch I had for migrating to TinyMCE 5. I've rebased it on the current master branch and added another commit for a few migration details I missed when I first did this in 2020. Once v5 is working well we can move on to v6.

A few notes:
- There's a commit in here to compile TinyMCE assets. I believe we are in flux as to whether to compile or copy these. I'm not sure what approach this PR should take.
- The last remaining migration detail that I'm aware of is to stop using `onPostRender` as described [here](https://www.tiny.cloud/docs/migration-from-4x/#migratingonpostrendertoonsetup). I see that we use this function [here](https://github.com/owen2345/camaleon-cms/blob/d333e719f1b3e600530f9a6fc1bb8d4e7d64881a/app/assets/javascripts/camaleon_cms/admin/_data.js#L56) and [here](https://github.com/owen2345/camaleon-cms/blob/d333e719f1b3e600530f9a6fc1bb8d4e7d64881a/app/assets/javascripts/camaleon_cms/admin/_data.js#L65). I'm not sure what Camaleon is using this for, and since I don't know what it's doing the migration docs don't make a ton of sense to me. I need some help finishing this off.

By all appearances, TinyMCE 5 works well using the changes in this PR even without finishing the last migration step described above.

@owen2345 @texpert if you can chime in with any advice, I'll be able to finish this off and move on to working on v6.