### PR TITLE
Address false positives on malicious upload check

### DIFF
--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -2,16 +2,23 @@
 
 module CamaleonCms
   module UploaderHelper
-    SUSPICIOUS_PATTERNS = [
+    UNSAFE_EVENT_PATTERNS = %w[
+      onabort onafter onbefore onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick
+      ondrag ondrop ondurationchange onended onerror onfocus onhashchange oninvalid oninput onkey onload onmessage
+      onmouse ononline onoffline onpagehide onpageshow onpage onpaste onpause onplay onpopstate onprogress
+      onpropertychange onratechange onreadystatechange onreset onresize onscroll onsearch onseek onselect onshow
+      onstalled onstorage onsuspend ontimeupdate ontoggle onunloadonsubmit onvolumechange onwaiting onwheel
+    ].map { |pattern| /#{pattern}\w*\s*=/i }.freeze
+
+    SUSPICIOUS_PATTERNS = (UNSAFE_EVENT_PATTERNS + [
       /<script[\s>]/i,  # Script tags
-      /on\w{3,}\s*=/i,  # Inline event handlers like oncut, onload, onclick, etc.
       /javascript:/i,   # JavaScript in href/src attributes
       /<iframe[\s>]/i,  # Iframes
       /<object[\s>]/i,  # Object tags
       /<embed[\s>]/i,   # Embed tags
       /<base[\s>]/i,    # Base tags (can be used to manipulate URLs)
       /data:/i          # data: URLs (which can include scripts)
-    ].freeze
+    ]).freeze
 
     include ActionView::Helpers::NumberHelper
     include CamaleonCms::CamaleonHelper


### PR DESCRIPTION
Fixes #1106 

This is based on [an earlier version](https://github.com/owen2345/camaleon-cms/commit/cad7c8e3e2a7623cafd42410045b61fe0907c8ac) of @texpert 's work. I did not alter the list of attributes screened for in that work, I just reimplemented them to address the issue above caused by the more general regexp.