### PR TITLE
TinyMCE version 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spec/dummy/**/*.sqlite3
 spec/support/fixtures/rails_tmp.png
 *.gem
 .tool-versions
+node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add Ruby 3.2 to CI
 - Require Rails 6+
 - Require Ruby 2.7+
+- Upgrade to TinyMCE v5
 
 ## [2.6.4](https://github.com/owen2345/camaleon-cms/tree/2.6.4) (2022-06-08)
 - Reformat JSON comments for OJ compatibility

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -18,7 +18,7 @@ function BuildCustomFieldGroup(fieldValues, groupId, fieldsData, isRepeat, field
       .find('input, textarea, select')
       .not('.code_style')
       .each(
-        function() {
+        function () {
           $(this).attr(
             'name', $(this).attr('name').replace(fieldNameGroup, fieldNameGroup + '[' + fieldGroupCounter + ']')
           )
@@ -38,27 +38,27 @@ function BuildCustomFieldGroup(fieldValues, groupId, fieldsData, isRepeat, field
     groupPanelBody.sortable({
       handle: '.move.fa-arrows',
       items: ' > .custom_sortable_grouped',
-      update: function() { groupPanel.trigger('update_custom_group_number') },
-      start: function(e, ui) { // fix tinymce
-        $(ui.item).find('.mce-panel').each(function() {
+      update: function () { groupPanel.trigger('update_custom_group_number') },
+      start: function (e, ui) { // fix tinymce
+        $(ui.item).find('.mce-panel').each(function () {
           tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'))
         })
       },
-      stop: function(e, ui) { // fix tinymce
-        $(ui.item).find('.cama_restore_editor').each(function() {
+      stop: function (e, ui) { // fix tinymce
+        $(ui.item).find('.cama_restore_editor').each(function () {
           tinymce.execCommand('mceAddEditor', true, $(this).attr('id'))
         })
       }
     })
     groupPanel.find('.btn.duplicate_cutom_group').click(AddGroup)
-    groupPanelBody.on('click', '.header-field-grouped .del', function() { if (confirm(I18n('msg.delete_item'))) $(this).closest('.custom_sortable_grouped').fadeOut('slow', function() { $(this).remove(); groupPanel.trigger('update_custom_group_number') }); return false })
-    groupPanelBody.on('click', '.header-field-grouped .toggleable', function() {
+    groupPanelBody.on('click', '.header-field-grouped .del', function () { if (confirm(I18n('msg.delete_item'))) $(this).closest('.custom_sortable_grouped').fadeOut('slow', function () { $(this).remove(); groupPanel.trigger('update_custom_group_number') }); return false })
+    groupPanelBody.on('click', '.header-field-grouped .toggleable', function () {
       if ($(this).hasClass('fa-angle-down')) $(this).removeClass('fa-angle-down').addClass('fa-angle-up').closest('.header-field-grouped').next().slideUp()
       else $(this).removeClass('fa-angle-up').addClass('fa-angle-down').closest('.header-field-grouped').next().slideDown()
       return false
     })
-    groupPanel.bind('update_custom_group_number', function() { $(this).find('.custom_sortable_grouped').each(function(index) { $(this).find('input.cama_custom_group_number').val(index) }) })
-    $.each(fieldValues, function(fieldVal, key) { AddGroup(this) })
+    groupPanel.bind('update_custom_group_number', function () { $(this).find('.custom_sortable_grouped').each(function (index) { $(this).find('input.cama_custom_group_number').val(index) }) })
+    $.each(fieldValues, function (fieldVal, key) { AddGroup(this) })
   } else
     AddGroup(fieldValues[0])
 }
@@ -70,7 +70,7 @@ function CamaBuildCustomField(panel, fieldData, values) {
 
   panel.html(
     "<div class='cama_w_custom_fields'></div>" +
-      (fieldData.multiple ? "<div class='field_multiple_btn'> <a href='#' class='btn btn-warning btn-xs'> <i class='fa fa-plus'></i> " + panel.attr('data-add_field_title') + '</a></div>' : '')
+    (fieldData.multiple ? "<div class='field_multiple_btn'> <a href='#' class='btn btn-warning btn-xs'> <i class='fa fa-plus'></i> " + panel.attr('data-add_field_title') + '</a></div>' : '')
   )
 
   const fieldActions = '<div class="actions"><i style="cursor: move" class="fa fa-arrows"></i> <i style="cursor: pointer" class="fa fa-times text-danger"></i></div>'
@@ -85,11 +85,11 @@ function CamaBuildCustomField(panel, fieldData, values) {
         field.children('.actions').find('.fa-times').remove()
     }
     if (!$field.find('.group-input-fields-content').hasClass('cama_skip_cf_rename_multiple'))
-      field.find('input, textarea, select').each(function() { $(this).attr('name', $(this).attr('name').replace('[]', '[' + fieldCounter + ']')) })
+      field.find('input, textarea, select').each(function () { $(this).attr('name', $(this).attr('name').replace('[]', '[' + fieldCounter + ']')) })
 
     if (fieldData.disabled) {
-      field.find('input, textarea, select').prop('readonly', true).filter('select').click(function() { return false }).focus(function() { $(this).blur() })
-      field.find('.btn').addClass('disabled').unbind().click(function() { return false })
+      field.find('input, textarea, select').prop('readonly', true).filter('select').click(function () { return false }).focus(function () { $(this).blur() })
+      field.find('.btn').addClass('disabled').unbind().click(function () { return false })
     }
 
     if (fieldData.kind === 'checkbox')
@@ -111,25 +111,25 @@ function CamaBuildCustomField(panel, fieldData, values) {
     if (fieldData.kind === 'checkbox')
       AddField(values[0])
     else {
-      $.each(values, function(i, value) {
+      $.each(values, function (i, value) {
         AddField(value)
       })
     }
   } else AddField(values)
 
   if (fieldData.multiple) { // sortable actions
-    panel.find('.field_multiple_btn .btn').click(function() { AddField(fieldData.default_value); return false })
-    panel.delegate('.actions .fa-times', 'click', function() { if (confirm(I18n('msg.delete_item'))) $(this).closest('.editor-custom-fields').remove(); return false })
+    panel.find('.field_multiple_btn .btn').click(function () { AddField(fieldData.default_value); return false })
+    panel.delegate('.actions .fa-times', 'click', function () { if (confirm(I18n('msg.delete_item'))) $(this).closest('.editor-custom-fields').remove(); return false })
     $sortable.sortable({
       handle: '.fa-arrows',
       items: ' > .editor-custom-fields',
-      start: function(e, ui) { // fix tinymce
-        $(ui.item).find('.mce-panel').each(function() {
+      start: function (e, ui) { // fix tinymce
+        $(ui.item).find('.mce-panel').each(function () {
           tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'))
         })
       },
-      stop: function(e, ui) { // fix tinymce
-        $(ui.item).find('.cama_restore_editor').each(function() {
+      stop: function (e, ui) { // fix tinymce
+        $(ui.item).find('.cama_restore_editor').each(function () {
           tinymce.execCommand('mceAddEditor', true, $(this).attr('id'))
         })
       }
@@ -159,7 +159,7 @@ function CustomFieldCheckboxVal($field, values) {
 // eslint-disable-next-line no-unused-vars
 function CustomFieldCheckboxesVal($field, values) {
   if ($field) {
-    const selector = values.map(function(value) {
+    const selector = values.map(function (value) {
       return "input[value='" + value + "']"
     }).join(',')
     $field.find(selector).prop('checked', true)
@@ -255,7 +255,7 @@ function LoadUploadAudioField(thiss) {
 
   $.fn.upload_filemanager({
     formats: 'audio',
-    selected: function(file, response) {
+    selected: function (file, response) {
       $input.val(file.url)
     }
   })
@@ -267,7 +267,7 @@ function LoadUploadFileField(thiss) {
 
   $.fn.upload_filemanager({
     formats: $input.data('formats') ? $input.data('formats') : '',
-    selected: function(file, response) {
+    selected: function (file, response) {
       $input.val(file.url)
     }
   })
@@ -279,7 +279,7 @@ function LoadUploadPrivateFileField(thiss) {
 
   $.fn.upload_filemanager({
     formats: $input.data('formats') ? $input.data('formats') : '',
-    selected: function(file, response) {
+    selected: function (file, response) {
       $input.val(file.url.split('?file=')[1].replace(/%2/g, '/'))
     },
     private: true
@@ -293,7 +293,7 @@ function LoadUploadImageField($input) {
     dimension: $input.attr('data-dimension') || '',
     versions: $input.attr('data-versions') || '',
     thumb_size: $input.attr('data-thumb_size') || '',
-    selected: function(file, response) {
+    selected: function (file, response) {
       $input.val(file.url).trigger('change')
     }
   })
@@ -326,7 +326,7 @@ function LoadUploadVideoField(thiss) {
   const $input = $(thiss).prev()
   $.fn.upload_filemanager({
     formats: 'video',
-    selected: function(file, response) {
+    selected: function (file, response) {
       $input.val(file.url)
     }
   })

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -18,7 +18,7 @@ function BuildCustomFieldGroup(fieldValues, groupId, fieldsData, isRepeat, field
       .find('input, textarea, select')
       .not('.code_style')
       .each(
-        function () {
+        function() {
           $(this).attr(
             'name', $(this).attr('name').replace(fieldNameGroup, fieldNameGroup + '[' + fieldGroupCounter + ']')
           )
@@ -38,27 +38,27 @@ function BuildCustomFieldGroup(fieldValues, groupId, fieldsData, isRepeat, field
     groupPanelBody.sortable({
       handle: '.move.fa-arrows',
       items: ' > .custom_sortable_grouped',
-      update: function () { groupPanel.trigger('update_custom_group_number') },
-      start: function (e, ui) { // fix tinymce
-        $(ui.item).find('.mce-panel').each(function () {
+      update: function() { groupPanel.trigger('update_custom_group_number') },
+      start: function(e, ui) { // fix tinymce
+        $(ui.item).find('.mce-panel').each(function() {
           tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'))
         })
       },
-      stop: function (e, ui) { // fix tinymce
-        $(ui.item).find('.cama_restore_editor').each(function () {
+      stop: function(e, ui) { // fix tinymce
+        $(ui.item).find('.cama_restore_editor').each(function() {
           tinymce.execCommand('mceAddEditor', true, $(this).attr('id'))
         })
       }
     })
     groupPanel.find('.btn.duplicate_cutom_group').click(AddGroup)
-    groupPanelBody.on('click', '.header-field-grouped .del', function () { if (confirm(I18n('msg.delete_item'))) $(this).closest('.custom_sortable_grouped').fadeOut('slow', function () { $(this).remove(); groupPanel.trigger('update_custom_group_number') }); return false })
-    groupPanelBody.on('click', '.header-field-grouped .toggleable', function () {
+    groupPanelBody.on('click', '.header-field-grouped .del', function() { if (confirm(I18n('msg.delete_item'))) $(this).closest('.custom_sortable_grouped').fadeOut('slow', function() { $(this).remove(); groupPanel.trigger('update_custom_group_number') }); return false })
+    groupPanelBody.on('click', '.header-field-grouped .toggleable', function() {
       if ($(this).hasClass('fa-angle-down')) $(this).removeClass('fa-angle-down').addClass('fa-angle-up').closest('.header-field-grouped').next().slideUp()
       else $(this).removeClass('fa-angle-up').addClass('fa-angle-down').closest('.header-field-grouped').next().slideDown()
       return false
     })
-    groupPanel.bind('update_custom_group_number', function () { $(this).find('.custom_sortable_grouped').each(function (index) { $(this).find('input.cama_custom_group_number').val(index) }) })
-    $.each(fieldValues, function (fieldVal, key) { AddGroup(this) })
+    groupPanel.bind('update_custom_group_number', function() { $(this).find('.custom_sortable_grouped').each(function(index) { $(this).find('input.cama_custom_group_number').val(index) }) })
+    $.each(fieldValues, function(fieldVal, key) { AddGroup(this) })
   } else
     AddGroup(fieldValues[0])
 }
@@ -85,11 +85,11 @@ function CamaBuildCustomField(panel, fieldData, values) {
         field.children('.actions').find('.fa-times').remove()
     }
     if (!$field.find('.group-input-fields-content').hasClass('cama_skip_cf_rename_multiple'))
-      field.find('input, textarea, select').each(function () { $(this).attr('name', $(this).attr('name').replace('[]', '[' + fieldCounter + ']')) })
+      field.find('input, textarea, select').each(function() { $(this).attr('name', $(this).attr('name').replace('[]', '[' + fieldCounter + ']')) })
 
     if (fieldData.disabled) {
-      field.find('input, textarea, select').prop('readonly', true).filter('select').click(function () { return false }).focus(function () { $(this).blur() })
-      field.find('.btn').addClass('disabled').unbind().click(function () { return false })
+      field.find('input, textarea, select').prop('readonly', true).filter('select').click(function() { return false }).focus(function() { $(this).blur() })
+      field.find('.btn').addClass('disabled').unbind().click(function() { return false })
     }
 
     if (fieldData.kind === 'checkbox')
@@ -111,25 +111,25 @@ function CamaBuildCustomField(panel, fieldData, values) {
     if (fieldData.kind === 'checkbox')
       AddField(values[0])
     else {
-      $.each(values, function (i, value) {
+      $.each(values, function(i, value) {
         AddField(value)
       })
     }
   } else AddField(values)
 
   if (fieldData.multiple) { // sortable actions
-    panel.find('.field_multiple_btn .btn').click(function () { AddField(fieldData.default_value); return false })
-    panel.delegate('.actions .fa-times', 'click', function () { if (confirm(I18n('msg.delete_item'))) $(this).closest('.editor-custom-fields').remove(); return false })
+    panel.find('.field_multiple_btn .btn').click(function() { AddField(fieldData.default_value); return false })
+    panel.delegate('.actions .fa-times', 'click', function() { if (confirm(I18n('msg.delete_item'))) $(this).closest('.editor-custom-fields').remove(); return false })
     $sortable.sortable({
       handle: '.fa-arrows',
       items: ' > .editor-custom-fields',
-      start: function (e, ui) { // fix tinymce
-        $(ui.item).find('.mce-panel').each(function () {
+      start: function(e, ui) { // fix tinymce
+        $(ui.item).find('.mce-panel').each(function() {
           tinymce.execCommand('mceRemoveEditor', false, $(this).next().addClass('cama_restore_editor').attr('id'))
         })
       },
-      stop: function (e, ui) { // fix tinymce
-        $(ui.item).find('.cama_restore_editor').each(function () {
+      stop: function(e, ui) { // fix tinymce
+        $(ui.item).find('.cama_restore_editor').each(function() {
           tinymce.execCommand('mceAddEditor', true, $(this).attr('id'))
         })
       }
@@ -159,7 +159,7 @@ function CustomFieldCheckboxVal($field, values) {
 // eslint-disable-next-line no-unused-vars
 function CustomFieldCheckboxesVal($field, values) {
   if ($field) {
-    const selector = values.map(function (value) {
+    const selector = values.map(function(value) {
       return "input[value='" + value + "']"
     }).join(',')
     $field.find(selector).prop('checked', true)
@@ -255,7 +255,7 @@ function LoadUploadAudioField(thiss) {
 
   $.fn.upload_filemanager({
     formats: 'audio',
-    selected: function (file, response) {
+    selected: function(file, response) {
       $input.val(file.url)
     }
   })
@@ -267,7 +267,7 @@ function LoadUploadFileField(thiss) {
 
   $.fn.upload_filemanager({
     formats: $input.data('formats') ? $input.data('formats') : '',
-    selected: function (file, response) {
+    selected: function(file, response) {
       $input.val(file.url)
     }
   })
@@ -279,7 +279,7 @@ function LoadUploadPrivateFileField(thiss) {
 
   $.fn.upload_filemanager({
     formats: $input.data('formats') ? $input.data('formats') : '',
-    selected: function (file, response) {
+    selected: function(file, response) {
       $input.val(file.url.split('?file=')[1].replace(/%2/g, '/'))
     },
     private: true
@@ -293,7 +293,7 @@ function LoadUploadImageField($input) {
     dimension: $input.attr('data-dimension') || '',
     versions: $input.attr('data-versions') || '',
     thumb_size: $input.attr('data-thumb_size') || '',
-    selected: function (file, response) {
+    selected: function(file, response) {
       $input.val(file.url).trigger('change')
     }
   })
@@ -326,7 +326,7 @@ function LoadUploadVideoField(thiss) {
   const $input = $(thiss).prev()
   $.fn.upload_filemanager({
     formats: 'video',
-    selected: function (file, response) {
+    selected: function(file, response) {
       $input.val(file.url)
     }
   })

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -21,40 +21,40 @@ function CamaGetTinymceSettings(settings) {
     remove_script_host: false,
     browser_spellcheck: true,
     language_url: tinymce_global_settings.language_url,
-    file_browser_callback: function (fieldName, url, type, win) {
+    file_browser_callback: function(fieldName, url, type, win) {
       $.fn.upload_filemanager({
         formats: type,
-        selected: function (file, response) {
+        selected: function(file, response) {
           $('#' + fieldName).val(file.url)
         }
       })
     },
     fix_list_elements: true,
-    setup: function (editor) {
-      editor.on('blur', function () {
+    setup: function(editor) {
+      editor.on('blur', function() {
         tinymce.triggerSave()
         $('textarea#' + editor.id).trigger('change')
       })
 
-      editor.on('PostProcess', function (ed) {
+      editor.on('PostProcess', function(ed) {
         ed.content = ed.content.replace(/(<p><\/p>)/gi, '<br />')
       })
 
       editor.ui.registry.addMenuItem('append_line', {
         text: 'New line at the end',
         context: 'insert',
-        onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-'); }
-      });
+        onclick: function() { editor.dom.add(editor.getBody(), 'p', {}, '-New line-') }
+      })
       editor.ui.registry.addMenuItem('add_line', {
         text: 'New line',
         context: 'insert',
-        onclick: function () { editor.insertContent('<p>-New line-</p>'); }
-      });
+        onclick: function() { editor.insertContent('<p>-New line-</p>') }
+      })
 
       // eval all extra setups
       for (const ff in tinymce_global_settings.setups) tinymce_global_settings.setups[ff](editor)
 
-      editor.on('init', function (e) {
+      editor.on('init', function(e) {
         for (const ff in tinymce_global_settings.init) tinymce_global_settings.init[ff](editor)
       })
     }

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -54,17 +54,10 @@ function CamaGetTinymceSettings(settings) {
       // eval all extra setups
       for (const ff in tinymce_global_settings.setups) tinymce_global_settings.setups[ff](editor)
 
-      editor.on('postRender', function (e) {
-        editor.settings.onPostRender(editor)
-        // eval all extra setups
-        for (const ff in tinymce_global_settings.post_render) tinymce_global_settings.post_render[ff](editor)
-      })
-
       editor.on('init', function (e) {
         for (const ff in tinymce_global_settings.init) tinymce_global_settings.init[ff](editor)
       })
-    },
-    onPostRender: function (editor) { }
+    }
   }
   for (const ff in tinymce_global_settings.settings) tinymce_global_settings.settings[ff](settings, def)
   return $.extend({}, def, settings)

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -21,50 +21,50 @@ function CamaGetTinymceSettings(settings) {
     remove_script_host: false,
     browser_spellcheck: true,
     language_url: tinymce_global_settings.language_url,
-    file_browser_callback: function(fieldName, url, type, win) {
+    file_browser_callback: function (fieldName, url, type, win) {
       $.fn.upload_filemanager({
         formats: type,
-        selected: function(file, response) {
+        selected: function (file, response) {
           $('#' + fieldName).val(file.url)
         }
       })
     },
     fix_list_elements: true,
-    setup: function(editor) {
-      editor.on('blur', function() {
+    setup: function (editor) {
+      editor.on('blur', function () {
         tinymce.triggerSave()
         $('textarea#' + editor.id).trigger('change')
       })
 
-      editor.on('PostProcess', function(ed) {
+      editor.on('PostProcess', function (ed) {
         ed.content = ed.content.replace(/(<p><\/p>)/gi, '<br />')
       })
 
-      editor.addMenuItem('append_line', {
+      editor.ui.registry.addMenuItem('append_line', {
         text: 'New line at the end',
         context: 'insert',
-        onclick: function() { editor.dom.add(editor.getBody(), 'p', {}, '-New line-') }
-      })
-      editor.addMenuItem('add_line', {
+        onclick: function () { editor.dom.add(editor.getBody(), 'p', {}, '-New line-'); }
+      });
+      editor.ui.registry.addMenuItem('add_line', {
         text: 'New line',
         context: 'insert',
-        onclick: function() { editor.insertContent('<p>-New line-</p>') }
-      })
+        onclick: function () { editor.insertContent('<p>-New line-</p>'); }
+      });
 
       // eval all extra setups
       for (const ff in tinymce_global_settings.setups) tinymce_global_settings.setups[ff](editor)
 
-      editor.on('postRender', function(e) {
+      editor.on('postRender', function (e) {
         editor.settings.onPostRender(editor)
         // eval all extra setups
         for (const ff in tinymce_global_settings.post_render) tinymce_global_settings.post_render[ff](editor)
       })
 
-      editor.on('init', function(e) {
+      editor.on('init', function (e) {
         for (const ff in tinymce_global_settings.init) tinymce_global_settings.init[ff](editor)
       })
     },
-    onPostRender: function(editor) {}
+    onPostRender: function (editor) { }
   }
   for (const ff in tinymce_global_settings.settings) tinymce_global_settings.settings[ff](settings, def)
   return $.extend({}, def, settings)

--- a/app/assets/javascripts/camaleon_cms/admin/_post.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_post.js
@@ -88,11 +88,11 @@ function CamaInitPost(obj) {
       }
 
       const $link = $('<div class="sl-slug-edit">' +
-                '<strong>' + I18n('msg.permalink') + ':&nbsp;</strong><span class="sl-link"></span> <span> &nbsp;&nbsp;</span>' +
-                '<a href="#" class="btn btn-default btn-xs btn-edit">' + I18n('button.edit') + '</a> &nbsp;&nbsp; ' +
-                '<a href="#" class="btn btn-info btn-xs btn-preview" target="_blank">' + I18n('msg.preview') + '</a> &nbsp;&nbsp; ' +
-                '<a href="#" class="btn btn-success btn-xs btn-view" style="display: none" target="_blank">' + I18n('msg.view_page') + '</a>' +
-                '</div>').hide()
+        '<strong>' + I18n('msg.permalink') + ':&nbsp;</strong><span class="sl-link"></span> <span> &nbsp;&nbsp;</span>' +
+        '<a href="#" class="btn btn-default btn-xs btn-edit">' + I18n('button.edit') + '</a> &nbsp;&nbsp; ' +
+        '<a href="#" class="btn btn-info btn-xs btn-preview" target="_blank">' + I18n('msg.preview') + '</a> &nbsp;&nbsp; ' +
+        '<a href="#" class="btn btn-success btn-xs btn-view" style="display: none" target="_blank">' + I18n('msg.view_page') + '</a>' +
+        '</div>').hide()
       $this.addClass('sluged')
       $this.after($link)
 
@@ -203,7 +203,7 @@ function CamaInitPost(obj) {
     }
   })
 
-  try { $('.tinymce_textarea:not(.translated-item)', $form).tinymce().destroy() } catch (e) {}
+  try { $('.tinymce_textarea:not(.translated-item)', $form).tinymce().destroy() } catch (e) { }
   tinymce.init(CamaGetTinymceSettings({
     selector: '.tinymce_textarea:not(.translated-item)',
     height: '480px',
@@ -326,7 +326,6 @@ function CamaInitPost(obj) {
 
   function GetHashForm() {
     tinymce.editors.forEach(function(editor) {
-      editor = tinymce.editors[editor]
       $('#' + editor.id).val(tinymce.get(editor.id).getContent()).trigger('change')
     })
 

--- a/app/assets/javascripts/camaleon_cms/admin/_translator.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_translator.js
@@ -1,13 +1,13 @@
 /* eslint-env jquery */
 jQuery(function($) {
-/**
- * TRANSLATOR PLUGIN
- *
- * Example:
- * var trans = jQuery("input[type='text'], textarea").not(":hidden").Translatable(["es", "en"])  ===> convert input/textarea into translatable panel
- *
- * trans.trigger("trans_integrate") ==> encode translations into owner element (destroy translation elements)
- */
+  /**
+   * TRANSLATOR PLUGIN
+   *
+   * Example:
+   * var trans = jQuery("input[type='text'], textarea").not(":hidden").Translatable(["es", "en"])  ===> convert input/textarea into translatable panel
+   *
+   * trans.trigger("trans_integrate") ==> encode translations into owner element (destroy translation elements)
+   */
 
   /**
      *
@@ -32,13 +32,11 @@ jQuery(function($) {
       let res = ''
       /* eslint-disable-next-line eqeqeq */
       if (!text || text.trim().search('<!--') != 0) { // not translated string
-        languages.forEach(function(i) { translationsPerLocale[languages[i]] = text })
-
+        languages.forEach(function(lang) { translationsPerLocale[lang] = text })
         res = translationsPerLocale
       } else { // has translations
         const splitted = text.split('<!--:-->')
-        splitted.forEach(function(i) {
-          const str = splitted[i]
+        splitted.forEach(function(str) {
           const mAtch = str.trim().match(/^<!--:([\w||-]{2,5})/)
           if (mAtch && mAtch.length === 2) {
             mAtch[1] = mAtch[1].replace('--', '')
@@ -71,22 +69,22 @@ jQuery(function($) {
       const translations = getTranslations(ele.is('select') ? ele.data('value') : ele.val()); const inputs = {}
       const classGroup = ele.parent().hasClass('form-group') ? '' : 'form-group'
       // decoding languages
-      languages.forEach(function(ii) {
-        const l = languages[ii]
-        const key = 'translation-' + l + '-' + translatorCounter
+      languages.forEach(function(lang) {
+        const firstLang = lang === languages[0]
+        const key = 'translation-' + lang + '-' + translatorCounter
         tabsTitle.push(
           /* eslint-disable-next-line eqeqeq */
-          '<li role="presentation" class="pull-right ' + (ii == 0 ? 'active' : '') + '"><a href="#pane-' + key + '" role="tab" data-toggle="tab">' + l.titleize() + '</a></li>'
+          '<li role="presentation" class="pull-right ' + (firstLang ? 'active' : '') + '"><a href="#pane-' + key + '" role="tab" data-toggle="tab">' + lang.titleize() + '</a></li>'
         )
         const clone = ele.clone(true)
-          .attr({ id: key, name: key, 'data-name': key, 'data-translation_l': l, 'data-translation': 'translation-' + l })
-          .addClass('translate-item').val(getTranslation(translations, l))
-        if (ii > 0 && !clone.hasClass('required_all_langs'))
+          .attr({ id: key, name: key, 'data-name': key, 'data-translation_l': lang, 'data-translation': 'translation-' + lang })
+          .addClass('translate-item').val(getTranslation(translations, lang))
+        if (!firstLang && !clone.hasClass('required_all_langs'))
           clone.removeClass('required') // to permit enter empty values for secondary languages
-        inputs[l] = clone
+        inputs[lang] = clone
         clone.wrap(
           /* eslint-disable-next-line eqeqeq */
-          "<div class='tab-pane " + classGroup + ' trans_tab_item ' + (ii == 0 ? 'active' : '') + "' id='pane-" + key + "'/>"
+          "<div class='tab-pane " + classGroup + ' trans_tab_item ' + (firstLang ? 'active' : '') + "' id='pane-" + key + "'/>"
         )
         tabsContent.push(clone.parent())
         translatorCounter++

--- a/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
+++ b/app/assets/javascripts/camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min.js
@@ -14,13 +14,13 @@ tinymce.PluginManager.add('filemanager', function(editor) {
             }
         });
     }
-    editor.addButton('filemanager', {
+    editor.ui.registry.addButton('filemanager', {
         icon: 'browse',
         tooltip: 'Insert file',
         onclick: openmanager,
         stateSelector: 'img:not([data-mce-object])'
     });
-    editor.addMenuItem('filemanager', {
+    editor.ui.registry.addMenuItem('filemanager', {
         icon: 'browse',
         text: 'Insert file',
         onclick: openmanager,

--- a/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
+++ b/app/assets/stylesheets/camaleon_cms/admin/_custom_admin.css.scss
@@ -16,32 +16,39 @@
 //************** Main content
 #admin_content {
   min-height: 400px;
+
   .panel {
-    &.panel-toggled > .panel-body {
+    &.panel-toggled>.panel-body {
       display: none;
     }
+
     .panel-heading {
       //overflow: hidden;
       position: relative;
+
       .panel-controls {
         float: right;
         list-style: outside none none;
         position: absolute;
         right: 26px;
         top: 5px;
+
         li {
           float: left;
+
           a {
             @include link_round();
           }
         }
       }
-      > .btn{
+
+      >.btn {
         position: absolute;
         right: 26px;
         top: 14px;
       }
     }
+
     .panel-footer {
       overflow: hidden;
     }
@@ -53,16 +60,21 @@
     font-size: 12px;
     vertical-align: middle;
   }
+
   // reset label inputs
   label {
-    input[type="radio"], input[type="checkbox"] {
+
+    input[type="radio"],
+    input[type="checkbox"] {
       margin-right: 4px;
     }
   }
+
   // category lists
   .categorychecklist {
     padding-left: 10px;
     list-style: none;
+
     ul {
       padding-left: 25px;
       list-style: none;
@@ -73,6 +85,7 @@
     .sl-slug-edit {
       margin-top: 4px;
     }
+
     .gallery-item-remove {
       position: absolute;
       margin-top: -22px;
@@ -84,12 +97,14 @@
     .inner {
       padding-top: 30px;
     }
+
     a {
       position: absolute;
       top: 4px;
       right: 5px;
       @include link_round(25);
       background: rgba(250, 250, 250, 0.4);
+
       &.edit_link {
         left: 5px;
         right: auto;
@@ -102,49 +117,57 @@
     padding: 0;
     margin: 0;
     white-space: nowrap;
-    & > * {
+
+    &>* {
       background-color: #fafafa;
       border: 1px solid #ddd;
       color: #777;
       padding: 6px 12px;
       margin: 0 -2px;
     }
+
     em {
       background-color: #337ab7;
       border-color: #337ab7;
       color: #fff;
       cursor: default;
     }
+
     span {
       cursor: not-allowed;
     }
   }
+
   form {
-    .form-group > .trans_panel{
+    .form-group>.trans_panel {
       margin-top: -25px;
     }
   }
 }
 
 //************** sidebar left
-#sidebar-menu{
+#sidebar-menu {
   z-index: 2;
 }
 
 //************** reset modals
-.modal, #admin_content {
+.modal,
+#admin_content {
   .btn_upload {
     cursor: pointer;
   }
+
   .input-append.date .input-group-addon {
     padding: 7px 0;
     width: 30px;
   }
-  .input-group.color{
+
+  .input-group.color {
     .input-group-addon {
       background-color: #ccc;
     }
-    .over_field + span{
+
+    .over_field+span {
       padding: 5px;
       position: absolute;
       right: 0;
@@ -158,10 +181,12 @@
     .nav-tabs .has-error {
       color: #a94442;
     }
+
     .tab-pane .has-error {
       border: 1px solid #a94442;
     }
   }
+
   .trans_panel {
     //fix for multilanguage tabs
     //margin-top: -25px;
@@ -170,28 +195,35 @@
   // custom fields render in forms
   .item-custom-field {
     margin-bottom: 15px;
-    > label {
+
+    >label {
       display: block;
-      .shortcode_field input{
+
+      .shortcode_field input {
         min-width: 250px;
       }
     }
-    .actions{
+
+    .actions {
       overflow: hidden;
       width: 67px;
       float: left;
+
       .fa {
         @include link_round;
       }
-      & + .group-input-fields-content {
+
+      &+.group-input-fields-content {
         margin-left: 75px;
       }
     }
   }
-  .custom_sortable_grouped .header-field-grouped{
+
+  .custom_sortable_grouped .header-field-grouped {
     padding: 5px;
     margin-bottom: 3px;
-    .fa{
+
+    .fa {
       @include link_round;
       display: inline-block;
       float: none;
@@ -200,23 +232,21 @@
 }
 
 //************** Main Header && intro js custom
-#main-header{
+#main-header {
   z-index: 4;
-  &.introjs-fixParent{
+
+  &.introjs-fixParent {
     width: 100%;
+
     .navbar {
       width: 100%;
     }
   }
+
   .logo img {
     max-width: 100%;
     max-height: 100%;
   }
-}
-
-//************** fix tinymce fullscreen
-div.mce-fullscreen{
-  z-index: 10;
 }
 
 #tab-information {
@@ -232,10 +262,11 @@ div.mce-fullscreen{
 }
 
 //************** custom loading style
-#cama_custom_loading{
+#cama_custom_loading {
   position: relative;
   z-index: 999999;
-  .back_spinner{
+
+  .back_spinner {
     position: fixed;
     z-index: 99998;
     width: 100%;
@@ -244,7 +275,8 @@ div.mce-fullscreen{
     background-color: #2D95BF;
     background-color: rgba(60, 141, 188, 0.2);
   }
-  .loader_spinner{
+
+  .loader_spinner {
     z-index: 99999;
     position: fixed;
     left: 50%;
@@ -259,7 +291,7 @@ div.mce-fullscreen{
 }
 
 // copy paste code style
-input.code_style{
+input.code_style {
   background-color: #f9f2f4;
   border-radius: 4px;
   color: #c7254e;
@@ -270,23 +302,28 @@ input.code_style{
 }
 
 // fix tab content padding
-.tab-content > .tab-pane{
+.tab-content>.tab-pane {
   padding-top: 5px;
 }
-.content-upload-plugin{
+
+.content-upload-plugin {
   min-height: 45px;
   position: relative;
-  .rm-file{
+
+  .rm-file {
     position: absolute;
     top: 100%;
     margin-top: -22px;
   }
-  img{
+
+  img {
     max-height: 100px;
     max-width: 200px;
   }
 }
-label.error, span.error{
+
+label.error,
+span.error {
   color: #a94442;
   font-size: 11px;
 }
@@ -296,8 +333,7 @@ label.error, span.error{
 
 // themes: index page
 .theme-card {
-  border: 1px 
-  solid #ddd; 
+  border: 1px solid #ddd;
   border-radius: 0;
   position: relative;
 
@@ -305,13 +341,13 @@ label.error, span.error{
     padding: 0;
 
     .theme-image {
-      width: 100%; 
+      width: 100%;
       height: 260px;
       background-size: cover;
     }
 
     &:hover {
-      & + .theme-description {
+      &+.theme-description {
         display: block;
       }
     }
@@ -334,14 +370,14 @@ label.error, span.error{
   }
 
   .panel-footer {
-    background-color: #fafafa; 
-    border: 0; 
-    border-radius: 0; 
-    box-shadow: inset 0 1px 0 rgba(0,0,0,.1);
+    background-color: #fafafa;
+    border: 0;
+    border-radius: 0;
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, .1);
     display: flex;
     justify-content: space-between;
     align-items: center;
-  
+
 
     .theme-name {
       font-size: 1.6rem;

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'will_paginate-bootstrap'
   s.add_dependency 'breadcrumbs_on_rails'
   s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'tinymce-rails', '< 5'
+  s.add_dependency 'tinymce-rails', '~> 5.1', '>= 5.1.4.1'
   s.add_dependency 'jquery-rails'
   s.add_dependency 'sass-rails'
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,8 +3,6 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-Rails.application.config.tinymce.install = :copy
-
 # Add additional assets to the asset load path
 Rails.application.config.assets.precompile += %w[camaleon_cms/*]
 # Rails.application.config.assets.precompile += %w( themes/*/assets/* )

--- a/spec/features/admin/settings_spec.rb
+++ b/spec/features/admin/settings_spec.rb
@@ -42,7 +42,7 @@ describe 'the Site Settings SideBar options', js: true do
       expect(webfont_icon_fetch_status('fa fa-cog', 'fontawesome-webfont', 'woff2')).to eql(200)
 
       within '#theme_settings_form' do
-        within '.mce-edit-area' do
+        within '.tox-edit-area' do
           within_frame do
             editor = page.find_by_id('tinymce')
             expect(editor.text).to eql('Copyright © 2015 - Camaleon CMS. All rights reservated.')
@@ -53,7 +53,7 @@ describe 'the Site Settings SideBar options', js: true do
         click_button 'Submit'
       end
 
-      within '.mce-edit-area' do
+      within '.tox-edit-area' do
         within_frame do
           editor = page.find_by_id('tinymce')
           expect(editor.text).to eql("Copyright © 2015 - Camaleon CMS. All rights reservated.#{added_text}")


### PR DESCRIPTION
This PR completes the upgrade of TinyMCE to v5, replacing #1035. It has been rebased on the v3 branch. One last consideration is whether the TinyMCE assets should be copied or compiled. We've switched it a couple of times. This PR chooses the compile option, but only because I did that for some reason when I first tried version 5 in 2020. It can be changed if needed.

For the next upgrade to v6, the tricky part is that the jQuery wrapper was removed from the gem, so we most likely have to change a bunch of code. We had discussed removing jQuery entirely and re-writing the frontend, so I'd like to hear ideas about that before diving into the next step.