### PR TITLE
Mitigate remote code execution through code injection (GHSL-2024-185)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 - **Security fix:** Mitigate stored XSS through user file upload (GHSL-2024-184)
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
+- **Security fix:** Mitigate remote code execution through code injection (GHSL-2024-185)
+  - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 - **Security fix:** Mitigate arbitrary file delete vulnerability (GHSL-2024-186)
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 - Use actions/checkout@v4 on CI to remove warning about deprecated Node JS version

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -24,12 +24,9 @@ module CamaleonCms
     # -  options (textbox sample):  {"field_key":"text_box","multiple":"1","required":"1",
     #     "translate":"1"}
     #   * field_key (string) | translate (boolean) | default_value (unique value) |
-    #      default_values (array - multiple values for this field) | label_eval (boolean) |
-    #      multiple_options (array)
+    #      default_values (array - multiple values for this field) | multiple_options (array)
     #   * multiple_options (used for select, radio and checkboxes ): [{"title"=>"Option Title",
     #      "value"=>"2", "default"=>"1"}, {"title"=>"abcde", "value"=>"3"}]
-    #   * label_eval: (Boolean, default false), true => will evaluate the label and description of
-    #       current field using (eval('my_label')) to have translatable|dynamic labels
     # ****** check all options for each case in Admin::CustomFieldsHelper ****
     # SAMPLE: my_model.add_field({"name"=>"Sub Title", "slug"=>"subtitle"}, {"field_key"=>"text_box",
     #   "translate"=>true, default_value: "Get in Touch"})

--- a/app/views/camaleon_cms/admin/settings/custom_fields/_get_items.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/_get_items.html.erb
@@ -23,7 +23,6 @@
       <div class="panel-body">
         <%= hidden_field(:fields, :id, index: @index, value: @item_id) %>
         <%= hidden_field(:field_options, :field_key, index: @index, value: @key) %>
-        <%= hidden_field(:field_options, :label_eval, index: @index, value: @item_options_value[:label_eval].to_s.cama_true? ? 'true' : '') %>
         <%= hidden_field(:field_options, :panel_hidden, index: @index, value: @item_options_value[:panel_hidden], class: 'input-panel-hidden') %>
         <div class="form-group input-group-sm">
           <label for=""><%= t('camaleon_cms.admin.table.name') %></label><br>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
@@ -20,14 +20,14 @@
                             <input name="<%= field_name %>[<%= field.slug %>][id]" type="hidden" value="<%= field.id %>"/>
                             <input name="<%= field_name %>[<%= field.slug %>][group_number]" class="cama_custom_group_number" type="hidden" value="0"/>
                             <label>
-                                <%= field.options[:label_eval].present? ? eval(field.name) : field.name %>
+                                <%= field.name %>
                                 <%= raw "<em class='text-danger'>*</em>" if field.options[:required].to_s.to_bool %>
                                 <% if current_site.get_option('custom_fields_show_shortcodes') && ["post", "posttype", "category", "postTag", "site", "user", "navmenu", "theme"].include?(obj_class) %>
                                     <small class="shortcode_field"><br><%= raw cama_shortcode_print("[data field='#{field.slug}' #{"object='#{obj_class}' #{"id='#{record.id}'" if obj_class != "Theme" }" unless record.new_record?}]") %></small>
                                 <% end %>
                             </label>
                             <% if field.description.present? %>
-                                <p><small><%= field.options[:label_eval].present? ? eval(field.description) : field.description %></small></p>
+                                <p><small><%= field.description %></small></p>
                             <% end  %>
                             <div class="editor-custom-fields content-field-<%= field.id %>" data-add_field_title="<%= t('camaleon_cms.admin.button.add_new_field', default: 'Add new field')%>">
                                 <%= begin


### PR DESCRIPTION
Thanks GHSL team member @p- for disovering and reporting this!

Remote code execution through code injection (GHSL-2024-185) vulnerability reported:

"The pages rendering custom fields contain a hidden feature called label evaluation, that can be enabled when creating custom field groups. If an attacker performed an account takeover of an administrator account (See: GHSL-2024-184) they can execute arbitrary Ruby code on the server hosting Camaleon CMS.

If the (hidden) custom field option label_eval was set when creating the custom field form, the text of the label is evaluated when it's rendered."

This PR fixes the vulnerability by removing the hidden `label_eval` field and removing the calls to `eval` the `field.name` and `field.description`.
