### PR TITLE
Fix the test email for non-main sites

### DIFF
--- a/app/controllers/camaleon_cms/admin/settings_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings_controller.rb
@@ -70,7 +70,8 @@ module CamaleonCms
 
       # send email test
       def test_email
-        CamaleonCms::HtmlMailer.sender(params[:email], 'Test', { content: 'Test content' }).deliver_now
+        data = { content: 'Test content', current_site: current_site, url_base: cama_root_url }
+        CamaleonCms::HtmlMailer.sender(params[:email], 'Test', data).deliver_now
         head :ok
       rescue StandardError => e
         render inline: e.message, status: 502

--- a/app/mailers/camaleon_cms/html_mailer.rb
+++ b/app/mailers/camaleon_cms/html_mailer.rb
@@ -58,8 +58,11 @@ module CamaleonCms
       prepend_view_path(Rails.root.join(views_dir).to_s)
 
       theme = @current_site.get_theme
-      lookup_context.prefixes.prepend("themes/#{theme.slug}") if theme.settings['gem_mode']
-      lookup_context.prefixes.prepend("themes/#{theme.slug}/views") unless theme.settings['gem_mode']
+      if theme.settings && theme.settings['gem_mode']
+        lookup_context.prefixes.prepend("themes/#{theme.slug}")
+      else
+        lookup_context.prefixes.prepend("themes/#{theme.slug}/views")
+      end
       lookup_context.use_camaleon_partial_prefixes = true
       ((data[:files] || []) + (data[:attachments] || [])).each do |attach|
         if File.exist?(attach) && !File.directory?(attach)


### PR DESCRIPTION
Previously, the test email always sent from the main site even when initiated from a different site.

Fixes #1049 