### PR TITLE
Add magic comment to use mutable strings

### DIFF
--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: false
+
 require 'json'
 class PluginRoutes
   @@_vars = []


### PR DESCRIPTION
Ruby 3.4 issues deprecation warnings when mutating strings in a file that does not have a `frozen_string_literal: false` comment. When testing my app locally with Ruby 3.4, there are deprecation warnings because plugin_routes.rb uses mutated strings.

This PR adds a magic comment to that file to silence the deprecation warnings and to ensure that the current behavior will continue even after a future version of Ruby freezes strings by default.