### PR TITLE
Remove deprecated method

### DIFF
--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -303,7 +303,7 @@ module CamaleonCms
 
     def fix_meta_value(value)
       return value.to_json if value.is_a?(ActionController::Parameters)
-      return JSON.fast_generate(value) if value.is_a?(Array) || value.is_a?(Hash)
+      return JSON.generate(value) if value.is_a?(Array) || value.is_a?(Hash)
 
       value
     end

--- a/app/models/concerns/camaleon_cms/metas.rb
+++ b/app/models/concerns/camaleon_cms/metas.rb
@@ -134,7 +134,7 @@ module CamaleonCms
       changed_value = if value.is_a?(ActionController::Parameters)
                         value.to_json
                       elsif value.is_a?(Array) || value.is_a?(Hash)
-                        JSON.fast_generate(value)
+                        JSON.generate(value)
                       else
                         value
                       end

--- a/lib/ext/string.rb
+++ b/lib/ext/string.rb
@@ -1,7 +1,7 @@
 class String
   def to_bool
-    return true if self == true || self =~ (/(true|t|yes|y|1)$/i)
-    return false if self == false || blank? || self =~ (/(false|f|no|n|0)$/i)
+    return true if self == true || self =~ /(true|t|yes|y|1)$/i
+    return false if self == false || blank? || self =~ /(false|f|no|n|0)$/i
 
     raise ArgumentError, "invalid value for Boolean: \"#{self}\""
   end


### PR DESCRIPTION
JSON.fast_generate will be removed in version 3 of the json gem.