### PR TITLE
Fix TermTaxonomy attributes sanitizing to not remove translation tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix `TermTaxonomy` attributes sanitizing to not remove translation tags
+
 ## [2.8.1](https://github.com/owen2345/camaleon-cms/tree/2.8.1) (2024-08-21)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -29,8 +29,8 @@ module CamaleonCms
           next unless new_record? || attribute_changed?(attr)
 
           self[attr] = ActionController::Base.helpers.sanitize(
-            __send__(attr).gsub(TRANSLATION_TAG_HIDE_REGEX, TRANSLATION_TAG_HIDE_MAP)
-          ).gsub(TRANSLATION_TAG_RESTORE_REGEX, TRANSLATION_TAG_RESTORE_MAP)
+            __send__(attr)&.gsub(TRANSLATION_TAG_HIDE_REGEX, TRANSLATION_TAG_HIDE_MAP)
+          )&.gsub(TRANSLATION_TAG_RESTORE_REGEX, TRANSLATION_TAG_RESTORE_MAP)
         end
       end
     else

--- a/spec/shared_specs/sanitize_attrs.rb
+++ b/spec/shared_specs/sanitize_attrs.rb
@@ -2,22 +2,21 @@
 
 RSpec.shared_examples 'sanitize attrs' do |model:, attrs_to_sanitize:|
   attrs_to_sanitize.each do |attr|
-    it 'sanitizes name attribute on create' do
-      attrs_for_creation = { attr => '"><script>alert(1)</script>' }
+    it 'sanitizes attributes on create, not touching translation tags' do
+      attrs_for_creation = { attr => '<!--:en-->"><script>alert(1)</script>' }
       attrs_for_creation.merge!(site: @site) if defined?(@site)
       model_instance = model.create(attrs_for_creation)
 
-      expect(model_instance.__send__(attr)).to eql('"&gt;alert(1)')
+      expect(model_instance.__send__(attr)).to eql('<!--:en-->"&gt;alert(1)')
     end
 
-    it 'sanitizes name attribute on update' do
+    it 'sanitizes attributes on update, not touching translation tags' do
       attrs_for_creation = { attr => 'Legit text' }
       attrs_for_creation.merge!(site: @site) if defined?(@site)
       model_instance = model.create(attrs_for_creation)
-      # attrs_for_creation = { attr => '"><script>alert(1)</script>' }
-      model_instance.update(attr => '"><script>alert(1)</script>')
+      model_instance.update(attr => '<!--:en-->"><script>alert(1)</script>')
 
-      expect(model_instance.__send__(attr)).to eql('"&gt;alert(1)')
+      expect(model_instance.__send__(attr)).to eql('<!--:en-->"&gt;alert(1)')
     end
   end
 end


### PR DESCRIPTION
Sanitization of the `TermTaxonomy` attributes were surprizingly removing translation tags.

So, instead of a `<!--:en-->Vineyards<!--:--><!--:ru-->Виноградники<!--:--><!--:md-->Podgorii<!--:-->` attr value, the `VineyardsВиноградникиPodgorii` was stored into the DB.

This PR fixes the issue, hiding the translation tags before sanitizing them, and restoring them afterwards.
