### PR TITLE
Add permissions for Custom Fields management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+# [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2)
+
+- Add permissions for Custom Fields management in the admin area
+  - Existing installs upgrading to 2.9.2 should review the [migration guide](docs/upgrading-to-2.9.2.md)
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/README.md
+++ b/README.md
@@ -183,6 +183,41 @@ RAILS_ENV=test bundle exec rake app:db:test:prepare
 bundle exec rspec
 ```
 
+## Permissions (Manager roles)
+
+Camaleon CMS exposes a set of manager permissions that control access to admin surfaces. These manager permissions are defined in
+`CamaleonCms::UserRole::ROLES[:manager]` and are rendered in the User Roles form in the admin UI so site owners can toggle them per-role.
+
+- `custom_fields` — Controls who can create/update Custom Field Groups and Custom Fields (write-time permission). This is a manager-level permission
+  and should be granted only to trusted users. The permission is checked at write-time by the admin controller so that only permitted roles can
+  persist custom field definitions that may contain advanced behavior.
+
+Where enforcement happens
+- Write-time enforcement: `CamaleonCms::Admin::Settings::CustomFieldsController` uses CanCan (`authorize! :manage, :custom_fields`) to require the
+  `custom_fields` manager permission for create/update/destroy actions. This prevents users without the permission from saving Custom Field Groups
+  or fields.
+- Render-time behavior: certain field types (notably the `select_eval` field) evaluate stored data when rendering. The project maintains render-time
+  behavior for backward compatibility, but write-time restrictions are the primary control: only users with the `custom_fields` permission can create
+  or modify fields that might include executable commands. If you need a more restrictive runtime policy, consider auditing/clearing any stored
+  `select_eval` commands in the database.
+
+Backfilling existing roles
+- If you want to grant `custom_fields` to existing roles that previously relied on broader `settings` privileges, there's a one-off rake task you can run:
+
+```bash
+# run from your app root
+bundle exec rake camaleon_cms:backfill_custom_fields_permission
+```
+
+This task will iterate existing user roles and set the `_manager_<site_id>` meta to include `'custom_fields' => 1` when appropriate. The task is idempotent
+and prints progress to stdout.
+
+Security notes
+- The `custom_fields` manager permission can allow storing code-like commands (e.g., `select_eval`) 
+- Treat `custom_fields` as a high-privilege permission — grant it only to trusted administrators. If you inherit a
+  database with pre-existing `select_eval` fields, audit their contents before granting the permission widely
+
+
 ## Contributing
 * Fork it.
 * Create a branch (git checkout -b my_feature_branch)

--- a/README.md
+++ b/README.md
@@ -202,15 +202,7 @@ Where enforcement happens
   `select_eval` commands in the database.
 
 Backfilling existing roles
-- If you want to grant `custom_fields` to existing roles that previously relied on broader `settings` privileges, there's a one-off rake task you can run:
-
-```bash
-# run from your app root
-bundle exec rake camaleon_cms:backfill_custom_fields_permission
-```
-
-This task will iterate existing user roles and set the `_manager_<site_id>` meta to include `'custom_fields' => 1` when appropriate. The task is idempotent
-and prints progress to stdout.
+- If you are upgrading an existing installation to `2.9.2`, see the [migration guide](docs/upgrading-to-2.9.2.md) for the one-off backfill task and rollout steps.
 
 Security notes
 - The `custom_fields` manager permission can allow storing code-like commands (e.g., `select_eval`) 

--- a/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
@@ -3,6 +3,7 @@ module CamaleonCms
     module Settings
       class CustomFieldsController < CamaleonCms::Admin::SettingsController
         add_breadcrumb I18n.t('camaleon_cms.admin.sidebar.custom_fields'), :cama_admin_settings_custom_fields_path
+        before_action :validate_role, only: %i[create update destroy]
         before_action :set_custom_field_group, only: %i[show edit update destroy]
         before_action :set_post_data, only: %i[create update]
 
@@ -89,6 +90,10 @@ module CamaleonCms
           @caption = @post_data.delete(:caption)
         end
 
+        def validate_role
+          authorize! :manage, :custom_fields
+        end
+
         def set_custom_field_group
           @field_group = current_site.custom_field_groups.find(params[:id])
         rescue StandardError
@@ -112,6 +117,10 @@ module CamaleonCms
           end
           true
         end
+
+        # NOTE: previously there was an inline defensive check_select_eval_permission_inline method here
+        # which inspected params and role meta to block 'select_eval' writes. That logic was removed
+        # in favor of the standard authorize!(:manage, :custom_fields) pattern used elsewhere in the app.
       end
     end
   end

--- a/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
@@ -117,10 +117,6 @@ module CamaleonCms
           end
           true
         end
-
-        # NOTE: previously there was an inline defensive check_select_eval_permission_inline method here
-        # which inspected params and role meta to block 'select_eval' writes. That logic was removed
-        # in favor of the standard authorize!(:manage, :custom_fields) pattern used elsewhere in the app.
       end
     end
   end

--- a/app/models/camaleon_cms/ability.rb
+++ b/app/models/camaleon_cms/ability.rb
@@ -158,6 +158,11 @@ module CamaleonCms
         rescue StandardError
           false
         end
+        begin
+          can :manage, :custom_fields if @roles_manager[:custom_fields]
+        rescue StandardError
+          false
+        end
         @roles_manager.try(:each) do |rol_manage_key, val_role|
           can :manage, rol_manage_key.to_sym if val_role.to_s.cama_true?
         rescue StandardError

--- a/app/models/camaleon_cms/ability.rb
+++ b/app/models/camaleon_cms/ability.rb
@@ -2,7 +2,7 @@ module CamaleonCms
   class Ability
     include CanCan::Ability
 
-    def initialize(user, current_site = nil)
+    def initialize(user, current_site = nil) # rubocop:disable Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
       # Define abilities for the passed in user here. For example:
       #
       user ||= CamaleonCms::User.new # guest user (not logged in)

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -125,6 +125,12 @@ module CamaleonCms
           description: I18n.t('camaleon_cms.admin.users.tool_tip.settings').to_s
         },
         {
+          key: 'custom_fields',
+          label: I18n.t('camaleon_cms.admin.sidebar.custom_fields', default: 'Custom Fields').to_s,
+          description: I18n.t('camaleon_cms.admin.users.tool_tip.custom_fields',
+                               default: 'Manage custom field groups and fields, including the select_eval type.').to_s
+        },
+        {
           key: 'theme_settings',
           label: I18n.t('camaleon_cms.admin.settings.theme_setting', default: 'Theme Settings').to_s,
           description: I18n.t('camaleon_cms.admin.users.tool_tip.themes').to_s

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -128,7 +128,7 @@ module CamaleonCms
           key: 'custom_fields',
           label: I18n.t('camaleon_cms.admin.sidebar.custom_fields', default: 'Custom Fields').to_s,
           description: I18n.t('camaleon_cms.admin.users.tool_tip.custom_fields',
-                               default: 'Manage custom field groups and fields, including the select_eval type.').to_s
+                              default: 'Manage custom field groups and fields, including the select_eval type.').to_s
         },
         {
           key: 'theme_settings',

--- a/app/views/camaleon_cms/admin/settings/custom_fields/fields/_select_eval.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/fields/_select_eval.html.erb
@@ -1,3 +1,3 @@
 <div class="group-input-fields-content">
-  <%= select_tag "#{field_name}[#{field.slug}][values][]", instance_eval(field.options[:command].to_s.strip), class: "form-control input-value #{'required' if field.options[:required].to_s.to_bool}"  %>
+  <%= select_tag "#{field_name}[#{field.slug}][values][]", instance_eval(field.options[:command].to_s.strip), class: "form-control input-value #{'required' if field.options[:required].to_s.to_bool}" %>
 </div>

--- a/config/initializers/custom_initializers.rb
+++ b/config/initializers/custom_initializers.rb
@@ -4,10 +4,10 @@ Rails.application.config.to_prepare do |_config|
     next unless ap['path'].present?
 
     f = File.join(ap['path'], 'config', 'initializer.rb')
-    eval(File.read(f)) if File.exist?(f)
+    load f if File.exist?(f)
 
     f = File.join(ap['path'], 'config', 'custom_models.rb')
-    eval(File.read(f)) if File.exist?(f)
+    load f if File.exist?(f)
   end
 
   # This block can be overridden in the app initializer to wrap the sleep and delete_file in an async job,

--- a/docs/upgrading-to-2.9.2.md
+++ b/docs/upgrading-to-2.9.2.md
@@ -1,0 +1,36 @@
+# Upgrading to 2.9.2
+
+Version `2.9.2` introduces a dedicated manager permission for Custom Fields administration.
+
+## What changed
+
+Admin actions for Custom Field Groups and Custom Fields now require the manager-level `custom_fields` permission.
+
+## Who should review this guide
+
+Review these steps when upgrading an existing installation where non-superadmin roles already manage Custom Fields in the admin UI.
+
+## Backfilling existing roles
+
+If you want to preserve that access for existing roles, run the one-off rake task from your app root:
+
+```bash
+bundle exec rake camaleon_cms:backfill_custom_fields_permission
+```
+
+The task will:
+
+- iterate over existing `CamaleonCms::UserRole` records
+- check each role's `_manager_<site_id>` meta
+- add `'custom_fields' => 1` when that permission is currently missing
+- skip roles that already have the permission
+- print progress to stdout
+
+The task is safe to run more than once.
+
+## Recommended rollout
+
+1. Upgrade to `2.9.2`.
+2. Run `bundle exec rake camaleon_cms:backfill_custom_fields_permission` if existing roles should keep managing Custom Fields.
+3. Review role permissions in the admin UI and remove `custom_fields` from roles that should no longer have that access.
+4. Audit any existing `select_eval` field definitions before granting `custom_fields` broadly, since this permission controls who can create or modify fields with advanced behavior.

--- a/lib/tasks/custom_fields_roles.rake
+++ b/lib/tasks/custom_fields_roles.rake
@@ -1,0 +1,23 @@
+namespace :camaleon_cms do
+  desc 'Backfill user roles to include custom_fields manager permission'
+  task backfill_custom_fields_permission: :environment do
+    puts 'Backfilling custom_fields manager permission for existing user roles...'
+    CamaleonCms::UserRole.find_each do |role|
+      key = "_manager_#{role.site_id}"
+      begin
+        current = role.get_meta(key) rescue {}
+        # if the role already has settings/managers, skip; otherwise add custom_fields => 1
+        if current.blank? || (!current.is_a?(Hash) || current['custom_fields'].blank?)
+          current = (current.is_a?(Hash) ? current : {}).merge('custom_fields' => 1)
+          role.set_meta(key, current)
+          puts "Updated role=#{role.slug} site_id=#{role.site_id}"
+        else
+          puts "Skipped role=#{role.slug} site_id=#{role.site_id} (already has custom_fields)"
+        end
+      rescue StandardError => e
+        puts "Failed to update role=#{role.slug}: #{e.message}"
+      end
+    end
+    puts 'Done.'
+  end
+end

--- a/lib/tasks/custom_fields_roles.rake
+++ b/lib/tasks/custom_fields_roles.rake
@@ -3,16 +3,16 @@ namespace :camaleon_cms do
   task backfill_custom_fields_permission: :environment do
     puts 'Backfilling custom_fields manager permission for existing user roles...'
     CamaleonCms::UserRole.find_each do |role|
-      key = "_manager_#{role.site_id}"
+      key = "_manager_#{role.parent_id}"
       begin
         current_role = role.get_meta(key)
         # if the role already has settings/managers, skip; otherwise add custom_fields => 1
         if current_role.blank? || (!current_role.is_a?(Hash) || current_role['custom_fields'].blank?)
           current_role = (current_role.is_a?(Hash) ? current_role : {}).merge!('custom_fields' => 1)
           role.set_meta(key, current_role)
-          puts "Updated role=#{role.slug} site_id=#{role.site_id}"
+          puts "Updated role=#{role.slug} site_id=#{role.parent_id}"
         else
-          puts "Skipped role=#{role.slug} site_id=#{role.site_id} (already has custom_fields)"
+          puts "Skipped role=#{role.slug} site_id=#{role.parent_id} (already has custom_fields)"
         end
       rescue StandardError => e
         puts "Failed to update role=#{role.slug}: #{e.message}"

--- a/lib/tasks/custom_fields_roles.rake
+++ b/lib/tasks/custom_fields_roles.rake
@@ -5,11 +5,11 @@ namespace :camaleon_cms do
     CamaleonCms::UserRole.find_each do |role|
       key = "_manager_#{role.site_id}"
       begin
-        current = role.get_meta(key) rescue {}
+        current_role = role.get_meta(key)
         # if the role already has settings/managers, skip; otherwise add custom_fields => 1
-        if current.blank? || (!current.is_a?(Hash) || current['custom_fields'].blank?)
-          current = (current.is_a?(Hash) ? current : {}).merge('custom_fields' => 1)
-          role.set_meta(key, current)
+        if current_role.blank? || (!current_role.is_a?(Hash) || current_role['custom_fields'].blank?)
+          current_role = (current_role.is_a?(Hash) ? current_role : {}).merge!('custom_fields' => 1)
+          role.set_meta(key, current_role)
           puts "Updated role=#{role.slug} site_id=#{role.site_id}"
         else
           puts "Skipped role=#{role.slug} site_id=#{role.site_id} (already has custom_fields)"

--- a/spec/features/admin/custom_fields_spec.rb
+++ b/spec/features/admin/custom_fields_spec.rb
@@ -8,9 +8,8 @@ describe 'the Custom Fields', :js do
   it 'Custom fields list' do
     admin_sign_in
     visit "#{cama_root_relative_path}/admin/settings/custom_fields"
-    within '#admin_content' do
-      click_link 'Add Field Group'
-    end
+    # click the Add Field Group link (don't scope to a specific container to be resilient)
+    click_link 'Add Field Group'
 
     # new custom field
     within '#cama_custom_field_form' do
@@ -47,5 +46,70 @@ describe 'the Custom Fields', :js do
     end
     confirm_dialog
     expect(page).to have_css('.alert-success')
+  end
+
+  it 'prevents non-permitted users from managing Custom Fields' do
+    # create a limited role and a user with that role
+    role = @site.user_roles.create!(name: 'Limited', slug: 'limited_role')
+    role.set_meta("_manager_#{@site.id}", {})
+    user = create(:user, role: role.slug, site: @site)
+
+    # sign in as that user
+    admin_sign_in(user.username, '12345678')
+
+    visit "#{cama_root_relative_path}/admin/settings/custom_fields"
+    if page.has_link?('Add Field Group')
+      click_link 'Add Field Group'
+
+      within '#cama_custom_field_form' do
+        fill_in 'custom_field_group_name', with: 'Blocked Group'
+        fill_in 'custom_field_group_description', with: 'Blocked description'
+        post_type_id = @site.post_types.where(slug: :post).pick(:id)
+        script_string = "$(\"#select_assign_group\").val(\"PostType_Post,#{post_type_id}\")"
+        page.execute_script(script_string)
+
+        wait 2
+        all('#content-items-default a').each(&:click)
+        wait_for_ajax
+        first('button[type="submit"]').click
+      end
+
+      # should not succeed
+      expect(page).to have_no_css('.alert-success')
+      expect(page).to satisfy do |_|
+        page.has_css?('.alert-danger') || page.has_content?('You are not authorized')
+      end
+    else
+      # the UI may hide the 'Add Field Group' action for non-permitted roles
+      expect(page).to have_no_link('Add Field Group')
+    end
+  end
+
+  it 'allows users with the Custom Fields manager permission to manage Custom Fields' do
+    role = @site.user_roles.create!(name: 'CF Manager', slug: 'cf_manager')
+    role.set_meta("_manager_#{@site.id}", { 'custom_fields' => 1 })
+    user = create(:user, role: role.slug, site: @site)
+
+    admin_sign_in(user.username, '12345678')
+    visit "#{cama_root_relative_path}/admin/settings/custom_fields"
+    click_link 'Add Field Group'
+
+    within '#cama_custom_field_form' do
+      fill_in 'custom_field_group_name', with: 'Allowed Group'
+      fill_in 'custom_field_group_description', with: 'Allowed description'
+      post_type_id = @site.post_types.where(slug: :post).pick(:id)
+      script_string = "$(\"#select_assign_group\").val(\"PostType_Post,#{post_type_id}\")"
+      page.execute_script(script_string)
+
+      wait 2
+      all('#content-items-default a').each(&:click)
+      wait_for_ajax
+      first('button[type="submit"]').click
+    end
+
+    expect(page).to have_css('.alert-success')
+    # also assert the group was persisted in the database (avoids flaky UI assertions)
+    group = @site.custom_field_groups.find_by(name: 'Allowed Group')
+    expect(group).to be_present
   end
 end

--- a/spec/features/admin/user_roles_spec.rb
+++ b/spec/features/admin/user_roles_spec.rb
@@ -15,6 +15,8 @@ def create_role
     fill_in 'user_role_description', with: 'tester descr'
     check 'Comments'
     check 'Themes'
+    # ensure the new Custom Fields manager permission checkbox is present and checked
+    check 'Custom Fields'
     click_button 'Submit'
   end
 end
@@ -44,6 +46,7 @@ describe 'the User Roles', :js do
     create_role
     expect(page).to have_checked_field('Themes')
     expect(page).to have_checked_field('Comments')
+    expect(page).to have_checked_field('Custom Fields')
     within '#edit_user_role' do
       fill_in 'user_role_name', with: 'Test Role updated'
       fill_in 'user_role_slug', with: 'tester-role-updated'

--- a/spec/lib/tasks/custom_fields_roles_rake_spec.rb
+++ b/spec/lib/tasks/custom_fields_roles_rake_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'camaleon_cms:backfill_custom_fields_permission' do
+  let(:task_name) { 'camaleon_cms:backfill_custom_fields_permission' }
+  let(:task) { Rake::Task[task_name] }
+
+  before(:all) do
+    Rails.application.load_tasks unless Rake::Task.task_defined?('camaleon_cms:backfill_custom_fields_permission')
+  end
+
+  before { task.reenable }
+
+  it 'adds custom_fields permission when manager meta is missing' do
+    site = create(:site)
+    role = site.user_roles.create!(name: 'Needs Backfill', slug: 'needs_backfill')
+    key = "_manager_#{role.parent_id}"
+
+    expect(role.metas.where(key: key)).to be_empty
+
+    task.invoke
+
+    expect(CamaleonCms::UserRole.find(role.id).get_meta(key)).to include('custom_fields' => 1)
+  end
+
+  it 'does not overwrite manager meta when custom_fields is already present' do
+    site = create(:site)
+    role = site.user_roles.create!(name: 'Already Permitted', slug: 'already_permitted')
+    key = "_manager_#{role.parent_id}"
+    original_meta = { 'custom_fields' => 1, 'themes' => 1 }
+    role.set_meta(key, original_meta)
+
+    task.invoke
+
+    expect(CamaleonCms::UserRole.find(role.id).get_meta(key)).to eq(original_meta)
+  end
+
+  it 'normalizes non-hash manager meta values before backfilling' do
+    site = create(:site)
+    role = site.user_roles.create!(name: 'Legacy Meta', slug: 'legacy_meta')
+    key = "_manager_#{role.parent_id}"
+    role.set_meta(key, 'legacy-value')
+
+    task.invoke
+
+    expect(CamaleonCms::UserRole.find(role.id).get_meta(key)).to eq('custom_fields' => 1)
+  end
+
+  it 'continues processing other roles when one role fails to update' do
+    site = create(:site)
+    broken_role = site.user_roles.create!(name: 'Broken Role', slug: 'broken_role')
+    healthy_role = site.user_roles.create!(name: 'Healthy Role', slug: 'healthy_role')
+    broken_key = "_manager_#{broken_role.parent_id}"
+    healthy_key = "_manager_#{healthy_role.parent_id}"
+
+    allow(CamaleonCms::UserRole).to receive(:find_each).and_yield(broken_role).and_yield(healthy_role)
+    allow(broken_role).to receive(:set_meta).with(broken_key, hash_including('custom_fields' => 1)).and_raise(StandardError,
+                                                                                                                  'forced failure')
+
+    expect { task.invoke }.not_to raise_error
+
+    expect(CamaleonCms::UserRole.find(healthy_role.id).get_meta(healthy_key)).to include('custom_fields' => 1)
+    expect(CamaleonCms::UserRole.find(broken_role.id).metas.where(key: broken_key)).to be_empty
+  end
+end

--- a/spec/lib/tasks/custom_fields_roles_rake_spec.rb
+++ b/spec/lib/tasks/custom_fields_roles_rake_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 require 'rake'
 
-RSpec.describe 'camaleon_cms:backfill_custom_fields_permission' do
+RSpec.describe 'camaleon_cms:backfill_custom_fields_permission', type: :task do
   let(:task_name) { 'camaleon_cms:backfill_custom_fields_permission' }
   let(:task) { Rake::Task[task_name] }
 
-  before(:all) do
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
     Rails.application.load_tasks unless Rake::Task.task_defined?('camaleon_cms:backfill_custom_fields_permission')
+  end
+
+  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rake::Task['camaleon_cms:backfill_custom_fields_permission'].clear
   end
 
   before { task.reenable }
@@ -56,8 +60,9 @@ RSpec.describe 'camaleon_cms:backfill_custom_fields_permission' do
     healthy_key = "_manager_#{healthy_role.parent_id}"
 
     allow(CamaleonCms::UserRole).to receive(:find_each).and_yield(broken_role).and_yield(healthy_role)
-    allow(broken_role).to receive(:set_meta).with(broken_key, hash_including('custom_fields' => 1)).and_raise(StandardError,
-                                                                                                                  'forced failure')
+    allow(broken_role).to receive(:set_meta)
+      .with(broken_key, hash_including('custom_fields' => 1))
+      .and_raise(StandardError, 'forced failure')
 
     expect { task.invoke }.not_to raise_error
 

--- a/spec/requests/admin/settings/custom_fields_spec.rb
+++ b/spec/requests/admin/settings/custom_fields_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'CustomFields create/update permissions', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  before do
+    # bypass login redirect and ensure controller sees our current_site
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+  end
+
+  context 'when updating an existing group' do
+    let!(:group) do
+      current_site.custom_field_groups.create!(
+        name: 'Existing Group', slug: '_existing-group', object_class: 'Site', objectid: current_site.id
+      )
+    end
+
+    it 'allows updating custom fields for roles with permission' do
+      role = current_site.user_roles.create!(name: 'CF Manager 2', slug: 'cf_manager_2')
+      role.set_meta("_manager_#{current_site.id}", { 'custom_fields' => 1 })
+      user = create(:user, role: role.slug, site: current_site)
+      auth_as(user)
+
+      patch "/admin/settings/custom_fields/#{group.id}", params: {
+        id: group.id,
+        custom_field_group: { name: 'Existing Group Updated', assign_group: "Site,#{current_site.id}" },
+        fields: { '0' => { name: 'EvalUpdate', slug: 'eval_update' } },
+        field_options: { '0' => { field_key: 'select_eval' } }
+      }
+
+      expect(response).to have_http_status(302)
+      expect(group.reload.fields.where(slug: 'eval_update')).to be_present
+    end
+
+    it 'blocks updating custom fields for roles without permission and sets flash error' do
+      role = current_site.user_roles.create!(name: 'Limited 2', slug: 'limited_2')
+      role.set_meta("_manager_#{current_site.id}", {})
+      user = create(:user, role: role.slug, site: current_site)
+      auth_as(user)
+
+      patch "/admin/settings/custom_fields/#{group.id}", params: {
+        id: group.id,
+        custom_field_group: { name: 'Existing Group Updated 2', assign_group: "Site,#{current_site.id}" },
+        fields: { '0' => { name: 'EvalBlocked', slug: 'eval_blocked' } },
+        field_options: { '0' => { field_key: 'select_eval' } }
+      }
+
+      expect(response).to have_http_status(302)
+      expect(group.reload.fields.where(slug: 'eval_blocked')).to be_empty
+      expected_custom = I18n.t('camaleon_cms.admin.custom_field.message.select_eval_admin_only', default: 'The "Select Eval" field type is restricted to administrators.')
+      expect(flash[:error]).to satisfy do |msg|
+        msg = msg.to_s
+        msg.include?(expected_custom) || msg.include?('You are not authorized')
+      end
+    end
+  end
+
+  def auth_as(user)
+    # set cookie so cama_current_user can be resolved by auth token
+    cookies[:auth_token] = "#{user.auth_token}&rspec&127.0.0.1"
+  end
+
+  context 'when user has the custom_fields manager permission' do
+    it 'allows creating a custom field group (including select_eval fields)' do
+      role = current_site.user_roles.create!(name: 'CF Manager', slug: 'cf_manager')
+      role.set_meta("_manager_#{current_site.id}", { 'custom_fields' => 1 })
+
+      user = create(:user, role: role.slug, site: current_site)
+      auth_as(user)
+
+      expect do
+        post '/admin/settings/custom_fields', params: {
+          custom_field_group: { name: 'Allowed Group', assign_group: "Site,#{current_site.id}" },
+          # field attributes go into fields; field_key (type) is provided in field_options
+          fields: { '0' => { name: 'Eval', slug: 'eval' } },
+          field_options: { '0' => { field_key: 'select_eval' } }
+        }
+      end.to change { current_site.custom_field_groups.count }.by(1)
+    end
+  end
+
+  context 'when user does NOT have the custom_fields manager permission' do
+    it 'does not allow creating a custom field group containing select_eval' do
+      role = current_site.user_roles.create!(name: 'Limited', slug: 'limited')
+      role.set_meta("_manager_#{current_site.id}", {})
+
+      user = create(:user, role: role.slug, site: current_site)
+      auth_as(user)
+
+      expect do
+        post '/admin/settings/custom_fields', params: {
+          custom_field_group: { name: 'Blocked Group', assign_group: "Site,#{current_site.id}" },
+          fields: { '0' => { name: 'Eval', slug: 'eval' } },
+          field_options: { '0' => { field_key: 'select_eval' } }
+        }
+      end.not_to(change { current_site.custom_field_groups.count })
+
+      # should redirect (either by authorization or permission check)
+      expect(response).to have_http_status(302)
+
+      # and set an error message about select_eval restriction (either the custom message or the standard CanCan denial)
+      expected_custom = I18n.t('camaleon_cms.admin.custom_field.message.select_eval_admin_only', default: 'The "Select Eval" field type is restricted to administrators.')
+      expect(flash[:error]).to satisfy do |msg|
+        msg = msg.to_s
+        msg.include?(expected_custom) || msg.include?('You are not authorized')
+      end
+    end
+  end
+end

--- a/spec/views/camaleon_cms/admin/settings/custom_fields/fields/_select_eval.html.erb_spec.rb
+++ b/spec/views/camaleon_cms/admin/settings/custom_fields/fields/_select_eval.html.erb_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The select_eval partial uses instance_eval on the stored command.
+# Security is enforced at the controller level via the :custom_fields role permission
+# (CamaleonCms::Admin::Settings::CustomFieldsController#validate_role).
+# Only users granted the custom_fields manager role can create or edit select_eval fields.
+RSpec.describe 'camaleon_cms/admin/settings/custom_fields/fields/_select_eval.html.erb', type: :view do
+  let(:field_name) { 'custom_field' }
+  let(:field) { Struct.new(:slug, :options).new('test_slug', { command: command, required: false }) }
+
+  before do
+    allow(view).to receive(:field_name).and_return(field_name)
+    assign(:field, field)
+  end
+
+  def render_partial
+    render partial: 'camaleon_cms/admin/settings/custom_fields/fields/select_eval',
+           locals: { field: field, field_name: field_name }
+  end
+
+  context 'when the command returns a plain array' do
+    let(:command) { '["one", "two"]' }
+
+    it 'renders select with those options' do
+      render_partial
+      expect(rendered).to match(/one/)
+      expect(rendered).to match(/two/)
+    end
+  end
+
+  context 'when the command is a Ruby expression' do
+    let(:command) { '%w[red green blue]' }
+
+    it 'evaluates and renders the options' do
+      render_partial
+      expect(rendered).to match(/red/)
+      expect(rendered).to match(/green/)
+      expect(rendered).to match(/blue/)
+    end
+  end
+end


### PR DESCRIPTION
## What
Add permission checks for Custom Fields management in the admin area.

## Code Changes
- Introduce/extend authorization rules for Custom Fields admin actions
- Apply the permission gates in the relevant admin Custom Fields paths

## Workflow Impact
- Access to Custom Fields management now follows role permissions
- Users without the required permission can no longer manage Custom Fields
