### PR TITLE
Use MiniMime for mime types, because the MiniMagick 5.0 has no Image#mime_type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,8 +32,15 @@ Metrics/MethodLength:
 RSpec/ExampleLength:
   Enabled: false
 
+RSpec/AnyInstance:
+  Enabled: false
+
 RSpec/InstanceVariable:
   Enabled: false
+
+RSpec/MessageSpies:
+  Enabled: true
+  EnforcedStyle: receive
 
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
@@ -64,3 +71,7 @@ Style/FrozenStringLiteralComment:
 Style/MixinUsage:
   Exclude:
     - spec/**/*
+
+Style/NumericPredicate:
+  Enabled: true
+  EnforcedStyle: comparison

--- a/app/controllers/camaleon_cms/admin/installers_controller.rb
+++ b/app/controllers/camaleon_cms/admin/installers_controller.rb
@@ -27,7 +27,7 @@ module CamaleonCms
       def welcome; end
 
       def installer_verification
-        redirect_to cama_root_url unless CamaleonCms::Site.count.zero?
+        redirect_to cama_root_url unless CamaleonCms::Site.count == 0
       end
     end
   end

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -51,7 +51,7 @@ module CamaleonCms
     # generate captcha image
     def captcha
       image = cama_captcha_build(params[:len])
-      send_data image.to_blob, type: image.mime_type, disposition: 'inline'
+      send_data image.to_blob, type: MiniMime.lookup_by_extension(image.type).content_type, disposition: 'inline'
     end
 
     private

--- a/app/helpers/camaleon_cms/admin/category_helper.rb
+++ b/app/helpers/camaleon_cms/admin/category_helper.rb
@@ -17,7 +17,7 @@ module CamaleonCms
           options << [('—' * level) + category.the_title, category.id]
           children = attrs[:max_level] < level ? [] : category.children
           children = [] if attrs[:until_cats].include?(category.id)
-          options += cama_category_get_options_html(children, level + 1, attrs) if children.size.positive?
+          options += cama_category_get_options_html(children, level + 1, attrs) unless children.empty?
         end
         options
       end

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -117,7 +117,7 @@ module CamaleonCms
           index += 1
         end
 
-        if level.zero?
+        if level == 0
           html
         else
           html = "<#{args[:sub_container]} class='#{args[:sub_class]} #{if parent_current
@@ -143,7 +143,7 @@ module CamaleonCms
             '.html', ''
           )
           has_children = nav_menu_item.have_children?
-          has_children = false if max_levels.positive? && max_levels == internal_level
+          has_children = false if max_levels > 0 && max_levels == internal_level
           data_nav_item[:label] = data_nav_item[:name]
           data_nav_item[:url] = data_nav_item[:link]
           r = {
@@ -170,7 +170,7 @@ module CamaleonCms
           res << r
         end
 
-        if internal_level.zero?
+        if internal_level == 0
           res
         else
           [res, is_current_parent, levels.max]

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -98,7 +98,7 @@ module CamaleonCms
       terms.all.each do |term|
         options << [('—' * level) + term.name, term.id] unless @term.id == term.id
         children = term.children
-        options += cama_get_options_html_from_items(children, level + 1) if children.size.positive?
+        options += cama_get_options_html_from_items(children, level + 1) unless children.empty?
       end
       options
     end
@@ -121,18 +121,18 @@ module CamaleonCms
       libs[:datepicker] = { js: [] }
       libs[:datetimepicker] = { js: [], css: [] }
       libs[:tinymce] =
-        { js: ['camaleon_cms/admin/tinymce/tinymce.min', 'camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min'],
+        { js: %w[camaleon_cms/admin/tinymce/tinymce.min camaleon_cms/admin/tinymce/plugins/filemanager/plugin.min],
           css: ['camaleon_cms/admin/tinymce/skins/lightgray/content.min'] }
       libs[:form_ajax] = { js: ['camaleon_cms/admin/form/jquery.form'] }
       libs[:cropper] = {} # loaded by default
       libs[:post] =
-        { js: ['camaleon_cms/admin/jquery.tagsinput.min', 'camaleon_cms/admin/post'],
+        { js: %w[camaleon_cms/admin/jquery.tagsinput.min camaleon_cms/admin/post],
           css: ['camaleon_cms/admin/jquery.tagsinput'] }
       libs[:multiselect] = { js: ['camaleon_cms/admin/bootstrap-select.js'] }
       libs[:validate] = { js: ['camaleon_cms/admin/jquery.validate'] }
       libs[:nav_menu] =
         { css: ['camaleon_cms/admin/nestable/jquery.nestable'],
-          js: ['camaleon_cms/admin/jquery.nestable', 'camaleon_cms/admin/nav_menu'] }
+          js: %w[camaleon_cms/admin/jquery.nestable camaleon_cms/admin/nav_menu] }
       libs[:admin_intro] =
         { js: ['camaleon_cms/admin/introjs/intro.min'], css: ['camaleon_cms/admin/introjs/introjs.min'] }
       @_cama_assets_libraries = libs

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -72,7 +72,7 @@ module CamaleonCms
       # save file
       key = File.join(settings[:folder], settings[:filename]).to_s.cama_fix_slash
       res = cama_uploader.add_file(settings[:uploaded_io], key, { same_name: settings[:same_name] })
-      {} if (settings[:temporal_time]).positive?
+      return {} if (settings[:temporal_time]).positive?
 
       # generate image versions
       if res['file_type'] == 'image'

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -72,7 +72,6 @@ module CamaleonCms
       # save file
       key = File.join(settings[:folder], settings[:filename]).to_s.cama_fix_slash
       res = cama_uploader.add_file(settings[:uploaded_io], key, { same_name: settings[:same_name] })
-      return {} if (settings[:temporal_time]).positive?
 
       # generate image versions
       if res['file_type'] == 'image'
@@ -92,6 +91,12 @@ module CamaleonCms
       FileUtils.rm_f(uploaded_io.path) if settings[:remove_source] && File.exist?(uploaded_io.path)
 
       hooks_run('after_upload', settings)
+
+      # temporal file upload (always put as local for temporal files)
+      if settings[:temporal_time] > 0
+        CamaleonCmsUploader.delete_block.call(settings, cama_uploader, key)
+      end
+
       res
     end
 

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -42,7 +42,7 @@ module CamaleonCms
     validates_with CamaleonCms::PostUniqValidator
     attr_accessor :show_title_with_parent
 
-    before_create :fix_post_order, if: ->(p) { !p.post_order.present? || p.post_order.zero? }
+    before_create :fix_post_order, if: ->(p) { !p.post_order.present? || p.post_order == 0 }
 
     # return all parents for current page hierarchy ordered bottom to top
     def parents

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -158,6 +158,11 @@ class CamaleonCmsUploader
     File.exist?(file_name)
   end
 
+  def self.delete_block(&block)
+    @delete_block = block if block
+    @delete_block
+  end
+
   private
 
   def cache_key

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -14,18 +14,17 @@ module CamaleonCms
                    )
                    .where.not(id: record.id)
                    .where.not(status: %i[draft draft_child trash])
-      if posts.size.positive?
-        record.errors[:base] << if slug_array.size > 1
-                                  "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{posts.pluck(:slug).map do |slug|
-                                                                                                             record.slug.to_s.translations.map do |lng, r_slug|
-                                                                                                               if slug.translations_array.include?(r_slug)
-                                                                                                                 "#{r_slug} (#{lng})"
-                                                                                                               end
-                                                                                                             end.join(',')
-                                                                                                           end.join(',').split(',').uniq.clean_empty.join(', ')} "
-                                else
-                                  "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{record.slug} "
-                                end
+      unless posts.empty?
+        record.errors[:base] <<
+          if slug_array.size > 1
+            "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{posts.pluck(:slug).map do |slug|
+              record.slug.to_s.translations.map do |lng, r_slug|
+                "#{r_slug} (#{lng})" if slug.translations_array.include?(r_slug)
+              end.join(',')
+            end.join(',').split(',').uniq.clean_empty.join(', ')} "
+          else
+            "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{record.slug} "
+          end
       end
 
       # avoid recursive page parent

--- a/app/validators/camaleon_cms/uniq_validator.rb
+++ b/app/validators/camaleon_cms/uniq_validator.rb
@@ -3,9 +3,15 @@ module CamaleonCms
     def validate(record)
       return if record.skip_slug_validation?
 
-      if CamaleonCms::TermTaxonomy.where(slug: record.slug).where.not(id: record.id).where("#{CamaleonCms::TermTaxonomy.table_name}.taxonomy" => record.taxonomy).where("#{CamaleonCms::TermTaxonomy.table_name}.parent_id" => record.parent_id).size.positive?
-        record.errors[:base] << I18n.t('camaleon_cms.admin.post.message.requires_different_slug').to_s
-      end
+      taxonomy_table = CamaleonCms::TermTaxonomy.table_name
+      slug_exists = CamaleonCms::TermTaxonomy.where(slug: record.slug)
+                                             .where.not(id: record.id)
+                                             .where("#{taxonomy_table}.taxonomy" => record.taxonomy)
+                                             .where("#{taxonomy_table}.parent_id" => record.parent_id).exists?
+
+      return unless slug_exists
+
+      record.errors[:base] << I18n.t('camaleon_cms.admin.post.message.requires_different_slug').to_s
     end
   end
 end

--- a/app/views/camaleon_cms/default_theme/sitemap.xml.builder
+++ b/app/views/camaleon_cms/default_theme/sitemap.xml.builder
@@ -1,7 +1,7 @@
 xml.instruct! :xml, version: '1.0'
 xml.urlset 'xmlns' => 'https://www.sitemaps.org/schemas/sitemap/0.9' do
   current_site.get_languages.each_with_index do |lang, index|
-    lang = (index.zero? ? nil : lang)
+    lang = (index == 0 ? nil : lang)
     xml.url do
       xml.loc current_site.the_url(locale: lang)
       xml.lastmod current_site.updated_at.to_date

--- a/config/initializers/custom_initializers.rb
+++ b/config/initializers/custom_initializers.rb
@@ -9,4 +9,10 @@ Rails.application.config.to_prepare do |_config|
     f = File.join(ap['path'], 'config', 'custom_models.rb')
     eval(File.read(f)) if File.exist?(f)
   end
+
+  # This can be overridden in the app initializer to wrap the sleep and delete_file in an async job
+  CamaleonCmsUploader.delete_block do |settings, cama_uploader, file_key|
+    sleep(settings[:temporal_time])
+    cama_uploader.delete_file(file_key)
+  end
 end

--- a/config/initializers/custom_initializers.rb
+++ b/config/initializers/custom_initializers.rb
@@ -10,8 +10,16 @@ Rails.application.config.to_prepare do |_config|
     eval(File.read(f)) if File.exist?(f)
   end
 
-  # This can be overridden in the app initializer to wrap the sleep and delete_file in an async job
+  # This block can be overridden in the app initializer to wrap the sleep and delete_file in an async job,
+  # something like this:
+  #
+  # CamaleonDeleteFileJob.set(wait: temporal_time).perform_later(file_key)
+  # # put this in app/jobs/camaleon_delete_file_job.rb:
+  # include CamaleonCms::UploaderHelper
+  # cama_uploader.delete_file(file_key)
   CamaleonCmsUploader.delete_block do |settings, cama_uploader, file_key|
+    next unless Rails.env.test?
+
     sleep(settings[:temporal_time])
     cama_uploader.delete_file(file_key)
   end

--- a/package.json
+++ b/package.json
@@ -12,5 +12,6 @@
   "main": "index.js",
   "repository": "https://github.com/owen2345/camaleon-cms",
   "author": "owen2345 <owenperedo@gmail.com>",
-  "license": "MIT"
+  "license": "MIT",
+  "packageManager": "yarn@4.3.1+sha256.2535167e742927e1d2a1610d5004576e4e8f764d2ca5470d19536790f55cd6e2"
 }

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 describe CamaleonCms::UploaderHelper do
@@ -15,6 +17,34 @@ describe CamaleonCms::UploaderHelper do
 
   it 'upload a local file max size' do
     expect(upload_file(File.open(@path), { maximum: 1.byte }).keys.include?(:error)).to be(true)
+  end
+
+  describe 'deleting temporary uploaded file' do
+    before { allow(CamaleonCmsUploader).to receive(:delete_block).and_call_original }
+
+    it 'delete the uploaded file if temporal_time option is > 0' do
+      expect(CamaleonCmsUploader).to receive(:delete_block)
+      expect_any_instance_of(CamaleonCmsLocalUploader).to receive(:delete_file)
+      expect(upload_file(File.open(@path), { temporal_time: 1 }).keys.include?(:error)).to be(false)
+    end
+
+    it "doesn't delete the uploaded file if temporal_time option is missing" do
+      expect(CamaleonCmsUploader).not_to receive(:delete_block)
+      expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
+      expect(upload_file(File.open(@path)).keys.include?(:error)).to be(false)
+    end
+
+    it "doesn't delete the uploaded file if temporal_time option is 0" do
+      expect(CamaleonCmsUploader).not_to receive(:delete_block)
+      expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
+      expect(upload_file(File.open(@path), { temporal_time: 0 }).keys.include?(:error)).to be(false)
+    end
+
+    it "doesn't delete the uploaded file if temporal_time option is < 0" do
+      expect(CamaleonCmsUploader).not_to receive(:delete_block)
+      expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
+      expect(upload_file(File.open(@path), { temporal_time: -1 }).keys.include?(:error)).to be(false)
+    end
   end
 
   it 'upload a local file custom dimension' do


### PR DESCRIPTION
From the MiniMagick 5.0 release notes:

"Removed deprecated Image#mime_type, as it wasn't accurate.

MIME type from file content should be determined either using Marcel or MimeMagic, or mime-types or MiniMime using Image#type."
