### PR TITLE
Use jQuery 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Change Log
 
+## Unreleased
+- Use jQuery 2.x - 2.2.4
+  - If there are `//= require jquery` clauses in the main application, replace them with `//= require jquery2` 
+
 ## [2.7.5](https://github.com/owen2345/camaleon-cms/tree/2.7.5) (2023-11-22)
 - Fix the test email for non-main sites by [brian-kephart](https://github.com/brian-kephart) in [\#1050](https://github.com/owen2345/camaleon-cms/pull/1050)
 - Bump semver from 7.3.8 to 7.5.3 by [dependabot](https://github.com/apps/dependabot) in [\#1057](https://github.com/owen2345/camaleon-cms/pull/1057)
 - UserUrlValidator for SSRF mitigation by [texpert](https://github.com/texpert) in [\#1048](https://github.com/owen2345/camaleon-cms/pull/1048)
- - Thanks [paragbagul111](https://github.com/paragbagul111) for reporting the issue
+  - Thanks [paragbagul111](https://github.com/paragbagul111) for reporting the issue
 - Bump word-wrap from 1.2.3 to 1.2.4 by [dependabot](https://github.com/apps/dependabot)  in [\#1059](https://github.com/owen2345/camaleon-cms/pull/1059)
 - Remove webdrivers gem, which has no support for Chrome v115 [texpert](https://github.com/texpert) in [\#1060](https://github.com/owen2345/camaleon-cms/pull/1060)
 - Fix JS after conversion from CoffeeScript [texpert](https://github.com/texpert) in [\#1062](https://github.com/owen2345/camaleon-cms/pull/1062)

--- a/app/apps/themes/camaleon_first/assets/js/main.js
+++ b/app/apps/themes/camaleon_first/assets/js/main.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/bootstrap.min.js
 //= require ./modernizr.custom
 //= require ./magnific.min

--- a/app/apps/themes/default/assets/js/main.js
+++ b/app/apps/themes/default/assets/js/main.js
@@ -10,4 +10,4 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2

--- a/app/apps/themes/new/assets/js/main.js
+++ b/app/apps/themes/new/assets/js/main.js
@@ -10,5 +10,5 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/bootstrap.min

--- a/app/assets/javascripts/camaleon_cms/admin/admin-basic-manifest.js
+++ b/app/assets/javascripts/camaleon_cms/admin/admin-basic-manifest.js
@@ -1,3 +1,3 @@
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/bootstrap.min
 //= require ./jquery.validate

--- a/app/assets/javascripts/camaleon_cms/admin/admin-manifest.js
+++ b/app/assets/javascripts/camaleon_cms/admin/admin-manifest.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/admin/_data
 //= require camaleon_cms/bootstrap.min
 //= require camaleon_cms/admin/_jquery-ui.min

--- a/lib/generators/camaleon_cms/theme_template/assets/js/main.js
+++ b/lib/generators/camaleon_cms/theme_template/assets/js/main.js
@@ -10,5 +10,5 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery.js
+//= require jquery2
 //= require camaleon_cms/bootstrap.min.js

--- a/spec/dummy/app/apps/themes/camaleon_first/assets/js/main.js
+++ b/spec/dummy/app/apps/themes/camaleon_first/assets/js/main.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/bootstrap.min.js
 //= require ./modernizr.custom
 //= require ./magnific.min

--- a/spec/dummy/app/apps/themes/default/assets/js/main.js
+++ b/spec/dummy/app/apps/themes/default/assets/js/main.js
@@ -10,4 +10,4 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2

--- a/spec/dummy/app/apps/themes/new/assets/js/main.js
+++ b/spec/dummy/app/apps/themes/new/assets/js/main.js
@@ -10,5 +10,5 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery2
 //= require camaleon_cms/bootstrap.min


### PR DESCRIPTION
Before working on transition to jQuery 3.xx, which will presumably require additional refactoring work and testing, let's make an easy transition to jQuery 2.xx - actually, the last 2.xx version - the 2.2.4.

Here are some highlights of the changes that jQuery 2.0 brings:

- No more support for IE 6/7/8

- Reduced size: The final 2.0.0 file is 12 percent smaller than the 1.9.1 file, thanks to the elimination of patches that were only needed for IE 6, 7, and 8. 

- jQuery 1.9 API equivalence: jQuery 2.0 is API-compatible with 1.9

