### PR TITLE
Fix seo_canonical option to be translated for the frontend, and some optimizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ spec/dummy/**/*.sqlite3
 spec/support/fixtures/rails_tmp.png
 *.gem
 .tool-versions
+node_modules
+/tmp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,10 @@ RSpec/InstanceVariable:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/NestedGroups:
+  Enabled: true
+  Max: 5
+
 Style/Documentation:
   Enabled: false
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,3 +6,4 @@ Please email vulnerability reports to the maintainers:
 Email
 - owenperedo@gmail.com (Owen Peredo Diaz)
 - briantkephart@gmail.com (Brian Kephart)
+- branzeanu.aurel@gmail.com (Aurel Branzeanu)

--- a/app/helpers/camaleon_cms/frontend/application_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/application_helper.rb
@@ -25,7 +25,7 @@ module CamaleonCms
         if request.present?
           if options[:locale] == false
             options.delete(:locale)
-          elsif options[:locale].blank? && _current_site&.get_languages&.size > 1
+          elsif options[:locale].blank? && _current_site&.get_languages&.size&.>(1)
             options[:locale] = I18n.locale
           end
           if options[:locale].present? && _current_site&.get_languages&.first&.to_s == options[:locale].to_s

--- a/app/helpers/camaleon_cms/frontend/application_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/application_helper.rb
@@ -23,20 +23,20 @@ module CamaleonCms
         options = args.extract_options!
         _current_site = options.delete(:site) || current_site
         if request.present?
-          if options.include?(:locale) && options[:locale] == false
+          if options[:locale] == false
             options.delete(:locale)
-          elsif !options[:locale].present? && _current_site && _current_site.get_languages.size > 1
+          elsif options[:locale].blank? && _current_site&.get_languages&.size > 1
             options[:locale] = I18n.locale
           end
-          if options[:locale].present? && _current_site && _current_site.get_languages.first.to_s == options[:locale].to_s
+          if options[:locale].present? && _current_site&.get_languages&.first&.to_s == options[:locale].to_s
             options[:locale] =
               nil
           end
         end
 
         options.delete(:format) if PluginRoutes.system_info['skip_format_url'].present?
-        cama_current_site_host_port(options) unless options.keys.include?(:host)
-        send(url_to.gsub('-', '_'), *(args << options))
+        cama_current_site_host_port(options) unless options.key?(:host)
+        send(url_to.tr('-', '_'), *(args << options))
       end
     end
   end

--- a/app/helpers/camaleon_cms/frontend/seo_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/seo_helper.rb
@@ -9,31 +9,46 @@ module CamaleonCms
                   {}
                 elsif is_page?
                   { image: @cama_visited_post.the_thumb_url,
-                    title: "#{current_site.the_title} | #{@cama_visited_post.the_title}", description: @cama_visited_post.the_excerpt, keywords: @cama_visited_post.the_keywords, object: @cama_visited_post }
+                    title: "#{current_site.the_title} | #{@cama_visited_post.the_title}",
+                    description: @cama_visited_post.the_excerpt,
+                    keywords: @cama_visited_post.the_keywords,
+                    object: @cama_visited_post }
                 elsif is_ajax?
                   {}
                 elsif is_search?
                   { title: "#{current_site.the_title} | #{ct('search_title', default: 'Search')}" }
                 elsif is_post_type?
                   { image: @cama_visited_post_type.the_thumb_url,
-                    title: "#{current_site.the_title} | #{@cama_visited_post_type.the_title}", description: @cama_visited_post_type.the_excerpt, keywords: @cama_visited_post_type.the_keywords, object: @cama_visited_post_type }
+                    title: "#{current_site.the_title} | #{@cama_visited_post_type.the_title}",
+                    description: @cama_visited_post_type.the_excerpt,
+                    keywords: @cama_visited_post_type.the_keywords,
+                    object: @cama_visited_post_type }
                 elsif is_post_tag?
                   { title: "#{current_site.the_title} | #{@cama_visited_tag.the_title}",
-                    description: @cama_visited_tag.the_excerpt, keywords: @cama_visited_tag.the_keywords, object: @cama_visited_tag }
+                    description: @cama_visited_tag.the_excerpt,
+                    keywords: @cama_visited_tag.the_keywords,
+                    object: @cama_visited_tag }
                 elsif is_category?
                   { image: @cama_visited_category.the_thumb_url,
-                    title: "#{current_site.the_title} | #{@cama_visited_category.the_title}", description: @cama_visited_category.the_excerpt, keywords: @cama_visited_category.the_keywords, object: @cama_visited_category }
+                    title: "#{current_site.the_title} | #{@cama_visited_category.the_title}",
+                    description: @cama_visited_category.the_excerpt,
+                    keywords: @cama_visited_category.the_keywords,
+                    object: @cama_visited_category }
                 elsif is_profile?
                   { image: @user.the_avatar, title: "#{current_site.the_title} | #{@user.the_name}",
                     description: @user.the_slogan, object: @user }
                 else
                   {}
                 end
-        cama_build_seo(data2.merge(@_cama_seo_setting_values || {}).merge(data))
+        cama_build_seo(data2.merge!(@_cama_seo_setting_values || {}).merge(data))
       end
 
-      # permit to define seo attributes by code without hooks (check here for more attributes: https://github.com/kpumuk/meta-tags)
-      # @Sample: cama_seo_settings({title: "my custom title", description: "my descr", keywords: "my keywords", image: 'my img url'})
+      # permit to define seo attributes by code without hooks
+      # (check here for more attributes: https://github.com/kpumuk/meta-tags)
+      # @Sample:
+      # cama_seo_settings(
+      #   {title: "my custom title", description: "my descr", keywords: "my keywords", image: 'my img url'}
+      # )
       # This values will be shown within the_head(...)
       def cama_seo_settings(options)
         @_cama_seo_setting_values ||= {}
@@ -74,21 +89,22 @@ module CamaleonCms
           alternate: [
             { type: 'application/rss+xml', href: cama_rss_url }
           ],
-          canonical: current_site.get_option('seo_canonical')
-        }.merge(options.except(:object))
+          canonical: current_site.get_option('seo_canonical')&.translate
+        }.merge!(options.except(:object))
 
+        object_option = options[:object]
         l = current_site.get_languages
         if l.size > 1
           l.each do |lang|
             s[:alternate] << {
-              href: options[:object].present? ? options[:object].the_url(locale: lang) : current_site.the_url(locale: lang),
+              href: object_option.present? ? object_option.the_url(locale: lang) : current_site.the_url(locale: lang),
               hreflang: lang
             }
           end
         end
 
         # call all hooks for seo
-        r = { seo_data: s, object: options[:object] }
+        r = { seo_data: s, object: object_option }
         hooks_run('seo', r)
         r[:seo_data]
       end

--- a/lib/ext/translator.rb
+++ b/lib/ext/translator.rb
@@ -34,10 +34,9 @@ class String
   # sample: {es: "hola mundo", en: "Hello World"}
   def translations
     @translations ||= split_locales
-    @translations
   end
 
-  # return aray of translations for this string
+  # return array of translations for this string
   # sample: ["hola mundo", "Hello World"]
   def translations_array
     r = translations.map { |_key, value| value }

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CamaleonCms::Frontend::SeoHelper do
+  let(:host) { request_env['HTTP_HOST'] }
+  let(:request_env) { ActionDispatch::TestRequest.__send__(:default_env) }
+  let(:url_scheme) { request_env['rack.url_scheme']}
+
+  let!(:site) { create(:site, slug: host).decorate }
+
+  describe '#cama_the_seo' do
+    context 'the :canonical hash key value returned' do
+      context 'when no seo_canonical is specified for the site' do
+        it 'returns nil' do
+          result = helper.cama_the_seo
+
+          expect(result[:canonical]).to be_nil
+        end
+      end
+
+      context 'when seo_canonical is specified for the site and for the current locale (:en by default)' do
+        before { site.set_option('seo_canonical', "<!--:en-->https://#{host}/<!--:--><!--:es--><!--:-->") }
+
+        it 'returns the canonical url for the default language' do
+          result = helper.cama_the_seo
+
+          expect(result[:canonical]).to eql("https://#{host}/")
+        end
+      end
+
+      context 'when seo_canonical is specified for the site but not for the current locale' do
+        before { site.set_option('seo_canonical', "<!--:en-->https://#{host}/<!--:--><!--:es--><!--:-->") }
+
+        it 'returns an empty string as canonical url' do
+          I18n.locale = :es
+          result = helper.cama_the_seo
+
+          expect(result[:canonical]).to be_empty
+        end
+      end
+
+      context 'when seo_canonical is specified for the site and for the current, not default, locale' do
+        before do
+          site.set_option('seo_canonical', "<!--:en-->https://#{host}/<!--:--><!--:es-->https://#{host}/es<!--:-->")
+        end
+
+        it 'returns the canonical url for the current language' do
+          I18n.locale = :es
+          result = helper.cama_the_seo
+
+          expect(result[:canonical]).to eql("https://#{host}/es")
+        end
+      end
+    end
+
+    context 'when no site languages are specified' do
+      it 'returns the defaults for the english language' do
+        result = helper.cama_the_seo
+
+        expect(result[:alternate]).to eql(
+          [{ href: "#{url_scheme}://#{host}/rss", type: 'application/rss+xml' },
+           { href: "#{url_scheme}://#{host}/", hreflang: :en }]
+        )
+      end
+    end
+
+    context 'when there are site languages specified' do
+      before { site.set_meta("languages_site", [I18n.default_locale, :es]) }
+
+      it 'returns an array of alternates for all the languages' do
+        I18n.locale = :es
+        result = helper.cama_the_seo
+
+        expect(result[:alternate]).to eql(
+          [{ href: "#{url_scheme}://#{host}/rss", type: 'application/rss+xml' },
+           { href: "#{url_scheme}://#{host}/", hreflang: :en },
+           { href: "#{url_scheme}://#{host}/es", hreflang: :es }]
+        )
+      end
+    end
+  end
+end

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -5,12 +5,12 @@ require 'rails_helper'
 describe CamaleonCms::Frontend::SeoHelper do
   let(:host) { request_env['HTTP_HOST'] }
   let(:request_env) { ActionDispatch::TestRequest.__send__(:default_env) }
-  let(:url_scheme) { request_env['rack.url_scheme']}
+  let(:url_scheme) { request_env['rack.url_scheme'] }
 
   let!(:site) { create(:site, slug: host).decorate }
 
   describe '#cama_the_seo' do
-    context 'the :canonical hash key value returned' do
+    context 'with :canonical hash key value returned' do
       context 'when no seo_canonical is specified for the site' do
         it 'returns nil' do
           result = helper.cama_the_seo
@@ -55,18 +55,17 @@ describe CamaleonCms::Frontend::SeoHelper do
     end
 
     context 'when no site languages are specified' do
-      it 'returns the defaults for the english language' do
+      it "doesn't returns the an alternate hreflang" do
         result = helper.cama_the_seo
 
         expect(result[:alternate]).to eql(
-          [{ href: "#{url_scheme}://#{host}/rss", type: 'application/rss+xml' },
-           { href: "#{url_scheme}://#{host}/", hreflang: :en }]
+          [{ href: "#{url_scheme}://#{host}/rss", type: 'application/rss+xml' }]
         )
       end
     end
 
     context 'when there are site languages specified' do
-      before { site.set_meta("languages_site", [I18n.default_locale, :es]) }
+      before { site.set_meta('languages_site', [I18n.default_locale, :es]) }
 
       it 'returns an array of alternates for all the languages' do
         I18n.locale = :es


### PR DESCRIPTION
Currently, the canonical link, when it has different links on different languages, is generating a broken link:

```html
<link rel="canonical" href="[&lt;!--:en--&gt;https://florsan.md/&lt;!--:--&gt;&lt;!--:ru--&gt;https://florsan.md/ru&lt;!--:--&gt;&lt;!--:md--&gt;https://florsan.md/md&lt;!--:--&gt;](view-source:http://0.0.0.0:3000/%3C!--:en--%3Ehttps://florsan.md/%3C!--:--%3E%3C!--:ru--%3Ehttps://florsan.md/ru%3C!--:--%3E%3C!--:md--%3Ehttps://florsan.md/md%3C!--:--%3E)">
```

This PR is fixing it, calling `translate`: `current_site.get_option('seo_canonical')&.translate`

Also, some small performance optimizations were implemented.
