### PR TITLE
Add AGENTS.md and AI Agent DocumentationFeature/ai add agent docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,8 +1,0 @@
-CamaleonRecord is the base class of Camaleon CMS models. It inherits from `ActiveRecord::Base` and includes the `ActiveRecordExtras::Relation` module, which provides additional functionality to the models.
-
-Authorization is handled by the `cancancan` gem, which allows you to define user permissions in an `Ability` class. 
-You can specify what actions a user can perform on different models based on the UserRole ActiveRecord class.
-
-When running rspec tests, please ensure that the RAILS_ENV environment variable is always set to test. The command should be executed as RAILS_ENV=test bundle exec rspec.
-
-When providing 'Further Considerations,' always wait for my explicit confirmation before proceeding to any next steps or implementations.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,87 @@
+# Camaleon CMS
+
+A Ruby Gem implementing a Ruby on Rails content management system (Rails Engine). Ruby >= 3.0, Rails >= 6.1.
+Current development targets are Ruby `3.4.8` and Rails `8.1.2` (see `./docs/ai/rails-conventions.md` and `./.tool-versions`).
+
+## Agent Behaviour
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" -> "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" -> "Write a test that reproduces it, then make it pass"
+- "Refactor X" -> "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] -> verify: [check]
+2. [Step] -> verify: [check]
+3. [Step] -> verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
+When providing "Further Considerations," wait for explicit confirmation before proceeding with any next steps or implementations.
+
+## Progressive Guidance
+- [Workflow and branch/PR flow](./docs/ai/workflows.md) `must-read`
+- [Mechanical execution overrides](./docs/ai/mechanical_overrides.md) `must-read`
+- [Secrets handling policy](./docs/ai/secrets.md) `must-read`
+- [Rails/RSpec conventions and repo rules](./docs/ai/rails-conventions.md) `must-read`
+- [Code References](docs/ai/reference.md) `must-read`
+- [Code Style](docs/ai/code-style.md) `must-read`
+- [Testing and verification](./docs/ai/testing.md) `must-read`
+- [Quality criteria checklist](./docs/ai/quality/criteria.md) `must-read`
+- [Knowledge architecture and domain logging](./docs/ai/knowledge_architecture.md) `context`
+- [Decision journal workflow](./docs/ai/decision_journal.md) `context`
+- [Quality gate and review cadence](./docs/ai/quality_gate.md) `must-read`
+- [v2.9.2 custom fields permission upgrade](./docs/upgrading-to-2.9.2.md) (`lib/tasks/custom_fields_roles.rake`, `app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb`) `context`
+- [v2.9.2 select_eval migration and user-context requirements](./docs/MIGRATION_SELECT_EVAL.md) (`app/models/camaleon_cms/custom_field_group.rb`, `app/models/current_request.rb`, `app/models/camaleon_record.rb`) `context`
+- [Candidates to remove from legacy guidance](./docs/ai/deletion_candidates.md) `context`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   - **Security documentation:** See [Permissions & Security Guide](docs/security/permissions.md)
   - Run `bundle exec rake camaleon_cms:backfill_select_eval_permission` to fix the permission checkbox on admin roles
 
+- Add `AGENTS.md` and AI agent documentation in `docs/ai/` for agent behavior, Rails/RSpec conventions, and project guidance
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/docs/ai/code-style.md
+++ b/docs/ai/code-style.md
@@ -1,0 +1,30 @@
+# Code Style Guide
+
+## Linting
+
+```bash
+bundle exec rubocop
+```
+
+## General Formatting
+
+- **2-space indentation** (not tabs)
+- **UTF-8 encoding**
+- **Unix line endings** (LF)
+- **Frozen string literals**: `# frozen_string_literal: true` at top of Ruby files
+- **Max line length**: 120 chars (from rubocop todo)
+
+## Controller exception handling
+
+```ruby
+rescue_from CanCan::AccessDenied do |exception|
+  flash[:error] = "Error: #{exception.message}"
+  redirect_to cama_admin_dashboard_path
+end
+```
+
+## Immutability
+
+- Prefer `defined?` checks for memoization
+- Avoid mutation of method parameters
+- Use `dup` when needing a mutable copy

--- a/docs/ai/decision_journal.md
+++ b/docs/ai/decision_journal.md
@@ -1,0 +1,46 @@
+# Decision Journal
+
+## Before Making a Lasting Decision
+- If a decision affects more than today's task, search `docs/ai/decisions/` for prior decisions in that area first.
+- Follow existing decisions unless new information invalidates their reasoning.
+
+## When to Log a New Decision
+Log a decision when:
+- no prior decision exists for the topic, or
+- you are replacing an existing decision.
+
+## File Naming
+Create files as:
+- `docs/ai/decisions/YYYY-MM-DD-{topic}.md`
+
+## Format Options
+
+### Lightweight entry
+Use for fast, low-ambiguity decisions where a brief record is enough:
+```markdown
+## Decision: {what you decided}
+## Context: {why this came up}
+## Reasoning: {why this option won}
+## Trade-offs accepted: {what you gave up}
+## Supersedes: {link to prior decision, if replacing}
+```
+
+### ADR-style entry
+Use for architectural, integration, or cross-cutting decisions with meaningful alternatives:
+```markdown
+## Decision: {what you decided}
+## Context: {why this came up}
+## Status: {Accepted | Superseded | Deprecated}
+## Alternatives considered:
+- {option A}: {brief note}
+- {option B}: {brief note}
+## Reasoning: {why this option won}
+## Trade-offs accepted: {what you gave up}
+## Consequences: {what becomes easier or harder as a result}
+## Supersedes: {link to prior decision, if replacing}
+```
+
+**Guidance:** prefer ADR-style when the decision involves external integrations, framework choices, data persistence, or security trade-offs. Use lightweight for process, tooling, or docs-only choices.
+
+## Follow-up Rule
+- If new evidence invalidates a prior decision, create a new decision record instead of silently editing history.

--- a/docs/ai/decisions/README.md
+++ b/docs/ai/decisions/README.md
@@ -1,0 +1,38 @@
+# Architectural Decisions
+
+Document significant decisions that affect more than the current task.
+
+## When to Document
+
+Create a decision log when:
+- Adding a new gem dependency
+- Changing API patterns
+- Modifying database schema approach
+- Altering plugin/theme system behavior
+- Any change requiring significant refactoring
+
+## Decision Format
+
+Filename: `YYYY-MM-DD-{topic}.md`
+
+```markdown
+## Decision: {what you decided}
+
+## Context: {why this came up}
+
+## Alternatives considered:
+- Option A: {description}
+- Option B: {description}
+
+## Reasoning: {why this option won}
+
+## Trade-offs accepted: {what you gave up}
+
+## Supersedes: {link to prior decision, if replacing}
+```
+
+## Existing Decisions
+
+<!-- Add links to documented decisions -->
+
+- [Template](TEMPLATE.md) - Use this format

--- a/docs/ai/decisions/TEMPLATE.md
+++ b/docs/ai/decisions/TEMPLATE.md
@@ -1,0 +1,13 @@
+## Decision: {what you decided}
+
+## Context: {why this came up}
+
+## Alternatives considered:
+- Option A: {description}
+- Option B: {description}
+
+## Reasoning: {why this option won}
+
+## Trade-offs accepted: {what you gave up}
+
+## Supersedes: {link to prior decision, if replacing}

--- a/docs/ai/deletion_candidates.md
+++ b/docs/ai/deletion_candidates.md
@@ -1,0 +1,23 @@
+# Deletion Candidates Tracker
+
+This file is a working backlog for AGENTS-doc cleanup decisions. Items are only removed when a PR marks them `Resolved` with evidence.
+
+## Process
+1. Add candidate with `Open` status.
+2. In a PR, choose `delete`, `rewrite`, or `keep`.
+3. Link evidence (updated file path) and set `Resolved`.
+4. Remove fully resolved items in a later docs cleanup pass if history is no longer needed.
+
+## Status Legend
+- `Open`: needs decision.
+- `Deferred`: valid candidate, postponed.
+- `Resolved`: decision applied in repo.
+
+## Current Candidates
+| Candidate | Category | Status | Decision | Evidence |
+|---|---|---|---|---|
+
+## Template for New Candidates
+| Candidate | Category | Status | Decision | Evidence |
+|---|---|---|---|---|
+|  | Redundant / Too vague / Obvious / Contradiction | Open |  |  |

--- a/docs/ai/knowledge/README.md
+++ b/docs/ai/knowledge/README.md
@@ -1,0 +1,20 @@
+# Knowledge Base
+
+Learned patterns and insights about Camaleon CMS.
+
+## Structure
+
+- `patterns.md` - Recurring patterns confirmed through multiple uses
+- `hypotheses.md` - Patterns that need more evidence
+- `lessons.md` - Lessons learned (what went wrong)
+
+## Adding Knowledge
+
+When you learn something valuable:
+1. If confirmed 3+ times → add to `patterns.md`
+2. If uncertain → add to `hypotheses.md`
+3. From failures → add to `lessons.md`
+
+## Index
+
+<!-- Add links to topic folders if created -->

--- a/docs/ai/knowledge_architecture.md
+++ b/docs/ai/knowledge_architecture.md
@@ -1,0 +1,28 @@
+# Knowledge Architecture
+
+## Before Starting a Task
+- Review existing domain rules and hypotheses in `knowledge/` before starting a new task.
+- Apply rules by default.
+- Check whether today's work can confirm or contradict any hypothesis.
+
+## Storage Model
+Use domain folders under `docs/ai/knowledge/`, for example:
+- `docs/ai/knowledge/camaleon_cms/roles/`
+- `docs/ai/knowledge/camaleon_cms/permissions/`
+
+Each domain folder should contain:
+- `knowledge.md` — facts, observations, patterns
+- `hypotheses.md` — ideas that need more evidence
+- `rules.md` — confirmed patterns to apply by default
+
+## Index
+- Maintain `docs/ai/knowledge/INDEX.md` as the router to active domain folders.
+- Create a new domain entry in the index whenever a new knowledge folder is added.
+
+## Promotion / Demotion Rules
+- When a hypothesis is confirmed 3+ times, promote it to `rules.md`.
+- When a rule is contradicted by new evidence, demote it back to `hypotheses.md`.
+
+## End of Task
+- Extract reusable insights from the task.
+- Log them in the relevant domain folder so they are available for later analysis.

--- a/docs/ai/mechanical_overrides.md
+++ b/docs/ai/mechanical_overrides.md
@@ -1,0 +1,65 @@
+# Agent Directives: Mechanical Overrides
+
+These are strict execution directives for agent work in this repository.
+
+## Pre-Work
+
+1. **Step 0 rule**
+    - Before any structural refactor on a file larger than 300 LOC, first remove dead props, unused exports, unused imports, and debug logs.
+    - Commit this cleanup separately before the real refactor.
+
+2. **Phased execution**
+    - Do not attempt large multi-file refactors in one pass.
+    - Break work into explicit phases.
+    - Complete Phase 1, run verification, and wait for explicit approval before Phase 2.
+    - Each phase should touch no more than 5 files.
+
+## Code Quality
+
+3. **Senior dev override**
+    - If architecture is flawed, state is duplicated, or patterns are inconsistent, propose and implement structural fixes.
+    - Do not stop at the minimally requested change when that would leave obvious design debt.
+
+4. **Forced verification (project equivalent required)**
+    - Do not report completion before running all relevant checks and fixing blocking errors.
+    - For this Rails repo, use project-equivalent checks:
+
+```bash
+bin/rails zeitwerk:check
+bin/rubocop
+bin/rspec
+```
+
+- If a checker is not configured for the task context, state that explicitly.
+
+## Context Management
+
+5. **Sub-agent swarming**
+    - For tasks touching more than 5 independent files, use parallel sub-agents where possible to reduce context decay.
+
+6. **Context decay awareness**
+    - After long conversations (10+ messages), re-read files before editing.
+    - Do not rely on memory of file contents.
+
+7. **File read budget**
+    - For large files, read in chunks using offsets/limits instead of assuming one read is complete.
+
+8. **Tool result blindness**
+    - If command/search results seem suspiciously short, re-run with narrower scope.
+    - State when truncation is suspected.
+
+## Edit Safety
+
+9. **Edit integrity**
+    - Re-read each file before editing.
+    - After edits, read/validate again to confirm the change applied correctly.
+    - Avoid many consecutive edits to the same file without verification reads.
+
+10. **No semantic search assumptions**
+- For renames/identifier changes, search separately for:
+    - direct calls and references
+    - type-level references
+    - string literals containing the name
+    - dynamic imports/`require` calls
+    - re-exports/barrel entries
+    - tests and mocks

--- a/docs/ai/quality/criteria.md
+++ b/docs/ai/quality/criteria.md
@@ -1,0 +1,45 @@
+# Quality Criteria
+
+Before marking any task complete, evaluate against these criteria.
+
+## Criteria
+
+### Code Quality
+- Code passes RuboCop: `bundle exec rubocop`
+- No new RuboCop violations introduced
+
+### Testing
+- Specs pass: `RAILS_ENV=test bundle exec rspec`
+- New functionality has test coverage
+- Bug fixes include a test that would have caught the bug
+
+### Security
+- No `eval`, `instance_eval`, or `class_eval` with user input
+- SQL queries use parameterized forms
+- User input is sanitized appropriately
+
+### Rails Conventions
+- Controllers use strong parameters
+- Models have proper associations and validations
+- Views use helpers instead of logic
+
+### Camaleon CMS Specific
+- Plugins/themes follow the established patterns
+- Hooks are used for extensibility
+- Custom fields are handled correctly
+
+## Severity Levels
+
+| Level | Meaning |
+|-------|---------|
+| blocking | Must fix before completing task |
+| warning | Should fix, but not blocking |
+
+## Adding New Criteria
+
+When a failure pattern is found, propose a new criterion with:
+- Specific, testable check
+- Severity level
+- Source (what prompted this)
+
+Criteria that catch real issues repeatedly should be promoted to blocking.

--- a/docs/ai/quality_gate.md
+++ b/docs/ai/quality_gate.md
@@ -1,0 +1,37 @@
+# Quality Gate and System Review
+
+## Quality Gate
+Before marking any task complete, evaluate it against `quality/criteria.md`.
+
+## Criteria Maintenance
+After evaluation:
+- If a criterion catches a real issue, update its `Last triggered` date.
+- If a criterion triggers 3+ times, promote it to an always-check item.
+- If a criterion never triggers after 10+ evaluations, suggest pruning it.
+- If you find a new failure pattern, flag it and propose a new criterion; do not add it silently.
+
+## If `docs/ai/quality/criteria.md` Is Missing
+- Create it with initial criteria based on the project domain and current standards.
+- Ask the user to review the initial criteria.
+
+## System Review Schedule
+Last system review: not yet
+
+Do not run a full system review automatically. Suggest one when **any** of these triggers fires:
+
+**Time-based:**
+- 2+ weeks have passed since the last review date above.
+
+**Trigger-based:**
+- The project hits a milestone (e.g., first successful AIS flow, first TPP registration).
+- A quality criterion fires 3+ times in a short period.
+- A knowledge rule gets contradicted by new evidence.
+- A decision record is superseded.
+
+Suggested review scope:
+- Prune stale rules in `docs/ai/knowledge/` that have not been applied in 30+ days.
+- Check whether any hypothesis has enough evidence to promote or enough contradictions to discard.
+- Review decision outcomes and whether their trade-offs played out as expected.
+- Evaluate quality criteria: promote frequent triggers and flag never-triggered criteria for pruning.
+- Report what changed and why.
+- Update the `Last system review` date above.

--- a/docs/ai/rails-conventions.md
+++ b/docs/ai/rails-conventions.md
@@ -1,0 +1,75 @@
+# Rails Conventions
+
+## App Baseline
+- Rails version target: `8.1.2`.
+- Ruby version target: `3.4.8` (`.tool-versions`).
+- Test framework: `rspec-rails`.
+
+## Repo Rules
+- Follow [`docs/ai/secrets.md`](./secrets.md) for what counts as a secret and how to handle it.
+
+## Documentation Rules
+- Keep runnable commands in `README.md` aligned with actual scripts/binaries.
+- Keep integration evidence and mismatch notes in `docs/` files, not in commit messages.
+
+### Layout Selection
+
+Dynamic layout based on request type:
+```ruby
+layout proc { |_controller|
+  params[:cama_ajax_request].present? ? 'camaleon_cms/admin/_ajax' : 'camaleon_cms/admin'
+}
+```
+
+## Model Conventions
+
+CamaleonRecord is used as a base class for the ActiveRecord models of Camaleon CMS
+- inherits from `ActiveRecord::Base`
+
+### Decorators (Draper)
+
+Located in `app/decorators/`:
+```ruby
+module CamaleonCms
+  class PostDecorator < CamaleonCms::ApplicationDecorator
+    delegate_all
+
+    def the_title
+      "#{object.title} - #{site.name}"
+    end
+  end
+end
+```
+
+### Association Options
+
+Always specify class_name and foreign_key explicitly
+
+## Hook System
+
+Camaleon CMS provides a hook system for plugin extensibility:
+
+```ruby
+# Trigger hooks
+hooks_run('admin_before_load')
+hooks_run('admin_after_load')
+
+# Register hooks (in plugins)
+CamaleonCms::HooksManager.add_listener(
+  hook: 'admin_before_load',
+  callback: -> { # do something }
+)
+```
+
+Available hook points:
+- `admin_before_load`, `admin_after_load`
+- `frontend_before_load`, `frontend_after_load`
+- `site_after_install`
+- `post_after_save`, `post_before_destroy`
+
+## Route Conventions
+
+Routes are split by scope in `config/routes/`:
+- `config/routes/admin.rb`
+- `config/routes/frontend.rb`
+- `config/routes.rb`

--- a/docs/ai/reference.md
+++ b/docs/ai/reference.md
@@ -1,0 +1,69 @@
+# Code References and conventions for Camaleon CMS
+
+## Namespacing
+
+Modules and classes are namespaced under `CamaleonCms`
+
+## Model Aliases
+
+The codebase uses `Cama::*` aliases for convenience:
+
+```ruby
+# Defined in config/initializers/model_alias.rb
+Cama::Site    # = CamaleonCms::Site
+Cama::Post    # = CamaleonCms::Post
+Cama::Category # = CamaleonCms::Category
+Cama::PostType # = CamaleonCms::PostType
+```
+
+## Key Paths
+
+| Path | Purpose |
+|------|---------|
+| `spec/dummy/` | Test Rails application |
+| `spec/support/` | Test helpers and shared configuration |
+| `spec/factories/` | FactoryBot factory definitions |
+| `app/apps/` | Themes and plugins |
+| `config/locales/` | Translation files |
+
+## Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `RAILS_ENV` | Rails environment (test, development, production) |
+| `DISABLE_DATABASE_ENVIRONMENT_CHECK` | Skip DB environment check |
+
+## Common Decorators
+
+```ruby
+@object.decorate       # Returns decorated object
+@object.the_title      # Decorated title
+@object.the_url        # Decorated URL
+@object.the_next_post  # Next post in sequence
+@object.the_prev_post  # Previous post in sequence
+```
+
+## Asset Pipeline
+
+- Uses **Dart Sass** via `dartsass-sprockets`
+
+## Test Database
+
+- Uses SQLite for tests
+- Schema in `spec/dummy/db/schema.rb`
+- Migrations run from both `db/migrate/` and `spec/dummy/db/migrate/`
+
+## Plugin System
+
+Plugins live in `app/apps/plugins/` and can:
+- Add controllers (frontend and admin)
+- Add helpers
+- Add routes
+- Hook into lifecycle events
+- Add migrations
+
+## Authorization
+
+- Roles and permissions managed via `CamaleonCms::UserRole` and CanaCanCan's `Ability` class
+- Admins have all permissions by default
+- Permissions are defined per site

--- a/docs/ai/secrets.md
+++ b/docs/ai/secrets.md
@@ -1,0 +1,20 @@
+# Secrets Handling
+
+Use this file as the single source of truth for secret material in this repository.
+
+## What Counts as a Secret
+- `.env` and `.env.*` runtime config files (except `.env.example`).
+- Rails key files, including `config/master.key` and other `config/*.key` files.
+- Certificate private key material and related artifacts, especially under `config/certs/`:
+    - `*.key`, `*.pem`, `*.p12`, `*.pfx`, `*.csr`
+- Sensitive credential values loaded via environment variables (client secrets, passphrases, private-key paths).
+
+## Repository Rules
+- Do not commit secrets to git.
+- Keep `.env.example` as template-only (no real values).
+- Keep certificate and key files local; store only non-sensitive docs/runbooks in `docs/`.
+- Generated public key artifacts (for example `~/secrets/camaleon_cms/guide_2026-04-04/client_public.key`) are non-secret but should remain local unless a portal explicitly requires upload/sharing.
+
+## Enforcement and References
+- Ignore rules are defined in `.gitignore` (`.env*`, `config/*.key`, `config/certs/*`, key/cert extensions).
+- Environment-variable shape: `.env.example` and `README.md`.

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -1,0 +1,128 @@
+# Testing Guide
+
+> **Important:** Always set `RAILS_ENV=test` when running specs.
+
+## Running Tests
+
+```bash
+# All specs (ALWAYS set RAILS_ENV=test)
+RAILS_ENV=test bundle exec rspec
+
+# Single spec file
+RAILS_ENV=test bundle exec rspec spec/models/site_spec.rb
+
+# Specific spec by line number
+RAILS_ENV=test bundle exec rspec spec/models/site_spec.rb:12
+
+# Specs matching a pattern
+RAILS_ENV=test bundle exec rspec spec/models/
+RAILS_ENV=test bundle exec rspec spec/features/admin/
+```
+
+## Database Setup
+
+```bash
+bundle exec rake app:db:migrate
+bundle exec rake app:db:test:prepare
+```
+
+## Test Helpers (`spec/support/common.rb`)
+
+```ruby
+init_site              # creates @site and @post
+admin_sign_in          # authenticate admin user
+admin_sign_in(user, pass)
+wait(2)                # wait for JS execution
+cama_root_relative_path # site URL helper
+confirm_dialog         # accept JS dialogs
+```
+
+## RSpec Conventions
+
+```ruby
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Site, type: :model do
+  it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]
+
+  describe 'check metas relationships' do
+    let!(:site) { create(:site).decorate }
+
+    it 'creates metas with correct object_class' do
+      front_cache_elements = site.metas.where(key: 'front_cache_elements').first
+      expect(front_cache_elements.object_class).to eql('Site')
+    end
+  end
+end
+```
+
+**Guidelines:**
+- Use `described_class` instead of hardcoding class names
+- Use `let!` when data is needed for all examples in a describe block
+- Use factories: `create(:site)`, `create(:post)`, `create(:post_type)`
+- Use `decorate` when testing Draper-decorated methods
+- Use `init_site` helper in feature specs
+- Use shared examples (`spec/shared_specs/`) for common behavior
+- Use `:js` tag for feature specs requiring JavaScript: `RSpec.describe 'Posts', :js do`
+
+## Factory Bot Conventions
+
+```ruby
+FactoryBot.define do
+  factory :site, class: 'CamaleonCms::Site' do
+    name { Faker::Name.unique.name }
+    slug { 'test-site' }
+    description { Faker::Lorem.sentence }
+
+    transient do
+      theme { 'default' }
+      skip_intro { true }
+    end
+
+    after(:create) do |site, evaluator|
+      site_after_install(site, evaluator.theme)
+    end
+  end
+end
+```
+
+## Feature Spec Pattern (Admin UI Tests)
+
+```ruby
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'Posts workflows for Admin', :js do
+  let(:post) { site.the_post('sample-post').decorate }
+  let(:post_type_id) { site.post_types.where(slug: :post).pick(:id) }
+  let!(:site) { create(:site).decorate }
+
+  it 'Creates a new post' do
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/post_type/#{post_type_id}/posts/new"
+    wait(2)
+    # ... test steps
+  end
+end
+```
+
+## Shared Examples
+
+Located in `spec/shared_specs/`:
+
+```ruby
+it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]
+it_behaves_like 'i18n value translation safety', described_class
+```
+
+## Test Types
+
+| Type | Location | Description |
+|------|----------|-------------|
+| `type: :model` | `spec/models/` | Unit tests for models |
+| `type: :request` | `spec/requests/` | HTTP request tests |
+| `type: :feature` | `spec/features/` | Browser-based UI tests |
+| Default | `spec/helpers/` | Helper method tests |

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,0 +1,43 @@
+# Workflows
+
+## Local Setup
+```bash
+mise install
+bundle install
+bin/rails db:prepare
+```
+
+## Verification Pointer
+- Test and verification commands live in `docs/ai/testing.md`.
+
+## CI Parity Notes
+- CI runs security scans and lint from `.github/workflows/ci.yml`:
+    - `bin/brakeman --no-pager`
+    - `bin/bundler-audit`
+    - `bin/rubocop -f github`
+
+## Branch and PR Flow
+- Start from updated `main`.
+- Create a dedicated branch per task.
+- Push branch and open PR into `main`.
+- Keep commits focused and reviewable.
+
+## PR and Commit Description Rules
+- Descriptions must summarise changes at a general level (what changed and why), not commit-by-commit.
+- Descriptions must include one sentence on user-visible impact (or explicitly state there is no user-visible impact).
+- Descriptions must not include a `Files Changed` section.
+- Descriptions must not include test example/failure counts.
+- Descriptions must not describe how verification was performed (commands run, environments used, or step-by-step validation details).
+- Descriptions must not reference commit SHAs or commit history in the description.
+
+## Task Start / Finish Checklist
+- Before starting a new domain task, review relevant files from `docs/ai/knowledge/` and prior records in `docs/ai/decisions/`.
+- While working, test whether any existing hypothesis can be confirmed or contradicted.
+- Before marking a task complete, evaluate it against `docs/ai/quality/criteria.md`.
+- See deeper guidance in `docs/ai/knowledge_architecture.md`, `docs/ai/decision_journal.md`, and `docs/ai/quality_gate.md`.
+- Apply execution constraints from `docs/ai/mechanical_overrides.md` (step-0 clean-up, phased execution, edit integrity).
+
+## When to Update Agent Docs
+- If setup commands change, update `AGENTS.md`, this file, and `README.md` in the same PR.
+- If test commands change, update `docs/ai/testing.md`, `AGENTS.md`, and `README.md` in the same PR.
+- If CI commands change, update this file to match `.github/workflows/ci.yml`.


### PR DESCRIPTION
### Summary

This PR introduces comprehensive documentation for AI agent behavior, project conventions, and Rails/RSpec guidelines. The goal is to standardize agent contributions, clarify expectations, and improve maintainability for both human and AI contributors.

### Key Changes

- New file: AGENTS.md — Defines agent behavioral guidelines, coding standards, and project-specific rules
- New documentation: Added multiple files under docs/ai/:
rails-conventions.md, code-style.md, testing.md, quality/criteria.md, workflows.md, mechanical_overrides.md, reference.md, secrets.md, decision_journal.md, knowledge_architecture.md, and others

### Motivation

- Establishes clear, enforceable standards for AI and human contributors
- Reduces ambiguity and common mistakes in code contributions
- Provides a single source of truth for project conventions and agent behavior