### PR TITLE
Refactor AR models to inherit from ApplicationRecord and extract the CommonRelationships concern

### DIFF
--- a/app/apps/plugins/attack/models/attack.rb
+++ b/app/apps/plugins/attack/models/attack.rb
@@ -1,7 +1,7 @@
 module Plugins
   module Attack
     module Models
-      class Attack < ApplicationRecord
+      class Attack < CamaleonRecord
         belongs_to :site, class_name: 'CamaleonCms::Site'
       end
     end

--- a/app/apps/plugins/attack/models/attack.rb
+++ b/app/apps/plugins/attack/models/attack.rb
@@ -1,7 +1,7 @@
 module Plugins
   module Attack
     module Models
-      class Attack < ActiveRecord::Base
+      class Attack < ApplicationRecord
         belongs_to :site, class_name: 'CamaleonCms::Site'
       end
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -57,11 +57,4 @@ class ApplicationRecord < ActiveRecord::Base
   def cama_build_cache_key(key)
     _key = "cama_cache_#{self.class.name}_#{id}_#{key}"
   end
-
-  # check if an attribute was changed
-  def cama_attr_changed?(attr_name)
-    return saved_change_to_attribute?(attr_name.to_sym) if methods.include?(:saved_change_to_attribute?)
-
-    send("#{attr_name}_changed?")
-  end
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,22 +3,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  def self.cama_define_common_relationships(key)
-    has_many :metas, -> { where(object_class: key) },
-             class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
-
-    has_many :custom_field_values, -> { where(object_class: key) },
-             class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
-
-    has_many :custom_fields, -> { where(object_class: key) },
-             class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
-
-    # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
-    # children groups
-    has_many :custom_field_groups, -> { where(object_class: key) },
-             class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
-  end
-
   # save cache value for this key
   def cama_set_cache(key, val)
     @cama_cache_vars ||= {}

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+
+  def self.cama_define_common_relationships(key)
+    has_many :metas, -> { where(object_class: key) },
+             class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
+
+    has_many :custom_field_values, -> { where(object_class: key) },
+             class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
+
+    has_many :custom_fields, -> { where(object_class: key) },
+             class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
+
+    # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
+    # children groups
+    has_many :custom_field_groups, -> { where(object_class: key) },
+             class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
+  end
+
+  # save cache value for this key
+  def cama_set_cache(key, val)
+    @cama_cache_vars ||= {}
+    @cama_cache_vars[cama_build_cache_key(key)] = val
+    val
+  end
+
+  # remove cache value for this key
+  def cama_remove_cache(key)
+    @cama_cache_vars.delete(cama_build_cache_key(key))
+  end
+
+  # fetch the cache value for this key
+  def cama_fetch_cache(key)
+    @cama_cache_vars ||= {}
+    _key = cama_build_cache_key(key)
+    if @cama_cache_vars.key?(_key)
+      # puts "*********** using model cache var: #{_key}"
+    else
+      @cama_cache_vars[_key] = yield
+    end
+    @cama_cache_vars[_key]
+  end
+
+  # return the cache value for this key
+  def cama_get_cache(key)
+    @cama_cache_vars ||= {}
+    begin
+      @cama_cache_vars[cama_build_cache_key(key)]
+    rescue StandardError
+      nil
+    end
+  end
+
+  # internal helper to generate cache key
+  def cama_build_cache_key(key)
+    _key = "cama_cache_#{self.class.name}_#{id}_#{key}"
+  end
+
+  # check if an attribute was changed
+  def cama_attr_changed?(attr_name)
+    return saved_change_to_attribute?(attr_name.to_sym) if methods.include?(:saved_change_to_attribute?)
+
+    send("#{attr_name}_changed?")
+  end
+end

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -8,8 +8,6 @@ module CamaleonCms
     scope :empty, -> { where(count: [0, nil]) } # return all categories that does not contain any post
     # scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
 
-    cama_define_common_relationships('Category')
-
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy
     belongs_to :parent, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, required: false

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class CustomField < ApplicationRecord
+  class CustomField < CamaleonRecord
     include CamaleonCms::Metas
 
     self.primary_key = :id

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class CustomField < ActiveRecord::Base
+  class CustomField < ApplicationRecord
     include CamaleonCms::Metas
 
     self.primary_key = :id

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class CustomFieldsRelationship < ActiveRecord::Base
+  class CustomFieldsRelationship < ApplicationRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}custom_fields_relationships"
 
     # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class,

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class CustomFieldsRelationship < ApplicationRecord
+  class CustomFieldsRelationship < CamaleonRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}custom_fields_relationships"
 
     # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class,

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class Media < ActiveRecord::Base
+  class Media < ApplicationRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}media"
 
     belongs_to :site, required: false

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class Media < ApplicationRecord
+  class Media < CamaleonRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}media"
 
     belongs_to :site, required: false

--- a/app/models/camaleon_cms/meta.rb
+++ b/app/models/camaleon_cms/meta.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class Meta < ActiveRecord::Base
+  class Meta < ApplicationRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}metas"
     # attr_accessible :objectid, :key, :value, :object_class
   end

--- a/app/models/camaleon_cms/meta.rb
+++ b/app/models/camaleon_cms/meta.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class Meta < ApplicationRecord
+  class Meta < CamaleonRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}metas"
     # attr_accessible :objectid, :key, :value, :object_class
   end

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -3,7 +3,6 @@ module CamaleonCms
     default_scope { where(taxonomy: :nav_menu).order(id: :asc) }
     alias_attribute :site_id, :parent_id
 
-    cama_define_common_relationships('NavMenu')
     has_many :children, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id, dependent: :destroy,
                         inverse_of: :parent
     belongs_to :site, foreign_key: :parent_id, inverse_of: :nav_menus, required: false

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -9,7 +9,6 @@ module CamaleonCms
     #
     default_scope { where(taxonomy: :nav_menu_item).order(id: :asc) }
 
-    cama_define_common_relationships('NavMenuItem')
     belongs_to :parent, class_name: 'CamaleonCms::NavMenu', inverse_of: :children, required: false
     belongs_to :parent_item, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id, inverse_of: :children,
                              required: false

--- a/app/models/camaleon_cms/plugin.rb
+++ b/app/models/camaleon_cms/plugin.rb
@@ -7,7 +7,6 @@ module CamaleonCms
 
     attr_accessor :error
 
-    cama_define_common_relationships('Plugin')
     belongs_to :site, foreign_key: :parent_id, required: false
 
     default_scope { where(taxonomy: :plugin) }

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -4,7 +4,6 @@ module CamaleonCms
 
     alias_attribute :post_type_id, :taxonomy_id
     default_scope -> { where(post_class: 'Post').order(post_order: :asc, created_at: :desc) }
-    cama_define_common_relationships('Post')
 
     # DEPRECATED
     has_many :post_relationships, class_name: 'CamaleonCms::PostRelationship', foreign_key: :objectid,

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class PostComment < ActiveRecord::Base
+  class PostComment < ApplicationRecord
     include CamaleonCms::Metas
 
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}comments"

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class PostComment < ApplicationRecord
+  class PostComment < CamaleonRecord
     include CamaleonCms::Metas
     include CommonRelationships
 

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -1,6 +1,7 @@
 module CamaleonCms
   class PostComment < ApplicationRecord
     include CamaleonCms::Metas
+    include CommonRelationships
 
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}comments"
     # attr_accessible :user_id, :post_id, :content, :author, :author_email, :author_url, :author_IP, :approved, :agent, :agent, :typee, :comment_parent, :is_anonymous
@@ -9,7 +10,6 @@ module CamaleonCms
     # default_scope order('comments.created_at ASC')
     # approved: approved | pending | spam
 
-    cama_define_common_relationships('PostComment')
     has_many :children, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, dependent: :destroy
     belongs_to :post, required: false
     belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, required: false

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class PostDefault < ActiveRecord::Base
+  class PostDefault < ApplicationRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
 

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -2,6 +2,7 @@ module CamaleonCms
   class PostDefault < ApplicationRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
+    include CommonRelationships
 
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}posts"
 

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class PostDefault < ApplicationRecord
+  class PostDefault < CamaleonRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
     include CommonRelationships

--- a/app/models/camaleon_cms/post_relationship.rb
+++ b/app/models/camaleon_cms/post_relationship.rb
@@ -1,6 +1,6 @@
 # DEPRECATED MODEL, NOT USED ANY MORE
 module CamaleonCms
-  class PostRelationship < ApplicationRecord
+  class PostRelationship < CamaleonRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_relationships"
     # attr_accessible :objectid, :term_taxonomy_id, :term_order
     default_scope -> { order(term_order: :asc) }

--- a/app/models/camaleon_cms/post_relationship.rb
+++ b/app/models/camaleon_cms/post_relationship.rb
@@ -1,6 +1,6 @@
 # DEPRECATED MODEL, NOT USED ANY MORE
 module CamaleonCms
-  class PostRelationship < ActiveRecord::Base
+  class PostRelationship < ApplicationRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_relationships"
     # attr_accessible :objectid, :term_taxonomy_id, :term_order
     default_scope -> { order(term_order: :asc) }

--- a/app/models/camaleon_cms/post_tag.rb
+++ b/app/models/camaleon_cms/post_tag.rb
@@ -2,7 +2,6 @@ module CamaleonCms
   class PostTag < CamaleonCms::TermTaxonomy
     default_scope { where(taxonomy: :post_tag) }
 
-    cama_define_common_relationships('PostTag')
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     belongs_to :post_type, foreign_key: :parent_id, inverse_of: :post_tags, required: false
     belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, required: false

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -24,7 +24,8 @@ module CamaleonCms
     after_create :set_default_site_user_roles
     after_create :refresh_routes
     after_destroy :refresh_routes
-    after_update :check_refresh_routes
+    after_update :refresh_routes,
+                 if: proc { |obj| obj.destroyed_by_association.blank? && obj.saved_change_to_attribute?(:slug) }
     before_update :default_category
 
     # check if current post type manage categories
@@ -187,12 +188,7 @@ module CamaleonCms
 
     # reload routes to enable this post type url, like: http://localhost/my-slug
     def refresh_routes
-      PluginRoutes.reload unless destroyed_by_association.present?
-    end
-
-    # check if slug was changed
-    def check_refresh_routes
-      refresh_routes if cama_attr_changed?(:slug)
+      PluginRoutes.reload
     end
   end
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -2,7 +2,7 @@ module CamaleonCms
   class PostType < CamaleonCms::TermTaxonomy
     alias_attribute :site_id, :parent_id
     default_scope { where(taxonomy: :post_type) }
-    cama_define_common_relationships('PostType')
+
     has_many :categories, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type_parent
     has_many :post_tags, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type
     has_many :posts, foreign_key: :taxonomy_id, dependent: :destroy, inverse_of: :post_type

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -7,7 +7,6 @@ module CamaleonCms
 
     default_scope { where(taxonomy: :site).reorder(term_group: :desc) }
 
-    cama_define_common_relationships('Site')
     has_many :post_types, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, dependent: :destroy
     has_many :nav_menus, class_name: 'CamaleonCms::NavMenu', foreign_key: :parent_id, dependent: :destroy,
                          inverse_of: :site

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class TermRelationship < ActiveRecord::Base
+  class TermRelationship < ApplicationRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_relationships"
     default_scope -> { order(term_order: :asc) }
 

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class TermRelationship < ApplicationRecord
+  class TermRelationship < CamaleonRecord
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_relationships"
     default_scope -> { order(term_order: :asc) }
 

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -2,6 +2,7 @@ module CamaleonCms
   class TermTaxonomy < ApplicationRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
+    include CommonRelationships
 
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}term_taxonomy"
     # attr_accessible :taxonomy, :description, :parent_id, :count, :name, :slug, :term_group, :status, :term_order, :user_id

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class TermTaxonomy < ActiveRecord::Base
+  class TermTaxonomy < ApplicationRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
 

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -1,5 +1,5 @@
 module CamaleonCms
-  class TermTaxonomy < ApplicationRecord
+  class TermTaxonomy < CamaleonRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
     include CommonRelationships

--- a/app/models/camaleon_cms/theme.rb
+++ b/app/models/camaleon_cms/theme.rb
@@ -2,7 +2,6 @@ module CamaleonCms
   class Theme < CamaleonCms::TermTaxonomy
     # attrs:
     #   slug => plugin key
-    cama_define_common_relationships('Theme')
     belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, required: false
 
     default_scope { where(taxonomy: :theme) }

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -1,6 +1,6 @@
 unless PluginRoutes.static_system_info['user_model'].present?
   module CamaleonCms
-    class User < ApplicationRecord
+    class User < CamaleonRecord
       include CamaleonCms::UserMethods
 
       self.table_name = PluginRoutes.static_system_info['cama_users_db_table'] || "#{PluginRoutes.static_system_info['db_prefix']}users"

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -1,6 +1,6 @@
 unless PluginRoutes.static_system_info['user_model'].present?
   module CamaleonCms
-    class User < ActiveRecord::Base
+    class User < ApplicationRecord
       include CamaleonCms::UserMethods
 
       self.table_name = PluginRoutes.static_system_info['cama_users_db_table'] || "#{PluginRoutes.static_system_info['db_prefix']}users"

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -3,7 +3,7 @@ module CamaleonCms
     after_destroy :set_users_as_cilent
 
     default_scope { where(taxonomy: :user_roles) }
-    cama_define_common_relationships('UserRole')
+
     belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, required: false
 
     def roles_post_type

--- a/app/models/camaleon_record.rb
+++ b/app/models/camaleon_record.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-class ApplicationRecord < ActiveRecord::Base
+class CamaleonRecord < ActiveRecord::Base
+  include ActiveRecordExtras::Relation
+
   self.abstract_class = true
 
   # save cache value for this key

--- a/app/models/concerns/camaleon_cms/common_relationships.rb
+++ b/app/models/concerns/camaleon_cms/common_relationships.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  module CommonRelationships
+    extend ActiveSupport::Concern
+
+    included do
+      class_name = self.class.name.demodulize
+      has_many :metas, -> { where(object_class: class_name) },
+               class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
+
+      has_many :custom_field_values, -> { where(object_class: class_name) },
+               class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
+
+      has_many :custom_fields, -> { where(object_class: class_name) },
+               class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
+
+      # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
+      # children groups
+      has_many :custom_field_groups, -> { where(object_class: class_name) },
+               class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
+    end
+  end
+end

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -4,6 +4,7 @@ module CamaleonCms
     included do
       include CamaleonCms::Metas
       include CamaleonCms::CustomFieldsRead
+      include CommonRelationships
 
       validates_uniqueness_of :username, scope: [:site_id], case_sensitive: false,
                                          message: I18n.t('camaleon_cms.admin.users.message.requires_different_username', default: 'Requires different username')
@@ -19,7 +20,6 @@ module CamaleonCms
       before_update { generate_token :auth_token if will_save_change_to_password_digest? }
 
       # relations
-      cama_define_common_relationships('User')
       has_many :all_posts, class_name: 'CamaleonCms::Post', foreign_key: :user_id
       has_many :all_comments, class_name: 'CamaleonCms::PostComment'
       belongs_to :site, class_name: 'CamaleonCms::Site', optional: true

--- a/config/initializers/active_record_extension.rb
+++ b/config/initializers/active_record_extension.rb
@@ -20,8 +20,6 @@ module ActiveRecordExtras
   end
 end
 
-ActiveRecord::Base.include ActiveRecordExtras::Relation
-
 ActiveRecord::Associations::CollectionProxy.class_eval do
   # order a collection by custom fields
   # Arguments:

--- a/config/initializers/active_record_extension.rb
+++ b/config/initializers/active_record_extension.rb
@@ -29,9 +29,10 @@ ActiveRecord::Associations::CollectionProxy.class_eval do
   # order: (String) order direction (ASC | DESC)
   # sample: CamaleonCms::Site.first.posts.sort_by_field("untitled-field-attributes", "desc")
   def sort_by_field(key, order = 'ASC')
-    joins("LEFT OUTER JOIN #{CamaleonCms::CustomFieldsRelationship.table_name} ON #{CamaleonCms::CustomFieldsRelationship.table_name}.objectid = #{build.class.table_name}.id").where(
-      "#{CamaleonCms::CustomFieldsRelationship.table_name}.custom_field_slug = ? and #{CamaleonCms::CustomFieldsRelationship.table_name}.object_class = ?", key, build.class.name.parseCamaClass
-    ).reorder("#{CamaleonCms::CustomFieldsRelationship.table_name}.value #{order}")
+    cfr_table = CamaleonCms::CustomFieldsRelationship.table_name
+    joins("LEFT OUTER JOIN #{cfr_table} ON #{cfr_table}.objectid = #{build.class.table_name}.id").where(
+      "#{cfr_table}.custom_field_slug = ? and #{cfr_table}.object_class = ?", key, build.class.name.parseCamaClass
+    ).reorder("#{cfr_table}.value #{order}")
   end
 
   # Filter by custom field values
@@ -39,83 +40,15 @@ ActiveRecord::Associations::CollectionProxy.class_eval do
   # key: (String) Custom field key
   # sample: my_posts_that_include_my_field = CamaleonCms::Site.first.posts.filter_by_field("untitled-field-attributes")
   #   this will return all posts of the first site that include custom field "untitled-field-attributes"
-  #   additionally, you can add extra filter: my_posts_that_include_my_field.where("#{CamaleonCms::CustomFieldsRelationship.table_name}.value=?", "my_value_for_field")
+  #   additionally, you can add extra filter:
+  # my_posts_that_include_my_field
+  #   .where("#{CamaleonCms::CustomFieldsRelationship.table_name}.value=?", "my_value_for_field")
   def filter_by_field(key, args = {})
-    res = joins("LEFT OUTER JOIN #{CamaleonCms::CustomFieldsRelationship.table_name} ON #{CamaleonCms::CustomFieldsRelationship.table_name}.objectid = #{build.class.table_name}.id").where(
-      "#{CamaleonCms::CustomFieldsRelationship.table_name}.custom_field_slug = ? and #{CamaleonCms::CustomFieldsRelationship.table_name}.object_class = ?", key, build.class.name.parseCamaClass
+    cfr_table = CamaleonCms::CustomFieldsRelationship.table_name
+    res = joins("LEFT OUTER JOIN #{cfr_table} ON #{cfr_table}.objectid = #{build.class.table_name}.id").where(
+      "#{cfr_table}.custom_field_slug = ? and #{cfr_table}.object_class = ?", key, build.class.name.parseCamaClass
     )
-    res = res.where("#{CamaleonCms::CustomFieldsRelationship.table_name}.value = ?", args[:value]) if args[:value]
+    res = res.where("#{cfr_table}.value = ?", args[:value]) if args[:value]
     res
-  end
-end
-
-ActiveSupport.on_load(:active_record) do
-  module ActiveRecord
-    class Base
-      def self.cama_define_common_relationships(key)
-        has_many :metas, lambda {
-                           where(object_class: key)
-                         }, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
-        has_many :custom_field_values, lambda {
-                                         where(object_class: key)
-                                       }, class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
-        has_many :custom_fields, lambda {
-                                   where(object_class: key)
-                                 }, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
-
-        # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or children groups
-        has_many :custom_field_groups, lambda {
-                                         where(object_class: key)
-                                       }, class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
-      end
-
-      # save cache value for this key
-      def cama_set_cache(key, val)
-        @cama_cache_vars ||= {}
-        @cama_cache_vars[cama_build_cache_key(key)] = val
-        val
-      end
-
-      # remove cache value for this key
-      def cama_remove_cache(key)
-        @cama_cache_vars.delete(cama_build_cache_key(key))
-      end
-
-      # fetch the cache value for this key
-      def cama_fetch_cache(key)
-        @cama_cache_vars ||= {}
-        _key = cama_build_cache_key(key)
-        if @cama_cache_vars.key?(_key)
-          # puts "*********** using model cache var: #{_key}"
-        else
-          @cama_cache_vars[_key] = yield
-        end
-        @cama_cache_vars[_key]
-      end
-
-      # return the cache value for this key
-      def cama_get_cache(key)
-        @cama_cache_vars ||= {}
-        begin
-          @cama_cache_vars[cama_build_cache_key(key)]
-        rescue StandardError
-          nil
-        end
-      end
-
-      # internal helper to generate cache key
-      def cama_build_cache_key(key)
-        _key = "cama_cache_#{self.class.name}_#{id}_#{key}"
-      end
-
-      # check if an attribute was changed
-      def cama_attr_changed?(attr_name)
-        if methods.include?(:saved_change_to_attribute?)
-          saved_change_to_attribute?(attr_name.to_sym)
-        else
-          send("#{attr_name}_changed?")
-        end
-      end
-    end
   end
 end

--- a/lib/generators/camaleon_cms/gem_plugin_template/app/models/plugins/my_plugin/my_plugin.rb
+++ b/lib/generators/camaleon_cms/gem_plugin_template/app/models/plugins/my_plugin/my_plugin.rb
@@ -1,4 +1,4 @@
-# class Plugins::PluginClass::PluginClass < ActiveRecord::Base
+# class Plugins::PluginClass::PluginClass < ApplicationRecord
 # belongs_to :site, class_name: "CamleonCms::Site"
 
 # here create your models normally

--- a/lib/generators/camaleon_cms/gem_plugin_template/app/models/plugins/my_plugin/my_plugin.rb
+++ b/lib/generators/camaleon_cms/gem_plugin_template/app/models/plugins/my_plugin/my_plugin.rb
@@ -1,4 +1,4 @@
-# class Plugins::PluginClass::PluginClass < ApplicationRecord
+# class Plugins::PluginClass::PluginClass < CamaleonRecord
 # belongs_to :site, class_name: "CamleonCms::Site"
 
 # here create your models normally


### PR DESCRIPTION
## Changes

- Move common AR methods from ActiveRecord::Base to ApplicationRecord
  - AR models now inherit from ApplicationRecord
- Remove cama_attr_changed? method used to detect Rails 4 - as from Rails 6 just use the `ActiveRecord::AttributeMethods::Dirty.saved_change_to_attribute?`
  - DRY a bit the PostType and Site models using conditional callbacks
- Refactor the AR class method `cama_define_common_relationships` into the `CommonRelationships` AR Concern included only where it is necessary