### PR TITLE
Revert previous colorpicker asset related changes and just require it in the admin-manifest.css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 - Replace sass-rails with dartsass-sprockets
   - Remove `sass` and `sass-rails` gems from the main app's Gemfile when upgrading `camaleon_cms` to this version
-- Fix colorpicker admin asset's extension from css.scss to just .scss
-- Add scss to the styleshhet_link_tag in cama_draw_custom_assets
+- Fix colorpicker missing admin asset, adding it to `admin-manifest.css`
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/app/assets/stylesheets/camaleon_cms/admin/admin-manifest.css
+++ b/app/assets/stylesheets/camaleon_cms/admin/admin-manifest.css
@@ -22,7 +22,8 @@
  *= require ./uploader/uploader_manifest
  *= require ./_bootstrap-select
 
+ *= require ./colorpicker
+
  // post
  *= require ./_jquery.tagsinput
  */
-

--- a/app/assets/stylesheets/camaleon_cms/admin/colorpicker.css
+++ b/app/assets/stylesheets/camaleon_cms/admin/colorpicker.css
@@ -2,7 +2,7 @@
 .colorpicker-saturation {
     width: 100px;
     height: 100px;
-    background-image: asset-url("camaleon_cms/admin/img/colorpicker/saturation.png");
+    background-image: url("camaleon_cms/admin/img/colorpicker/saturation.png");
     cursor: crosshair;
     float: left;
 }
@@ -47,10 +47,10 @@
     margin-top: -1px;
 }
 .colorpicker-hue {
-    background-image: asset-url("camaleon_cms/admin/img/colorpicker/hue.png");
+    background-image: url("camaleon_cms/admin/img/colorpicker/hue.png");
 }
 .colorpicker-alpha {
-    background-image: asset-url("camaleon_cms/admin/img/colorpicker/alpha.png");
+    background-image: url("camaleon_cms/admin/img/colorpicker/alpha.png");
     display: none;
 }
 .colorpicker {
@@ -80,7 +80,7 @@
     height: 10px;
     margin-top: 5px;
     clear: both;
-    background-image: asset-url("camaleon_cms/admin/img/colorpicker/alpha.png");
+    background-image: url("camaleon_cms/admin/img/colorpicker/alpha.png");
     background-position: 0 100%;
 }
 .colorpicker-color div {

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -74,10 +74,9 @@ module CamaleonCms
       libs = []
       @_assets_libraries.each_value do |assets|
         libs += assets[:css] if assets[:css].present?
-        libs += assets[:scss] if assets[:scss].present?
       end
       stylesheets = libs.uniq
-      css = stylesheet_link_tag(*stylesheets, extname: false, media: 'all')
+      css = stylesheet_link_tag(*stylesheets, media: 'all')
 
       libs = []
       @_assets_libraries.each_value do |assets|
@@ -118,7 +117,7 @@ module CamaleonCms
 
       libs = {}
       libs[:colorpicker] =
-        { js: ['camaleon_cms/admin/bootstrap-colorpicker'], scss: ['camaleon_cms/admin/colorpicker.scss'] }
+        { js: ['camaleon_cms/admin/bootstrap-colorpicker'], css: ['camaleon_cms/admin/colorpicker'] }
       libs[:datepicker] = { js: [] }
       libs[:datetimepicker] = { js: [], css: [] }
       libs[:tinymce] =


### PR DESCRIPTION
It was just forgotten to be added to `admin-manifest.css`.
