### PR TITLE
Mitigate stored XSS through user file upload (GHSL-2024-184)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Add Rails 7.2 to stable testing on CI, point rails_edge to main branch
 - **Security fix:** Mitigate arbitrary path traversal in download_private_file (GHSL-2024-183)
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
+- **Security fix:** Mitigate stored XSS through user file upload (GHSL-2024-184)
+  - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -10,6 +10,7 @@ module CamaleonCms
       onpropertychange onratechange onreadystatechange onreset onresize onscroll onsearch onseek onselect onshow
       onstalled onstorage onsuspend ontimeupdate ontoggle onunloadonsubmit onvolumechange onwaiting onwheel
     ].freeze
+    UNSAFE_DETECTION_REGEX = Regexp.union(UNSAFE_EXPRESSIONS + UNSAFE_EVENT_PATTERNS)
 
     include ActionView::Helpers::NumberHelper
     include CamaleonCms::CamaleonHelper
@@ -386,11 +387,11 @@ module CamaleonCms
 
       if file.respond_to?(:binmode)
         file.set_encoding(Encoding::BINARY) if file.respond_to?(:set_encoding)
-        file_content_unsafe = true if Regexp.union(UNSAFE_EXPRESSIONS + UNSAFE_EVENT_PATTERNS).match?(file.read)
+        file_content_unsafe = true if UNSAFE_DETECTION_REGEX.match?(file.read)
       else
         file.each do |line|
           downcased_line = line.downcase
-          break file_content_unsafe = true if downcased_line[Regexp.union(UNSAFE_EXPRESSIONS + UNSAFE_EVENT_PATTERNS)]
+          break file_content_unsafe = true if downcased_line[UNSAFE_DETECTION_REGEX]
         end
       end
 

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -71,7 +71,7 @@ module CamaleonCms
         same_name: false,
         versions: '',
         thumb_size: nil
-      }.merge(settings)
+      }.merge!(settings)
       hooks_run('before_upload', settings)
       res = { error: nil }
 
@@ -214,7 +214,7 @@ module CamaleonCms
     # Return: (String) file path where saved this cropped
     # sample: cama_resize_and_crop(my_file, 200, 200, {gravity: :north_east, overwrite: false})
     def cama_resize_and_crop(file, w, h, settings = {})
-      settings = { gravity: :north_east, overwrite: true, output_name: '' }.merge(settings)
+      settings = { gravity: :north_east, overwrite: true, output_name: +'' }.merge!(settings)
       img = MiniMagick::Image.open(file)
       if file.end_with? '.svg'
         img.format 'jpg'

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -4,7 +4,7 @@ module CamaleonCms
   module UploaderHelper
     SUSPICIOUS_PATTERNS = [
       /<script[\s>]/i,  # Script tags
-      /on\w+\s*=/i,     # Inline event handlers like onload, onclick, etc.
+      /on\w{3,}\s*=/i,  # Inline event handlers like oncut, onload, onclick, etc.
       /javascript:/i,   # JavaScript in href/src attributes
       /<iframe[\s>]/i,  # Iframes
       /<object[\s>]/i,  # Object tags

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -126,6 +126,8 @@ class CamaleonCmsUploader
   end
 
   def self.valid_folder_path?(path)
+    return true if path == '/'
+
     return false if path.include?('..') || File.absolute_path?(path) || path.include?('://')
 
     true

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -74,7 +74,7 @@ describe CamaleonCms::UploaderHelper do
 
     it "doesn't allow the file upload, returning an error" do
       expect(upload_file(File.open(unsafe_file_path), { folder: '/' })[:error])
-        .to eql('Files with unsafe content not allowed')
+        .to eql('Potentially malicious content found!')
     end
   end
 

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe CamaleonCms::UploaderHelper do
   init_site
+
   before do
     @path = "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/rails_tmp.png"
     FileUtils.cp("#{CAMALEON_CMS_ROOT}/spec/support/fixtures/rails.png", @path)
@@ -65,6 +66,15 @@ describe CamaleonCms::UploaderHelper do
 
     it 'upload a local file with an absolute path' do
       expect(upload_file(File.open(@path), { folder: '/tmp/config/initializers' }).keys.include?(:error)).to be(true)
+    end
+  end
+
+  describe 'file upload with unsafe content' do
+    let(:unsafe_file_path) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/unsafe-test-xss.svg" }
+
+    it "doesn't allow the file upload, returning an error" do
+      expect(upload_file(File.open(unsafe_file_path), { folder: '/' })[:error])
+        .to eql('Files with unsafe content not allowed')
     end
   end
 

--- a/spec/support/fixtures/unsafe-test-xss.svg
+++ b/spec/support/fixtures/unsafe-test-xss.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+        xmlns:dc="http://purl.org/dc/elements/1.1/"
+        xmlns:cc="http://creativecommons.org/ns#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:svg="http://www.w3.org/2000/svg"
+        xmlns="http://www.w3.org/2000/svg"
+        width="500"
+        height="500"
+        viewBox="0 0 198.4375 52.916666"
+        version="1.1">
+  <g
+          transform="translate(-9.8676114,4.8833333)">
+    <path
+            d="m 107.79557,-10.430538 -7.33315,-0.02213 -3.647402,-6.361755 3.685742,-6.339624 7.33314,0.02213 3.64741,6.361756 z"
+            style="fill:#131f6b;fill-opacity:1;stroke-width:0.05937638"
+            transform="scale(1,-1)" />
+    <!-- The below lines were added in a text editor to the image XML. This is the stored XSS attack. -->
+    <script type="text/javascript">
+      alert("This is an example of a stored XSS attack in an SVG image, here's the cookie: " + document.cookie);
+    </script>
+  </g>
+</svg>


### PR DESCRIPTION
Thanks GHSL team member @p- for disovering and reporting this!

Stored XSS through user file upload  (GHSL-2024-184) vulnerability reported:

A stored cross-site scripting has been found in the image upload functionality that can be used by normal registered users: It is possible to upload a SVG image containing JavaScript and it's also possible to upload a HTML document when the format parameter is manually changed to [documents](https://github.com/owen2345/camaleon-cms/blob/feccb96e542319ed608acd3a16fa5d92f13ede67/app/uploaders/camaleon_cms_uploader.rb#L105-L106) or a string of an [unsupported format](https://github.com/owen2345/camaleon-cms/blob/feccb96e542319ed608acd3a16fa5d92f13ede67/app/uploaders/camaleon_cms_uploader.rb#L110-L111). If an authenticated user or administrator visits that uploaded image or document malicious JavaScript can be executed on their behalf (e.g. changing or deleting content inside of the CMS.)

This PR fixes the vulnerability by introducing the `file_content_unsafe?` method, which is scanning the file content for unsafe expressions and patterns in the `upload_file` method of the `CamaleonCms::UploaderHelper`.
