### PR TITLE
Fix: Add authorization checks for broken access control vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@
 
 - Add `AGENTS.md` and AI agent documentation in `docs/ai/` for agent behavior, Rails/RSpec conventions, and project guidance
 
+- **Security fix:** Add authorization checks for broken access control vulnerabilities
+  - `/admin/media/ajax` now requires `manage :media` permission
+  - `/admin/plugins/attack/settings` now requires `manage :plugins` permission
+  - `/admin/plugins/front_cache/settings` now requires `manage :plugins` permission
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/app/apps/plugins/attack/admin_controller.rb
+++ b/app/apps/plugins/attack/admin_controller.rb
@@ -1,6 +1,8 @@
 module Plugins
   module Attack
     class AdminController < CamaleonCms::Apps::PluginsAdminController
+      before_action :authorize_plugin, only: [:settings, :save_settings]
+
       def settings
         @attack = current_site.get_meta('attack_config')
       end

--- a/app/apps/plugins/attack/admin_controller.rb
+++ b/app/apps/plugins/attack/admin_controller.rb
@@ -1,7 +1,7 @@
 module Plugins
   module Attack
     class AdminController < CamaleonCms::Apps::PluginsAdminController
-      before_action :authorize_plugin, only: [:settings, :save_settings]
+      before_action :authorize_plugin, only: %i[settings save_settings]
 
       def settings
         @attack = current_site.get_meta('attack_config')

--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -2,6 +2,8 @@ module Plugins
   module FrontCache
     class AdminController < CamaleonCms::Apps::PluginsAdminController
       include Plugins::FrontCache::FrontCacheHelper
+      before_action :authorize_plugin, only: [:settings, :save_settings, :clean_cache]
+
       def settings
         @caches = current_site.get_meta('front_cache_elements', { paths: [] })
         @caches[:paths] << '' unless @caches[:paths].present?

--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -2,7 +2,7 @@ module Plugins
   module FrontCache
     class AdminController < CamaleonCms::Apps::PluginsAdminController
       include Plugins::FrontCache::FrontCacheHelper
-      before_action :authorize_plugin, only: [:settings, :save_settings, :clean_cache]
+      before_action :authorize_plugin, only: %i[settings save_settings clean_cache]
 
       def settings
         @caches = current_site.get_meta('front_cache_elements', { paths: [] })

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -37,6 +37,7 @@ module CamaleonCms
 
       # render media for modal content
       def ajax
+        authorize! :manage, :media
         @show_file_actions = true if current_site.get_option('file_actions_in_modals') == 'yes'
         @tree = cama_uploader.search(params[:search]) if params[:search].present?
         @files = @tree.paginate(page: params[:page], per_page: 100)

--- a/app/controllers/camaleon_cms/apps/plugins_admin_controller.rb
+++ b/app/controllers/camaleon_cms/apps/plugins_admin_controller.rb
@@ -21,6 +21,10 @@ module CamaleonCms
         lookup_context.prefixes.prepend(params[:controller].sub("plugins/#{plugin_name}",
                                                                 "plugins/#{plugin_name}/views"))
       end
+
+      def authorize_plugin
+        authorize! :manage, :plugins
+      end
     end
   end
 end

--- a/spec/requests/admin/media_controller/ajax_spec.rb
+++ b/spec/requests/admin/media_controller/ajax_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Admin::MediaController, 'ajax endpoint', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  context 'when user has media management permission' do
+    let(:admin_role) { current_site.user_roles.create!(name: 'Media Admin', slug: 'media_admin') }
+    let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
+
+    before do
+      admin_role.set_meta("_manager_#{current_site.id}", { 'media' => 1 })
+    end
+
+    it 'allows access to ajax endpoint' do
+      sign_in_as(admin_user, site: current_site)
+
+      get '/admin/media/ajax'
+
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  context 'when user does NOT have media management permission' do
+    let(:limited_role) { current_site.user_roles.create!(name: 'Limited User', slug: 'limited_user') }
+    let(:limited_user) { create(:user, role: limited_role.slug, site: current_site) }
+
+    before do
+      limited_role.set_meta("_manager_#{current_site.id}", {})
+    end
+
+    it 'blocks access to ajax endpoint and redirects with error' do
+      sign_in_as(limited_user, site: current_site)
+
+      get '/admin/media/ajax'
+
+      expect(response).to redirect_to(/admin/)
+      expect(flash[:error]).to be_present
+    end
+  end
+end

--- a/spec/requests/admin/media_controller/ajax_spec.rb
+++ b/spec/requests/admin/media_controller/ajax_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe CamaleonCms::Admin::MediaController, 'ajax endpoint', type: :request do
+RSpec.describe CamaleonCms::Admin::MediaController, '#ajax', type: :request do
   init_site
 
   let(:current_site) { Cama::Site.first.decorate }

--- a/spec/requests/admin/plugins/attack_settings_spec.rb
+++ b/spec/requests/admin/plugins/attack_settings_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Plugin Attack Settings', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  before do
+    current_site.plugins.where(slug: 'attack').first_or_create(set_meta: { status: 'active' })
+  end
+
+  context 'when user has plugins management permission' do
+    let(:admin_role) { current_site.user_roles.create!(name: 'Plugin Admin', slug: 'plugin_admin') }
+    let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
+
+    before do
+      admin_role.set_meta("_manager_#{current_site.id}", { 'plugins' => 1 })
+    end
+
+    it 'allows access to attack settings' do
+      sign_in_as(admin_user, site: current_site)
+
+      get '/admin/plugins/attack/settings'
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'allows saving attack settings' do
+      sign_in_as(admin_user, site: current_site)
+
+      post '/admin/plugins/attack/settings', params: {
+        attack: { get_sec: '5', get_max: '10', post_sec: '20', post_max: '50', ban: '1', msg: 'Test message' }
+      }
+
+      expect(response).to redirect_to(/attack\/settings/)
+      expect(flash[:notice]).to be_present
+    end
+  end
+
+  context 'when user does NOT have plugins management permission' do
+    let(:limited_role) { current_site.user_roles.create!(name: 'Limited User', slug: 'limited_user') }
+    let(:limited_user) { create(:user, role: limited_role.slug, site: current_site) }
+
+    before do
+      limited_role.set_meta("_manager_#{current_site.id}", {})
+    end
+
+    it 'blocks access to attack settings' do
+      sign_in_as(limited_user, site: current_site)
+
+      get '/admin/plugins/attack/settings'
+
+      expect(response).to redirect_to(/admin/)
+      expect(flash[:error]).to be_present
+    end
+
+    it 'blocks saving attack settings' do
+      sign_in_as(limited_user, site: current_site)
+
+      post '/admin/plugins/attack/settings', params: {
+        attack: { get_sec: '99', get_max: '99', post_sec: '99', post_max: '99', ban: '1', msg: 'Hacked' }
+      }
+
+      expect(response).to redirect_to(/admin/)
+      expect(flash[:error]).to be_present
+      expect(current_site.get_meta('attack_config')['get']['sec']).not_to eq('99')
+    end
+  end
+end

--- a/spec/requests/admin/plugins/attack_settings_spec.rb
+++ b/spec/requests/admin/plugins/attack_settings_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Plugin Attack Settings', type: :request do
         attack: { get_sec: '5', get_max: '10', post_sec: '20', post_max: '50', ban: '1', msg: 'Test message' }
       }
 
-      expect(response).to redirect_to(/attack\/settings/)
+      expect(response).to redirect_to(%r{attack/settings})
       expect(flash[:notice]).to be_present
     end
   end

--- a/spec/requests/admin/plugins/front_cache_settings_spec.rb
+++ b/spec/requests/admin/plugins/front_cache_settings_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Plugin Front Cache Settings', type: :request do
         cache: { paths: ['/test'], posts: ['1'], skip_posts: [], home: '1', cache_login: '0' }
       }
 
-      expect(response).to redirect_to(/front_cache\/settings/)
+      expect(response).to redirect_to(%r{front_cache/settings})
       expect(flash[:notice]).to be_present
     end
   end

--- a/spec/requests/admin/plugins/front_cache_settings_spec.rb
+++ b/spec/requests/admin/plugins/front_cache_settings_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Plugin Front Cache Settings', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  before do
+    current_site.plugins.where(slug: 'front_cache').first_or_create(set_meta: { status: 'active' })
+  end
+
+  context 'when user has plugins management permission' do
+    let(:admin_role) { current_site.user_roles.create!(name: 'Plugin Admin', slug: 'plugin_admin') }
+    let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
+
+    before do
+      admin_role.set_meta("_manager_#{current_site.id}", { 'plugins' => 1 })
+    end
+
+    it 'allows access to front_cache settings' do
+      sign_in_as(admin_user, site: current_site)
+
+      get '/admin/plugins/front_cache/settings'
+
+      expect(response).to have_http_status(200)
+    end
+
+    it 'allows saving front_cache settings' do
+      sign_in_as(admin_user, site: current_site)
+
+      post '/admin/plugins/front_cache/settings', params: {
+        cache: { paths: ['/test'], posts: ['1'], skip_posts: [], home: '1', cache_login: '0' }
+      }
+
+      expect(response).to redirect_to(/front_cache\/settings/)
+      expect(flash[:notice]).to be_present
+    end
+  end
+
+  context 'when user does NOT have plugins management permission' do
+    let(:limited_role) { current_site.user_roles.create!(name: 'Limited User', slug: 'limited_user') }
+    let(:limited_user) { create(:user, role: limited_role.slug, site: current_site) }
+
+    before do
+      limited_role.set_meta("_manager_#{current_site.id}", {})
+    end
+
+    it 'blocks access to front_cache settings' do
+      sign_in_as(limited_user, site: current_site)
+
+      get '/admin/plugins/front_cache/settings'
+
+      expect(response).to redirect_to(/admin/)
+      expect(flash[:error]).to be_present
+    end
+
+    it 'blocks saving front_cache settings' do
+      sign_in_as(limited_user, site: current_site)
+
+      post '/admin/plugins/front_cache/settings', params: {
+        cache: { paths: ['/hacked'], cache_login: '1' }
+      }
+
+      expect(response).to redirect_to(/admin/)
+      expect(flash[:error]).to be_present
+      cached = current_site.get_meta('front_cache_elements')
+      expect(cached[:paths]).not_to include('/hacked')
+    end
+  end
+end


### PR DESCRIPTION
Fixed **Broken Access Control** vulnerabilities where low-privileged users could access and modify administrative settings without proper authorization.

### Vulnerabilities Fixed

| Endpoint | Issue |
|----------|-------|
| \`/admin/media/ajax\` | Missing \`authorize! :manage, :media\` check |
| \`/admin/plugins/attack/settings\` | No authorization check |
| \`/admin/plugins/front_cache/settings\` | No authorization check |

### Changes

1. **MediaController#ajax** - Added \`authorize! :manage, :media\`
2. **AttackPlugin::AdminController** - Added \`before_action :authorize_plugin\`
3. **FrontCachePlugin::AdminController** - Added \`before_action :authorize_plugin\`
4. **PluginsAdminController** - Added \`authorize_plugin\` private method

### Tests Added

- \`spec/requests/admin/media_controller/ajax_spec.rb\`
- \`spec/requests/admin/plugins/attack_settings_spec.rb\`
- \`spec/requests/admin/plugins/front_cache_settings_spec.rb\`

### Security Impact

CVSS: Medium (4.3) - Low-privileged users can no longer modify admin settings.
