### PR TITLE
On cama_site_check_existence, if site is unknown, allow_other_host: true for redirection to main site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
   - If there are `//= require jquery` clauses in the main application, replace them with `//= require jquery2`
 - Add Ruby 3.3 and Rails 7.2 to CI
 - Replace Tuzitio links with `camaleon.website` and http with https
+- On cama_site_check_existence, if site is unknown, use `allow_other_host: true` for redirection to main site
+  - Starting from Rails 7.0 a redirection to other host will raise an exception unless the `redirect_to` method is 
+    called with the `allow_other_host: true` option
 
 ## [2.7.5](https://github.com/owen2345/camaleon-cms/tree/2.7.5) (2023-11-22)
 - Fix the test email for non-main sites by [brian-kephart](https://github.com/brian-kephart) in [\#1050](https://github.com/owen2345/camaleon-cms/pull/1050)

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -103,7 +103,13 @@ module CamaleonCms
     def cama_site_check_existence
       if !current_site.present?
         if Cama::Site.main_site.present?
-          redirect_to Cama::Site.main_site.decorate.the_url
+          url = Cama::Site.main_site.decorate.the_url
+          # TODO: Remove this condition when Rails 6.x won't be supported
+          if Rails.gem_version >= Gem::Version.new('7.0.0')
+            redirect_to url, allow_other_host: true
+          else
+            redirect_to url
+          end
         else
           redirect_to cama_admin_installers_path
         end

--- a/lib/ext/string.rb
+++ b/lib/ext/string.rb
@@ -66,7 +66,7 @@ class String
   end
 
   # parse string into domain
-  # https://owem.camaleon.website into owem.camaleon.website
+  # https://owen.camaleon.website into owen.camaleon.website
   def parse_domain
     url = self
     uri = URI.parse(url)


### PR DESCRIPTION
Starting from Rails 7.0 a redirection to other host will raise an exception unless the `redirect_to` method is called with the `allow_other_host: true` option
