### PR TITLE
Fix mass assignment vulnerability in user registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
   - `/admin/plugins/attack/settings` now requires `manage :plugins` permission
   - `/admin/plugins/front_cache/settings` now requires `manage :plugins` permission
 
+- **Security fix:** Fix mass assignment vulnerability in user registration (cross-tenant account injection)
+  - Replace `permit!` with explicit whitelist of allowed params in `SessionsController#user_permit_data`
+  - Remove `params[:meta]` from user registration to prevent arbitrary meta injection
+  - Thanks Aryan Bhagat for reporting this
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -113,7 +113,7 @@ module CamaleonCms
           params[:user][:role] = PluginRoutes.system_info['default_user_role']
           params[:user][:is_valid_email] = false if current_site.need_validate_email?
           user_data = user_permit_data
-          result = cama_register_user(user_data, params[:meta])
+          result = cama_register_user(user_data, nil)
           if result[:result] == false && result[:type] == :captcha_error
             @user.errors.add(:captcha, t('camaleon_cms.admin.users.message.error_captcha'))
             render 'register'
@@ -171,7 +171,7 @@ module CamaleonCms
       end
 
       def user_permit_data
-        params.require(:user).permit!
+        params.require(:user).permit(:first_name, :last_name, :email, :username, :password, :password_confirmation, :is_valid_email)
       end
     end
   end

--- a/spec/requests/admin/sessions/register_spec.rb
+++ b/spec/requests/admin/sessions/register_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User registration mass assignment protection', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  before do
+    current_site.set_option('permit_create_account', true)
+    current_site.set_option('need_validate_email', true)
+  end
+
+  describe 'POST /admin/register' do
+    context 'when attempting mass assignment of site_id' do
+      it 'ignores injected site_id and creates user' do
+        target_site_id = current_site.id + 999
+        username = "massassign_#{Time.current.to_i}"
+
+        post cama_admin_register_path, params: {
+          user: {
+            first_name: 'MassAssign',
+            last_name: 'Test',
+            email: "#{username}@tester.com",
+            username: username,
+            password: 'password123',
+            password_confirmation: 'password123',
+            site_id: target_site_id,
+            is_valid_email: true,
+            active: true
+          }
+        }
+
+        user = CamaleonCms::User.find_by(username: username)
+        expect(user).not_to be_nil
+        # The user should exist on the current site (not the injected site_id)
+        expect(user.site_id).not_to eq(target_site_id)
+        # is_valid_email should be false (not the injected true)
+        expect(user.is_valid_email).to be(false)
+      end
+    end
+
+    context 'when attempting mass assignment of sensitive attributes' do
+      it 'ignores injected role, auth_token, password_reset_token, confirm_email_token' do
+        username = "sensitive_#{Time.current.to_i}"
+
+        post cama_admin_register_path, params: {
+          user: {
+            first_name: 'Sensitive',
+            last_name: 'Test',
+            email: "#{username}@tester.com",
+            username: username,
+            password: 'password123',
+            password_confirmation: 'password123',
+            role: 'admin',
+            auth_token: 'hacked_token',
+            password_reset_token: 'reset_token',
+            confirm_email_token: 'confirm_token'
+          }
+        }
+
+        user = CamaleonCms::User.find_by(username: username)
+        expect(user).not_to be_nil
+        expect(user.role).to eq('client')
+        expect(user.auth_token).not_to eq('hacked_token')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes a critical mass assignment vulnerability in the user registration endpoint that allows unauthenticated attackers to:

1. **Cross-tenant account injection** - Inject user accounts into any site in multi-site deployments by manipulating `site_id` parameter
2. **Privilege escalation** - Set arbitrary user attributes like `role`, `active`, etc.
3. **Arbitrary meta injection** - Inject custom metadata into user records via `params[:meta]`

This is distinct from CVE-2025-2304 which patched the same `permit!` pattern in `UsersController#updated_ajax` (an authenticated endpoint). This vulnerability targets the unauthenticated registration endpoint (`POST /admin/register`).

## Changes

- Replace `permit!` with explicit whitelist of allowed params in `user_permit_data`
- Remove `params[:meta]` from user registration to prevent arbitrary meta injection
- Add request specs to verify mass assignment protection

## CVSS v3.1 Score: 9.3 (Critical)

Vector: AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:L/A:N