### PR TITLE
Fix Improper escaping of output `posts.sendparams` endpoint that allows arbitrary file write

### DIFF
--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -41,9 +41,11 @@ module CamaleonCms
         @posts = posts_all
         params[:s] = 'published' unless params[:s].present?
         @lists_tab = params[:s]
-        case params[:s]
+        allowed_statuses = %w[published pending trash draft all]
+        status = allowed_statuses.include?(params[:s]) ? params[:s] : 'published'
+        case status
         when 'published', 'pending', 'trash'
-          @posts = @posts.send(params[:s])
+          @posts = @posts.send(status)
         when 'draft'
           @posts = @posts.drafts
         when 'all'


### PR DESCRIPTION
https://github.com/owen2345/camaleon-cms/blob/67de8835871935b18409c1a87a1666641c69c420/app/controllers/camaleon_cms/admin/posts_controller.rb#L46-L46

Directly evaluating user input (an HTTP request parameter) as code without first sanitizing the input allows an attacker arbitrary code execution. This can occur when user input is passed to code that interprets it as an expression to be evaluated, using methods such as `Kernel.eval` or `Kernel.send`.


fix the issue, we need to ensure that the value of `params[:s]` is explicitly validated against a whitelist of allowed values before it is passed to the `send` method. This can be achieved by introducing a validation step that checks if `params[:s]` is one of the permitted values (`'published'`, `'pending'`, `'trash'`, `'draft'`, `'all'`). If the value is not valid, we can either set a default value or handle the error appropriately.

The fix involves:
- Defining a whitelist of allowed values for `params[:s]`.
- Validating `params[:s]` against this whitelist before using it in the `send` method.
- Replacing the direct use of `params[:s]` in the `send` method with the validated value.

