### PR TITLE
Mitigate Arbitrary file delete vulnerability (GHSL-2024-186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 - **Security fix:** Mitigate stored XSS through user file upload (GHSL-2024-184)
   - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
+- **Security fix:** Mitigate arbitrary file delete vulnerability (GHSL-2024-186)
+  - Thanks [Peter Stöckli](https://github.com/p-) for reporting and providing clear reproduction steps
 
 ## [2.8.0](https://github.com/owen2345/camaleon-cms/tree/2.8.0) (2024-07-26)
 - Use jQuery 2.x - 2.2.4

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -2,7 +2,7 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def after_initialize
     @root_folder = @args[:root_folder] || @current_site.upload_directory
 
-    FileUtils.mkdir_p(@root_folder)
+    FileUtils.mkdir_p(@root_folder) unless Dir.exist?(@root_folder)
   end
 
   def setup_private_folder
@@ -109,6 +109,8 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
 
   # remove an existent folder
   def delete_folder(key)
+    return { error: 'Invalid folder path' } if key.include?('..')
+
     folder = File.join(@root_folder, key)
     FileUtils.rm_rf(folder) if Dir.exist? folder
     get_media_collection.find_by_key(key).take.destroy
@@ -116,6 +118,8 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
 
   # remove an existent file
   def delete_file(key)
+    return { error: 'Invalid file path' } if key.include?('..')
+
     file = File.join(@root_folder, key)
     FileUtils.rm(file) if File.exist? file
     @instance.hooks_run('after_delete', key)

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -1,6 +1,6 @@
 class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def after_initialize
-    @root_folder = @args[:root_folder] || @current_site.upload_directory
+    @root_folder = @current_site.upload_directory
 
     FileUtils.mkdir_p(@root_folder) unless Dir.exist?(@root_folder)
   end

--- a/spec/uploaders/local_uploader_spec.rb
+++ b/spec/uploaders/local_uploader_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCmsLocalUploader do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:uploader) { described_class.new(current_site: current_site) }
+
+  describe '#delete_folder' do
+    it 'returns an error' do
+      expect(uploader.delete_folder('../tmp')).to eql(error: 'Invalid folder path')
+    end
+  end
+
+  describe '#delete_file' do
+    it 'returns an error' do
+      expect(uploader.delete_file('../test.rb')).to eql(error: 'Invalid file path')
+    end
+  end
+end


### PR DESCRIPTION
Thanks GHSL team member @p- for disovering and reporting this!

Arbitrary file delete in `MediaController#delete_file` (GHSL-2024-186) vulnerability reported:

"The `actions` method, defined inside of the MediaController class, doesn't check whether a given path is inside a certain path (e.g. inside the media folder). If an attacker performed an account takeover of an administrator account (See: GHSL-2024-184) they could delete arbitrary files or folders on the server hosting Camaleon CMS".

The report, though, isn't accurate, because the `@current_site.upload_directory` folder is prefixing the folder or file name to delete in the  `delete_folder` and `delete_file` methods. What's missing, is a traversal check.

This PR fixes the vulnerability by introducing a check for path traversal check into the `delete_folder` and `delete_file` methods of the `CamaleonCmsLocalUploader`.
