### PR TITLE
Mitigate arbitrary path write in uploader (GHSL-2024-182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Replace sass-rails with dartsass-sprockets
   - Remove `sass` and `sass-rails` gems from the main app's Gemfile when upgrading `camaleon_cms` to this version
 - Fix colorpicker missing admin asset, adding it to `admin-manifest.css`
+- **Security fix:** Mitigate arbitrary path write in uploader (GHSL-2024-182)
+  - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -58,6 +58,9 @@ module CamaleonCms
       hooks_run('before_upload', settings)
       res = { error: nil }
 
+      # guard against path traversal
+      return { error: 'Invalid file path' } unless cama_uploader.class.valid_folder_path?(settings[:folder])
+
       # formats validations
       return { error: "#{ct('file_format_error')} (#{settings[:formats]})" } unless cama_uploader.class.validate_file_format(
         uploaded_io.path, settings[:formats]

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -126,7 +126,7 @@ class CamaleonCmsUploader
   end
 
   def self.valid_folder_path?(path)
-    return false if path.include?("..") || File.absolute_path?(path) || path.include?("://")
+    return false if path.include?('..') || File.absolute_path?(path) || path.include?('://')
 
     true
   end

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -125,6 +125,12 @@ class CamaleonCmsUploader
     valid_formats.include?(File.extname(key).sub('.', '').split('?').first.try(:downcase))
   end
 
+  def self.valid_folder_path?(path)
+    return false if path.include?("..") || File.absolute_path?(path) || path.include?("://")
+
+    true
+  end
+
   # verify if this file name already exist
   # if the file is already exist, return a new name for this file
   # sample: search_new_key("my_file/file.txt")

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -54,7 +54,21 @@ describe CamaleonCms::UploaderHelper do
     expect(upload_file(File.open(@path), { dimension: '50x20?' }).keys.include?(:error)).not_to eql(true)
   end
 
-  it 'upload a local file invalid format' do
+  describe 'file upload with invalid path' do
+    it 'upload a local file with invalid path of a path traversal try' do
+      expect(upload_file(File.open(@path), { folder: '../../config/initializers' }).keys.include?(:error)).to be(true)
+    end
+
+    it 'upload a local file with invalid URI-like path' do
+      expect(upload_file(File.open(@path), { folder: 'file:///config/initializers' }).keys.include?(:error)).to be(true)
+    end
+
+    it 'upload a local file with an absolute path' do
+      expect(upload_file(File.open(@path), { folder: '/tmp/config/initializers' }).keys.include?(:error)).to be(true)
+    end
+  end
+
+  it 'upload a local file with invalid format' do
     expect(upload_file(File.open(@path), { formats: 'audio' }).keys.include?(:error)).to be(true)
   end
 


### PR DESCRIPTION
Thanks GHSL team member @p- for disovering and reporting this!

Arbitrary file write to RCE (GHSL-2024-182) vulnerability reported:

An arbitrary file write vulnerability accessible via the upload method of the `MediaController` allows authenticated users to write arbitrary files to any location on the web server Camaleon CMS is running on (depending on the permissions of the underlying filesystem). E.g. This can lead to a delayed remote code execution in case an attacker is able to write a Ruby file into the config/initializers/ subfolder of the Ruby on Rails application.

This PR fixes the vulnerability by introducing the `CamaleonCmsUploader.valid_folder_path?` method which checks for directory traversal path, absolute file path, and URI-like path.
