### PR TITLE
Add scss to the styleshhet_link_tag in cama_draw_custom_assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Replace sass-rails with dartsass-sprockets
   - Remove `sass` and `sass-rails` gems from the main app's Gemfile when upgrading `camaleon_cms` to this version
 - Fix colorpicker admin asset's extension from css.scss to just .scss
+- Add scss to the styleshhet_link_tag in cama_draw_custom_assets
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -74,9 +74,10 @@ module CamaleonCms
       libs = []
       @_assets_libraries.each_value do |assets|
         libs += assets[:css] if assets[:css].present?
+        libs += assets[:scss] if assets[:scss].present?
       end
       stylesheets = libs.uniq
-      css = stylesheet_link_tag(*stylesheets, media: 'all')
+      css = stylesheet_link_tag(*stylesheets, extname: false, media: 'all')
 
       libs = []
       @_assets_libraries.each_value do |assets|


### PR DESCRIPTION
Previously, the `colorpicker` asset compilation has been fixed, now fixing for `scss` files to be added to the `styleshhet_link_tag` in `cama_draw_custom_assets`.
