### PR TITLE
Revert renaming to camelCase functions used in ERB - doesn't work

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+/* eslint camelcase: ["error", {properties: "never", ignoreGlobals: true}] */
+
 module.exports = {
   env: {
     browser: true,
@@ -35,15 +37,15 @@ module.exports = {
   },
   globals: {
     ADMIN_TRANSLATIONS: true,
-    CamaGetTinymceSettings: true,
+    cama_get_tinymce_settings: true,
     CURRENT_LOCALE: true,
     define: true,
     I18n: true,
-    InitFormValidations: true,
+    init_form_validations: true,
     hideLoading: true,
     introJs: true,
-    ModalFixMultiple: true,
-    OpenModal: true,
+    modal_fix_multiple: true,
+    open_modal: true,
     root_admin_url: true,
     showLoading: true,
     slugFunc: true,

--- a/app/assets/javascripts/camaleon_cms/admin/_actions.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_actions.js
@@ -1,19 +1,21 @@
 /* eslint-env jquery */
 jQuery(document).on('ready page:changed', function() {
   // initialize all validations for forms
-  InitFormValidations()
+  init_form_validations()
   setTimeout(PageActions, 1000)
-  if (!$('body').attr('data-intro')) setTimeout(InitIntro, 500)
+  if (!$('body').attr('data-intro')) setTimeout(init_intro, 500)
 })
 
 // show admin intro presentation
-function InitIntro() {
+// eslint-disable-next-line camelcase
+function init_intro() {
   const finish = function() {
     $.get(root_admin_url + '/ajax', { mode: 'save_intro' })
     const layer = $('.introjs-overlay').clone()
-    const of = $('.introjs-tooltip').offset()
-    const c = $('.introjs-tooltip')
-      .clone().css($.extend({}, { 'min-width': '0', position: 'absolute', overflow: 'hidden', zIndex: 9999999 }, of))
+    const introTooptip = $('.introjs-tooltip')
+    const of = introTooptip.offset()
+    const c = introTooptip.clone()
+      .css($.extend({}, { 'min-width': '0', position: 'absolute', overflow: 'hidden', zIndex: 9999999 }, of))
 
     $('html, body').animate({ scrollTop: $('body').height() }, 0)
     setTimeout(function() {
@@ -99,8 +101,8 @@ Object.size = function(obj) {
 
 // this is a fix for multiples modals when a modal was closed (reactivate scroll for next modal)
 // fix for boostrap multiple modals problem
-// eslint-disable-next-line no-unused-vars
-function ModalFixMultiple() {
+// eslint-disable-next-line no-unused-vars,camelcase
+function modal_fix_multiple() {
   const activeModal = $('.modal.in:last', 'body').data('bs.modal')
 
   if (activeModal) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -1,7 +1,8 @@
 // build custom field groups with values recovered from DB received in field_values
 /* eslint-env jquery */
-// eslint-disable-next-line no-unused-vars
-function BuildCustomFieldGroup(fieldValues, groupId, fieldsData, isRepeat, fieldNameGroup) {
+
+// eslint-disable-next-line no-unused-vars,camelcase
+function build_custom_field_group(fieldValues, groupId, fieldsData, isRepeat, fieldNameGroup) {
   if (fieldValues.length === 0)
     fieldValues = [{}]
 
@@ -143,21 +144,21 @@ function CustomFieldColorpicker($field) {
     $field.find('.my-colorpicker').colorpicker()
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldColorpickerVal($field, value) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_colorpicker_val($field, value) {
   if ($field)
     $field.find('.my-colorpicker').attr('data-color', value || '').colorpicker()
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldCheckboxVal($field, values) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_checkbox_val($field, values) {
   if (values === 't') values = 1 // fix for values saved as true
   if ($field)
     $field.find('input[value="' + values + '"]').prop('checked', true)
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldCheckboxesVal($field, values) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_checkboxs_val($field, values) {
   if ($field) {
     const selector = values.map(function(value) {
       return "input[value='" + value + "']"
@@ -166,8 +167,8 @@ function CustomFieldCheckboxesVal($field, values) {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldDate($field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_date($field) {
   if ($field) {
     const box = $field.find('.date-input-box')
     if (box.hasClass('is_datetimepicker'))
@@ -177,8 +178,8 @@ function CustomFieldDate($field) {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldEditor($field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_editor($field) {
   if ($field) {
     const id = 't_' + Math.floor((Math.random() * 100000) + 1) + '_area'
     const textarea = $field.find('textarea').attr('id', id)
@@ -188,7 +189,7 @@ function CustomFieldEditor($field) {
       const inputs = textarea.data('translation_inputs')
       if (inputs) { // multiples languages
         for (const lang in inputs) {
-          tinymce.init(CamaGetTinymceSettings({
+          tinymce.init(cama_get_tinymce_settings({
             selector: '#' + inputs[lang].attr('id'),
             height: 120
           }))
@@ -196,15 +197,15 @@ function CustomFieldEditor($field) {
         return
       }
     }
-    tinymce.init(CamaGetTinymceSettings({
+    tinymce.init(cama_get_tinymce_settings({
       selector: '#' + id,
       height: 120
     }))
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldFieldAttrsVal($field, value) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_field_attrs_val($field, value) {
   if ($field) {
     value = value || '{}'
     const data = typeof (value) === 'object' ? value : $.parseJSON(value)
@@ -214,34 +215,34 @@ function CustomFieldFieldAttrsVal($field, value) {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldRadioVal($field, value) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_radio_val($field, value) {
   if ($field) {
     $field.find('input').prop('checked', false)
     $field.find("input[value='" + value + "']").prop('checked', true)
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldTextArea($field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_text_area($field) {
   if ($field && $field.find('textarea').hasClass('is_translate'))
     $field.find('textarea').addClass('translatable').Translatable(ADMIN_TRANSLATIONS)
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldTextBox($field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_text_box($field) {
   if ($field && $field.find('input').hasClass('is_translate'))
     $field.find('input').addClass('translatable').Translatable(ADMIN_TRANSLATIONS)
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldUrlCallback($field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_url_callback($field) {
   if ($field && $field.find('input').hasClass('is_translate'))
     $field.find('input').addClass('translatable').Translatable(ADMIN_TRANSLATIONS)
 }
 
-// eslint-disable-next-line no-unused-vars
-function CustomFieldSelectCallback($field, val) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function custom_field_select_callback($field, val) {
   if ($field) {
     const sel = $field.find('select.input-value')
     if (!val) sel.data('value', sel.val()) // fix for select translator
@@ -249,8 +250,8 @@ function CustomFieldSelectCallback($field, val) {
   }
 }
 
-// eslint-disable-next-line no-unused-vars
-function LoadUploadAudioField(thiss) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function load_upload_audio_field(thiss) {
   const $input = $(thiss).prev()
 
   $.fn.upload_filemanager({
@@ -261,8 +262,8 @@ function LoadUploadAudioField(thiss) {
   })
 }
 
-// eslint-disable-next-line no-unused-vars
-function LoadUploadFileField(thiss) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function load_upload_file_field(thiss) {
   const $input = $(thiss).prev()
 
   $.fn.upload_filemanager({
@@ -273,8 +274,8 @@ function LoadUploadFileField(thiss) {
   })
 }
 
-// eslint-disable-next-line no-unused-vars
-function LoadUploadPrivateFileField(thiss) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function load_upload_private_file_field(thiss) {
   const $input = $(thiss).prev()
 
   $.fn.upload_filemanager({
@@ -286,8 +287,8 @@ function LoadUploadPrivateFileField(thiss) {
   })
 }
 
-// eslint-disable-next-line no-unused-vars
-function LoadUploadImageField($input) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function load_upload_image_field($input) {
   $.fn.upload_filemanager({
     formats: 'image',
     dimension: $input.attr('data-dimension') || '',
@@ -300,8 +301,8 @@ function LoadUploadImageField($input) {
 }
 
 // permit to show preview image of image custom fields
-// eslint-disable-next-line no-unused-vars
-function CamaCustomFieldImageChanged(field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function cama_custom_field_image_changed(field) {
   if (field.val()) {
     field.closest('.input-group')
       .append(
@@ -315,14 +316,14 @@ function CamaCustomFieldImageChanged(field) {
     field.closest('.input-group').find('.custom_field_image_preview').remove()
 }
 
-// eslint-disable-next-line no-unused-vars
-function CamaCustomFieldImageRemove(field) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function cama_custom_field_image_remove(field) {
   field.val('')
   field.closest('.input-group').find('.custom_field_image_preview').remove()
 }
 
-// eslint-disable-next-line no-unused-vars
-function LoadUploadVideoField(thiss) {
+// eslint-disable-next-line no-unused-vars,camelcase
+function load_upload_video_field(thiss) {
   const $input = $(thiss).prev()
   $.fn.upload_filemanager({
     formats: 'video',

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -1,6 +1,7 @@
 /* eslint-env jquery */
+/* eslint camelcase: ["error", {properties: "never", ignoreGlobals: true, allow: ["cama_get_tinymce_settings"]}] */
 // eslint-disable-next-line no-unused-vars
-function CamaGetTinymceSettings(settings) {
+function cama_get_tinymce_settings(settings) {
   if (!settings) settings = {}
   const def = {
     selector: '.tinymce_textarea',

--- a/app/assets/javascripts/camaleon_cms/admin/_libraries.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_libraries.js
@@ -23,8 +23,8 @@ jQuery(function() {
 // panel can be a object: $("#my_form")
 // if panel is null, then this will be replaced by body
 // args: {validate_settings}
-/* eslint-disable-next-line no-unused-vars */
-const InitFormValidations = function(form, args) {
+/* eslint-disable-next-line no-unused-vars,camelcase */
+const init_form_validations = function(form, args) {
   args = args || {};
   // slug management
   // you need to add class no_translate to avoid translations in slugs

--- a/app/assets/javascripts/camaleon_cms/admin/_modal.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_modal.js
@@ -3,7 +3,7 @@
  * add events to links for open their content by ajax into modal
  * use: <a class='my_link' href='mylink' title='my title' data-show_footer='true'>
  * $(".my_link").ajax_modal({settings});
- * settings: check OpenModal(settings)
+ * settings: check open_modal(settings)
  */
 /* eslint-env jquery */
 jQuery(function() {
@@ -14,7 +14,7 @@ jQuery(function() {
       const def = { title: title || $(this).data('title'), mode: 'ajax', url: $(this).attr('href'), show_footer: $(this).data('show_footer') }
       if ($(this).attr('data-modal_size')) def.modal_size = $(this).attr('data-modal_size')
       const cSettings = $.extend({}, def, settings)
-      OpenModal(cSettings)
+      open_modal(cSettings)
       e.preventDefault()
     })
     return this
@@ -39,7 +39,7 @@ jQuery(function() {
       options.content = options.title
       options.title = ''
     }
-    OpenModal(options)
+    open_modal(options)
   }
 })
 
@@ -60,7 +60,8 @@ jQuery(function() {
  * on_close: function executed after modal closed
  * return modal object
  */
-function OpenModal(settings) {
+// eslint-disable-next-line camelcase
+function open_modal(settings) {
   const def = {
     title: '',
     content: null,
@@ -102,7 +103,7 @@ function OpenModal(settings) {
   modal.on('hidden.bs.modal', function(e) {
     settings.on_close(modal)
     if (!$(e.currentTarget).attr('data-skip_destroy')) $(e.currentTarget).remove()
-    ModalFixMultiple()
+    modal_fix_multiple()
   })
 
   if (settings.zindex) modal.css('z-index', settings.zindex)

--- a/app/assets/javascripts/camaleon_cms/admin/_post.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_post.js
@@ -1,8 +1,11 @@
 /* eslint-env jquery */
-const AppPost = {}
+/* eslint camelcase: [
+"error", {properties: "never", ignoreGlobals: true, allow: ["App_post", "cama_init_post", "cama_upload_feature_image"]}
+] */
+const App_post = {}
 let $form = null
 /* eslint-disable-next-line no-unused-vars */
-function CamaInitPost(obj) {
+function cama_init_post(obj) {
   $form = $('#form-post')
 
   /* eslint-disable-next-line eqeqeq */
@@ -21,7 +24,7 @@ function CamaInitPost(obj) {
   const _ajaxPath = obj._ajax_path
   const _postTagsPath = obj._post_tags_path
 
-  AppPost.save_draft_ajax = function(callback, calledFromInterval) {
+  App_post.save_draft_ajax = function(callback, calledFromInterval) {
     _draftInited = true
     const data = $form.serializeObject()
     data._method = postDraftId ? 'patch' : 'post'
@@ -48,8 +51,8 @@ function CamaInitPost(obj) {
     }
   }
 
-  AppPost.save_draft = function() {
-    AppPost.save_draft_ajax(function() {
+  App_post.save_draft = function() {
+    App_post.save_draft_ajax(function() {
       $form.data('submitted', 1)
       location.href = _postsPath + '?flash[notice]=' + I18n('msg.draft')
     })
@@ -62,11 +65,11 @@ function CamaInitPost(obj) {
       if ($form.length === 0)
         clearInterval(window.post_editor_draft_intrval)
       else
-        AppPost.save_draft_ajax(null, true)
+        App_post.save_draft_ajax(null, true)
     },
     60 * 1000
   )
-  window.save_draft = AppPost.save_draft_ajax
+  window.save_draft = App_post.save_draft_ajax
 
   if ($form.find('.title-post' + classTranslate).length === 0)
     classTranslate = ''
@@ -148,7 +151,7 @@ function CamaInitPost(obj) {
       $link.find('.btn-preview').click(function() { // preview button
         const link = $(this)
         showLoading()
-        AppPost.save_draft_ajax(function() {
+        App_post.save_draft_ajax(function() {
           hideLoading()
           const ar = link.attr('href').split('draft_id=')
           ar[1] = postDraftId
@@ -204,7 +207,7 @@ function CamaInitPost(obj) {
   })
 
   try { $('.tinymce_textarea:not(.translated-item)', $form).tinymce().destroy() } catch (e) { }
-  tinymce.init(CamaGetTinymceSettings({
+  tinymce.init(cama_get_tinymce_settings({
     selector: '.tinymce_textarea:not(.translated-item)',
     height: '480px',
     base_path: obj.base_path
@@ -342,7 +345,7 @@ function CamaInitPost(obj) {
 
 // thumbnail uploader
 // eslint-disable-next-line no-unused-vars
-function CamaUploadFeatureImage(data) {
+function cama_upload_feature_image(data) {
   $.fn.upload_filemanager($.extend({
     formats: 'image',
     selected: function(image) {

--- a/app/assets/javascripts/camaleon_cms/admin/_user_profile.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_user_profile.js
@@ -1,6 +1,7 @@
 /* eslint-env jquery */
+/* eslint camelcase: ["error", {allow: ["init_profile_form"]}] */
 /* eslint-disable-next-line no-unused-vars */
-function InitProfileForm() {
+function init_profile_form() {
   const form = $('#user_form')
   form.validate()
 

--- a/app/assets/javascripts/camaleon_cms/admin/nav_menu.js
+++ b/app/assets/javascripts/camaleon_cms/admin/nav_menu.js
@@ -89,13 +89,13 @@ $(function() {
   // edit external menu items
   listPanel.on('click', '.item_external', function() {
     const link = $(this)
-    OpenModal({
+    open_modal({
       title: link.attr('data-original-title') || link.attr('title'),
       url: link.attr('href'),
       mode: 'ajax',
       callback(modal) {
         const form = modal.find('form')
-        InitFormValidations(form)
+        init_form_validations(form)
         return form.submit(function() {
           if (!form.valid())
             return false
@@ -132,7 +132,7 @@ $(function() {
     callback(modal) {
       const form = modal.find('form')
 
-      return setTimeout(() => InitFormValidations(form), 1000)
+      return setTimeout(() => init_form_validations(form), 1000)
     }
   })
 
@@ -147,13 +147,13 @@ $(function() {
   // custom fields
   return listPanel.on('click', '.custom_settings_link', function() {
     const link = $(this)
-    OpenModal({
+    open_modal({
       title: link.attr('data-original-title') || link.attr('title'),
       url: link.attr('href'),
       mode: 'ajax',
       callback(modal) {
         const form = modal.find('form')
-        InitFormValidations(form)
+        init_form_validations(form)
         return form.submit(function() {
           if (!form.valid())
             return false

--- a/app/assets/javascripts/camaleon_cms/admin/uploader/_media_manager.js
+++ b/app/assets/javascripts/camaleon_cms/admin/uploader/_media_manager.js
@@ -4,6 +4,7 @@
  * Full docs: https://github.com/decaffeinate/decaffeinate/blob/main/docs/suggestions.md
  */
 
+/* eslint camelcase: ["error", {properties: "never", ignoreGlobals: true}] */
 /* eslint-env jquery */
 window.cama_init_media = function(mediaPanel) {
   const mediaInfo = mediaPanel.find('.media_file_info')
@@ -323,7 +324,7 @@ window.cama_init_media = function(mediaPanel) {
         return false
       })
     }
-    OpenModal({ title: 'New Folder', content, callback, zindex: 9999999 })
+    open_modal({ title: 'New Folder', content, callback, zindex: 9999999 })
     return false
   })
 
@@ -435,7 +436,7 @@ window.cama_init_media = function(mediaPanel) {
             }
           })
         }
-        OpenModal(
+        open_modal(
           {
             zindex: 999992,
             modal_size: 'modal-lg',
@@ -514,7 +515,7 @@ window.cama_init_media = function(mediaPanel) {
       }
       , 300))
     }
-    OpenModal({
+    open_modal({
       zindex: 999991,
       id: 'media_panel_editor_image',
       title: I18n('button.edit_image', 'Edit Image') + ' - ' + data.name + (mediaPanel.attr('data-dimension') ? ' <small><i>(' + mediaPanel.attr('data-dimension') + ')</i></small>' : ''),
@@ -614,7 +615,7 @@ $.fn.upload_filemanager = function(args) {
   if (args.thumb_size === 'null')
     args.thumb_size = ''
 
-  return OpenModal({
+  return open_modal({
     title: args.title || I18n('msg.media_title'),
     id: 'cama_modal_file_uploader',
     modal_size: 'modal-lg',

--- a/app/views/camaleon_cms/admin/appearances/widgets/main/form.html.erb
+++ b/app/views/camaleon_cms/admin/appearances/widgets/main/form.html.erb
@@ -21,6 +21,6 @@
         <button class="btn btn-primary" type="submit"><%= t('camaleon_cms.admin.button.submit')%></button>
     </div>
     <script>
-        jQuery(function(){ InitFormValidations($("#widget_form")); });
+        jQuery(function(){ init_form_validations($("#widget_form")); });
     </script>
 <% end %>

--- a/app/views/camaleon_cms/admin/appearances/widgets/sidebar/form.html.erb
+++ b/app/views/camaleon_cms/admin/appearances/widgets/sidebar/form.html.erb
@@ -18,6 +18,6 @@
         <button class="btn btn-primary pull-right" type="submit"><%= t('camaleon_cms.admin.button.submit')%></button>
     </div>
     <script>
-        jQuery(function(){ InitFormValidations($("#sidebar-widget")); });
+        jQuery(function(){ init_form_validations($("#sidebar-widget")); });
     </script>
 <% end %>

--- a/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
+++ b/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
@@ -18,9 +18,9 @@
                 <div class="col-md-6">
                     <% if @post.draft?  %>
                         <a class="btn btn-default btn-xs pull-right" href="#" data-type="pending" onclick="$('#form-post').submit(); return false;" style="<%= 'display: none' unless @post.pending? %>" ><%= t('camaleon_cms.admin.post_type.save_pending')%> </a>
-                        <a class="btn btn-default btn-xs pull-right" href="#" data-type="draft" onclick="AppPost.save_draft(); return false;" style="<%= 'display: none' unless @post.draft? %>" ><%= t('camaleon_cms.admin.post_type.save_draft')%></a>
+                        <a class="btn btn-default btn-xs pull-right" href="#" data-type="draft" onclick="App_post.save_draft(); return false;" style="<%= 'display: none' unless @post.draft? %>" ><%= t('camaleon_cms.admin.post_type.save_draft')%></a>
                     <% else  %>
-                        <a class="btn btn-default btn-xs pull-right" href="#" onclick="AppPost.save_draft(); return false;" ><%= t('camaleon_cms.admin.post_type.save_draft')%></a>
+                        <a class="btn btn-default btn-xs pull-right" href="#" onclick="App_post.save_draft(); return false;" ><%= t('camaleon_cms.admin.post_type.save_draft')%></a>
                     <% end  %>
                 </div>
             </div>
@@ -144,7 +144,7 @@
                         <input data-error-place='#feature-image ~ .validation-errors:first' class="<%= 'required' if @post.is_required_picture? %>" name="meta[thumb]" type="hidden" value="<%= params[:meta][:thumb] rescue false || @post.get_meta("thumb", "") %>"/>
                     </div>
                     <!-- posts_thumb_versions ==> '200x200,400x450', posts_thumb_size ==> '100x100', posts_image_dimension ==> '1200x1200'-->
-                    <a href="#" class="btn btn-default" onclick="CamaUploadFeatureImage({versions: '<%= @post_type.get_option('posts_thumb_versions') %>', thumb_size: '<%= @post_type.get_option('posts_thumb_size') %>', dimension: '<%= @post_type.get_option('posts_image_dimension') %>' }); return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.post_type.upload_image', default: 'Upload Image')%></a>
+                    <a href="#" class="btn btn-default" onclick="cama_upload_feature_image({versions: '<%= @post_type.get_option('posts_thumb_versions') %>', thumb_size: '<%= @post_type.get_option('posts_thumb_size') %>', dimension: '<%= @post_type.get_option('posts_image_dimension') %>' }); return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.post_type.upload_image', default: 'Upload Image')%></a>
                     <div class="validation-errors"></div>
                 </div>
             </div>

--- a/app/views/camaleon_cms/admin/posts/form.html.erb
+++ b/app/views/camaleon_cms/admin/posts/form.html.erb
@@ -77,7 +77,7 @@
     <script type="text/javascript">
         jQuery(function($){
             setTimeout(function(){
-                CamaInitPost({
+                cama_init_post({
                     post_id: '<%= @post.draft? ? (@post.parent.present? ? @post.parent.id : nil) : @post.id %>',
                     post_draft_id: '<%= @post.id if @post.draft? %>',
                     post_status: '<%= @post.status %>',

--- a/app/views/camaleon_cms/admin/settings/_email_settings.html.erb
+++ b/app/views/camaleon_cms/admin/settings/_email_settings.html.erb
@@ -45,7 +45,7 @@
         $('#cama_email_send_test_email').click(function(){
             var link = $(this);
             var content = '<form><div><label for=""><%= t('camaleon_cms.admin.table.email', default: 'Email') %>: </label> <div class="input-group"><input class="form-control required email data-error-place-parent" name="email"><span class="input-group-btn"><button type="submit" class="btn btn-primary"><%= t('camaleon_cms.admin.settings.send_test_email') %></button></span></div></div></form>';
-            OpenModal({title: link.text(), content: content, callback: function(modal){
+            open_modal({title: link.text(), content: content, callback: function(modal){
                 var form = modal.find('form');
                 form.validate({submitHandler: function(){
                     showLoading();

--- a/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
@@ -40,7 +40,7 @@
                         </div>
                     <% end %>
                 </div>
-                <script> jQuery(function(){ BuildCustomFieldGroup(<%= raw(params[:field_options].present? ? (r = []; params[:field_options].each{|k, v| val = {}; v.each{|kk, vv| val["#{kk}"] = (vv['values'].values rescue vv['values']); }; r << val }; r.to_json) : record.get_fields_grouped(fields.pluck(:slug).uniq).to_json) %>, '<%= group.id %>', <%= raw group_field_data.to_json %>, <%= group.is_repeat %>, '<%= field_name %>'); }); </script>
+                <script> jQuery(function(){ build_custom_field_group(<%= raw(params[:field_options].present? ? (r = []; params[:field_options].each{|k, v| val = {}; v.each{|kk, vv| val["#{kk}"] = (vv['values'].values rescue vv['values']); }; r << val }; r.to_json) : record.get_fields_grouped(fields.pluck(:slug).uniq).to_json) %>, '<%= group.id %>', <%= raw group_field_data.to_json %>, <%= group.is_repeat %>, '<%= field_name %>'); }); </script>
             </div>
         </div>
         <% if group.is_repeat %>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_audio.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_audio.html.erb
@@ -1,4 +1,4 @@
 <div class="group-input-fields-content input-group">
   <input type="text" name="<%= field_name %>[<%= field.slug %>][values][]" class="data-error-place-parent form-control input-value <%= "required" if field.options[:required].to_s.to_bool %>" />
-  <span class="input-group-addon btn_upload" onclick="LoadUploadAudioField(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_audio')%></span>
+  <span class="input-group-addon btn_upload" onclick="load_upload_audio_field(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_audio')%></span>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkbox.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkbox.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldCheckboxVal">
+<div class="group-input-fields-content" data-callback-render="custom_field_checkbox_val">
   <div class="checkbox">
     <label>
       <input type="checkbox" value="1" name="<%= field_name %>[<%= field.slug %>][values][]">

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkboxes.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_checkboxes.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content cama_skip_cf_rename_multiple" data-callback-render="CustomFieldCheckboxesVal">
+<div class="group-input-fields-content cama_skip_cf_rename_multiple" data-callback-render="custom_field_checkboxs_val">
     <% field.options[:multiple_options].each do |option|  %>
         <div class="checkbox"><label><input type="checkbox" value="<%= option[:value] %>" name="<%= field_name %>[<%= field.slug %>][values][]" <%= 'checked' if default_use && option[:default].present? %> > <%= option[:title] %></label></div>
     <% end %>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_colorpicker.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_colorpicker.html.erb
@@ -1,5 +1,5 @@
 <% add_asset_library('colorpicker') %>
-<div class="group-input-fields-content" data-callback-render="CustomFieldColorpickerVal" style="max-width: 300px;">
+<div class="group-input-fields-content" data-callback-render="custom_field_colorpicker_val" style="max-width: 300px;">
   <div data-color-format="<%= field.options[:color_format].present? ? field.options[:color_format] : 'hex' %>" data-color="#fff" class="input-group color my-colorpicker">
     <input  type="text" name="<%= field_name %>[<%= field.slug %>][values][]" class="data-error-place-parent form-control input-value <%= "required" if field.options[:required].to_s.to_bool %>" />
     <span class="input-group-addon"><i></i></span>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_date.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_date.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldDate" style="max-width: 300px;">
+<div class="group-input-fields-content" data-callback-render="custom_field_date" style="max-width: 300px;">
   <div class="input-group date date-input-box <%= "is_datetimepicker" if field.options[:type_date].to_s.to_bool %>">
     <input type="text" data-locale='<%= current_locale %>' name="<%= field_name %>[<%= field.slug %>][values][]" class="data-error-place-parent input-value form-control <%= "required" if field.options[:required].to_s.to_bool %>" />
     <span class="add-on input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_editor.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_editor.html.erb
@@ -1,3 +1,3 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldEditor">
+<div class="group-input-fields-content" data-callback-render="custom_field_editor">
   <textarea id="" name="<%= field_name %>[<%= field.slug %>][values][]"  rows="8" class="form-control <%= 'is_translate' if field.options[:translate].to_s.to_bool %> input-value <%= "required" if field.options[:required].to_s.to_bool %>" <%= "readonly" if true %> <%= "disabled" if field.options[:disabled].present? %>></textarea>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_field_attrs.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_field_attrs.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content row" data-callback-render="CustomFieldFieldAttrsVal">
+<div class="group-input-fields-content row" data-callback-render="custom_field_field_attrs_val">
     <div class="col-md-4">
         <input type="text" name="<%= field_name %>[<%= field.slug %>][values][][attr]" placeholder="<%= t('camaleon_cms.admin.table.attribute') %>" class="<%= 'is_translate' if field.get_option('translate') %> form-control input-attr <%= "required" if field.options[:required].to_s.to_bool %>" />
     </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_file.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_file.html.erb
@@ -1,4 +1,4 @@
 <div class="group-input-fields-content input-group">
   <input type="text" data-formats="<%= field.options[:formats] || "" %>" name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control input-value data-error-place-parent file_format <%= "required" if field.options[:required].to_s.to_bool %>"  />
-  <span class="input-group-addon btn_upload" onclick="LoadUploadFileField(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_file') %></span>
+  <span class="input-group-addon btn_upload" onclick="load_upload_file_field(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_file') %></span>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_image.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_image.html.erb
@@ -1,7 +1,7 @@
 <div class="group-input-fields-content input-group">
     <input
         onfocus="<%= '$(this).blur().next(\'.btn_upload\').click();' if field.options[:dimension].present? || field.options[:versions].present? || field.options[:thumb_size].present? %>"
-        onchange="CamaCustomFieldImageChanged($(this))"
+        onchange="cama_custom_field_image_changed($(this))"
         data-dimension="<%= field.options[:dimension] %>"
         data-versions="<%= field.options[:versions] %>"
         data-thumb_size="<%= field.options[:thumb_size] %>"
@@ -12,5 +12,5 @@
       <i class="fa fa-upload"></i>
       <%= t('camaleon_cms.admin.button.upload_image')%> <%= "(#{field.get_option('dimension')})" if field.get_option('dimension').present? %>
     </span>
-    <span class="input-group-addon btn btn-primary btn-xs" onclick="CamaCustomFieldImageRemove($(this).parent().find('input'));"><i class="fa fa-times"></i></span>
+    <span class="input-group-addon btn btn-primary btn-xs" onclick="cama_custom_field_image_remove($(this).parent().find('input'));"><i class="fa fa-times"></i></span>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_private_file.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_private_file.html.erb
@@ -1,4 +1,4 @@
 <div class="group-input-fields-content input-group">
   <input onfocus="$(this).blur().next('.btn_upload').click();" type="text" data-formats="<%= field.options[:formats] || "" %>" name="<%= field_name %>[<%= field.slug %>][values][]" class="disabled form-control input-value data-error-place-parent file_format <%= "required" if field.options[:required].to_s.to_bool %>"  />
-  <span class="input-group-addon btn_upload" onclick="LoadUploadPrivateFileField(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_file') %></span>
+  <span class="input-group-addon btn_upload" onclick="load_upload_private_file_field(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_file') %></span>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_radio.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_radio.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldRadioVal">
+<div class="group-input-fields-content" data-callback-render="custom_field_radio_val">
     <% field.options[:multiple_options].each do |option|  %>
         <div class="radio"><label><input type="radio" value="<%= option[:value] %>" name="<%= field_name %>[<%= field.slug %>][values][]" <%= 'checked' if default_use &&  option[:default].present? && option[:default] != 'none' %> > <%= option[:title] %></label></div>
     <% end %>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_select.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_select.html.erb
@@ -1,4 +1,4 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldSelectCallback">
+<div class="group-input-fields-content" data-callback-render="custom_field_select_callback">
   <select name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control input-value <%= 'is_translate' if field.options[:translate].to_s.to_bool %> <%= "required" if field.options[:required].to_s.to_bool %>" >
     <% field.options[:multiple_options].each do |option|  %>
         <option value="<%= option[:value] %>" <%= 'selected' if option[:default].present? %>><%= option[:title] %></option>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_text_area.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_text_area.html.erb
@@ -1,3 +1,3 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldTextArea">
+<div class="group-input-fields-content" data-callback-render="custom_field_text_area">
   <textarea name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control input-value <%= 'is_translate' if field.options[:translate].to_s.to_bool %> <%= "required" if field.options[:required].to_s.to_bool %>" rows="6" ></textarea>
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_text_box.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_text_box.html.erb
@@ -1,3 +1,3 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldTextBox">
+<div class="group-input-fields-content" data-callback-render="custom_field_text_box">
     <input type="text" name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control input-value <%= 'is_translate' if field.options[:translate].to_s.to_bool %> <%= "required" if field.options[:required].to_s.to_bool %>"  />
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_url.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_url.html.erb
@@ -1,3 +1,3 @@
-<div class="group-input-fields-content" data-callback-render="CustomFieldUrlCallback">
+<div class="group-input-fields-content" data-callback-render="custom_field_url_callback">
   <input type="text" name="<%= field_name %>[<%= field.slug %>][values][]" class="form-control url input-value <%= 'is_translate' if field.options[:translate].to_s.to_bool %> <%= "required" if field.options[:required].to_s.to_bool %>" />
 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_video.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_video.html.erb
@@ -1,4 +1,4 @@
 <div class="group-input-fields-content input-group">
   <input type="text" name="<%= field_name %>[<%= field.slug %>][values][]" class="data-error-place-parent form-control input-value <%= "required" if field.options[:required].to_s.to_bool %>" />
-  <span class="input-group-addon btn_upload" onclick="LoadUploadVideoField(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_video')%></span>
+  <span class="input-group-addon btn_upload" onclick="load_upload_video_field(this);return false;"><i class="fa fa-upload"></i> <%= t('camaleon_cms.admin.button.upload_video')%></span>
 </div>

--- a/app/views/camaleon_cms/admin/users/form.html.erb
+++ b/app/views/camaleon_cms/admin/users/form.html.erb
@@ -156,6 +156,6 @@
     </div>
 </div>
 <script type="application/javascript">
-    jQuery(function ($) { InitProfileForm(); });
+    jQuery(function ($) { init_profile_form(); });
 </script>
 <!-- EOF MODALS -->


### PR DESCRIPTION
Live testing has revealed breakage after ESLint fixes - camelCase named JS functions are not working in ERB files.
