### PR TITLE
Mitigate arbitrary path traversal in download_private_file  (GHSL-2024-183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - **Security fix:** Mitigate arbitrary path write in uploader (GHSL-2024-182)
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 - Add Rails 7.2 to stable testing on CI, point rails_edge to main branch
+- **Security fix:** Mitigate arbitrary path traversal in download_private_file (GHSL-2024-183)
+  - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 gemspec
-gem 'non-digest-assets'
+gem 'non-digest-assets', git: 'https://github.com/mvz/non-digest-assets'
 gem 'oj'
-gem 'rails', '~> 7.1.0'
+gem 'rails', '~> 7.2.0'
 gem 'selenium-webdriver'
 gem 'sprockets-rails', '>= 3.5.1'
 

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -30,6 +30,8 @@ module CamaleonCms
 
         file = cama_uploader.fetch_file("private/#{params[:file]}")
 
+        return render plain: helpers.sanitize(file[:error]) if file.is_a?(Hash) && file[:error].present?
+
         send_file file, disposition: 'inline'
       end
 

--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -36,11 +36,11 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
   end
 
   def fetch_file(file_name)
-    bucket.object(file_name).download_file(file_name) unless file_exists?(file_name)
+    return file_name if file_exists?(file_name)
 
-    raise ActionController::RoutingError, 'File not found' unless file_exists?(file_name)
+    return file_name if bucket.object(file_name).download_file(file_name) && file_exists?(file_name)
 
-    file_name
+    { error: 'File not found' }
   end
 
   # parse an AWS file into custom file_object

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -25,6 +25,8 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   end
 
   def fetch_file(file_name)
+    return { error: 'Invalid file path' } if file_name.include?('..')
+
     raise ActionController::RoutingError, 'File not found' unless file_exists?(file_name)
 
     file_name

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -27,9 +27,9 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def fetch_file(file_name)
     return { error: 'Invalid file path' } if file_name.include?('..')
 
-    raise ActionController::RoutingError, 'File not found' unless file_exists?(file_name)
+    return file_name if file_exists?(file_name)
 
-    file_name
+    { error: 'File not found' }
   end
 
   def file_parse(key)

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -25,7 +25,11 @@ Rails.application.configure do
   config.assets.check_precompiled_asset = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  if ::Rails::VERSION::STRING < '7.2.0'
+    config.action_dispatch.show_exceptions = false
+  else
+    config.action_dispatch.show_exceptions = :none
+  end
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -25,11 +25,11 @@ Rails.application.configure do
   config.assets.check_precompiled_asset = false
 
   # Raise exceptions instead of rendering exception templates.
-  if ::Rails::VERSION::STRING < '7.2.0'
-    config.action_dispatch.show_exceptions = false
-  else
-    config.action_dispatch.show_exceptions = :none
-  end
+  config.action_dispatch.show_exceptions = if ::Rails::VERSION::STRING < '7.2.0'
+                                             false
+                                           else
+                                             :none
+                                           end
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/requests/download_private_file_spec.rb
+++ b/spec/requests/download_private_file_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Media requests', type: :request do
+  init_site
+
+  describe 'Download private file' do
+    let(:current_site) { Cama::Site.first.decorate }
+
+    before do
+      allow_any_instance_of(CamaleonCms::Admin::MediaController).to receive(:cama_authenticate)
+      allow_any_instance_of(CamaleonCms::Admin::MediaController).to receive(:current_site).and_return(current_site)
+    end
+
+    context 'when the file path is valid and file exists' do
+      before do
+        allow_any_instance_of(CamaleonCmsLocalUploader).to receive(:fetch_file).and_return('some_file')
+
+        allow_any_instance_of(CamaleonCms::Admin::MediaController).to receive(:send_file)
+        allow_any_instance_of(CamaleonCms::Admin::MediaController).to receive(:default_render)
+      end
+
+      it 'allows the file to be downloaded' do
+        expect_any_instance_of(CamaleonCms::Admin::MediaController).to receive(:send_file).with('some_file', disposition: 'inline')
+
+        get '/admin/media/download_private_file', params: { file: 'some_file' }
+      end
+    end
+
+    context 'when file path is invalid' do
+      it 'returns an error' do
+        get '/admin/media/download_private_file', params: { file: './../../../../../etc/passwd' }
+
+        expect(response.body).to include('Invalid file path')
+      end
+    end
+
+    context 'when the file is not found' do
+      it 'returns an error' do
+        expect { get '/admin/media/download_private_file', params: { file: 'passwd' } }
+          .to raise_error(ActionController::RoutingError, 'File not found')
+      end
+    end
+  end
+end

--- a/spec/requests/download_private_file_spec.rb
+++ b/spec/requests/download_private_file_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Media requests', type: :request do
     end
 
     context 'when file path is invalid' do
-      it 'returns an error' do
+      it 'returns invalid file path error' do
         get '/admin/media/download_private_file', params: { file: './../../../../../etc/passwd' }
 
         expect(response.body).to include('Invalid file path')
@@ -37,9 +37,10 @@ RSpec.describe 'Media requests', type: :request do
     end
 
     context 'when the file is not found' do
-      it 'returns an error' do
-        expect { get '/admin/media/download_private_file', params: { file: 'passwd' } }
-          .to raise_error(ActionController::RoutingError, 'File not found')
+      it 'returns file not found error' do
+        get '/admin/media/download_private_file', params: { file: 'passwd' }
+
+        expect(response.body).to include('File not found')
       end
     end
   end


### PR DESCRIPTION
Thanks GHSL team member @p- for disovering and reporting this!

Arbitrary path traversal in `download_private_file` (GHSL-2024-183) vulnerability reported:

A path traversal vulnerability accessible via MediaController's download_private_file method allows authenticated users to download any file on the web server Camaleon CMS is running on (depending on the file permissions).

This PR fixes the vulnerability by introducing a check in the `CamaleonCmsLocalUploader`'s `fetch_file` method for the filename to not include `..`.


Also, changed the exception-based control flow of the `fetch_file` to just returning errors, because:

- Rails 7.2 changed the behavior to only report errors that are not considered "handled" based on the `ActionDispatch::ExceptionWrapper.rescue_responses` list (see - https://github.com/rails/rails/commit/a8d1d927e80175a38bc62401076bf1cb1e61d796)
- the behavior of the `config.action_dispatch.show_exceptions` has changed - see https://github.com/rails/rails/pull/50339