### PR TITLE
Fix: Centralize plugin admin authorization in PluginsAdminController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,10 @@
 
 - Add `AGENTS.md` and AI agent documentation in `docs/ai/` for agent behavior, Rails/RSpec conventions, and project guidance
 
-- **Security fix:** Add authorization checks for broken access control vulnerabilities
-  - `/admin/media/ajax` now requires `manage :media` permission
-  - `/admin/plugins/attack/settings` now requires `manage :plugins` permission
-  - `/admin/plugins/front_cache/settings` now requires `manage :plugins` permission
+- **Security fix:** Centralize plugin admin authorization in `PluginsAdminController`
+  - All plugin admin routes now require `manage :plugins` permission by default (fail-closed)
+  - `/admin/plugins/*/settings` and related endpoints protected without per-controller opt-in
+  - Third-party plugins (via Ruby gems like `cama_contact_form`, `cama_meta_tag`) automatically protected when inheriting from `PluginsAdminController`
 
 - **Security fix:** Fix mass assignment vulnerability in user registration (cross-tenant account injection)
   - Replace `permit!` with explicit whitelist of allowed params in `SessionsController#user_permit_data`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,12 @@
   - All plugin admin routes now require `manage :plugins` permission by default (fail-closed)
   - `/admin/plugins/*/settings` and related endpoints protected without per-controller opt-in
   - Third-party plugins (via Ruby gems like `cama_contact_form`, `cama_meta_tag`) automatically protected when inheriting from `PluginsAdminController`
+  - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
 - **Security fix:** Fix mass assignment vulnerability in user registration (cross-tenant account injection)
   - Replace `permit!` with explicit whitelist of allowed params in `SessionsController#user_permit_data`
   - Remove `params[:meta]` from user registration to prevent arbitrary meta injection
-  - Thanks Aryan Bhagat for reporting this
+  - Thanks, Aryan Bhagat for reporting this
 
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 

--- a/app/apps/plugins/attack/admin_controller.rb
+++ b/app/apps/plugins/attack/admin_controller.rb
@@ -1,8 +1,6 @@
 module Plugins
   module Attack
     class AdminController < CamaleonCms::Apps::PluginsAdminController
-      before_action :authorize_plugin, only: %i[settings save_settings]
-
       def settings
         @attack = current_site.get_meta('attack_config')
       end

--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -2,7 +2,6 @@ module Plugins
   module FrontCache
     class AdminController < CamaleonCms::Apps::PluginsAdminController
       include Plugins::FrontCache::FrontCacheHelper
-      before_action :authorize_plugin, only: %i[settings save_settings clean_cache]
 
       def settings
         @caches = current_site.get_meta('front_cache_elements', { paths: [] })

--- a/app/controllers/camaleon_cms/apps/plugins_admin_controller.rb
+++ b/app/controllers/camaleon_cms/apps/plugins_admin_controller.rb
@@ -2,6 +2,7 @@ module CamaleonCms
   module Apps
     class PluginsAdminController < CamaleonCms::AdminController
       before_action :init_plugin
+      before_action :authorize_plugin
 
       private
 

--- a/spec/requests/admin/plugins/attack_settings_spec.rb
+++ b/spec/requests/admin/plugins/attack_settings_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Plugin Attack Settings', type: :request do
 
   before do
     current_site.plugins.where(slug: 'attack').first_or_create(set_meta: { status: 'active' })
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
   end
 
   context 'when user has plugins management permission' do

--- a/spec/requests/admin/plugins/front_cache_settings_spec.rb
+++ b/spec/requests/admin/plugins/front_cache_settings_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Plugin Front Cache Settings', type: :request do
 
   before do
     current_site.plugins.where(slug: 'front_cache').first_or_create(set_meta: { status: 'active' })
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
   end
 
   context 'when user has plugins management permission' do


### PR DESCRIPTION
## Summary

- **Add** `before_action :authorize_plugin` to `PluginsAdminController` base class to enforce authorization by default
- **Remove** redundant `before_action` declarations from `attack` and `front_cache` plugin controllers (now inherited)
- **Update** specs with proper test isolation for consistent behavior

## Security Fix

Addresses **Broken Access Control (CVSS 6.3)** where low-privileged users could access plugin admin settings endpoints at `/admin/plugins/attack/settings`, `/admin/plugins/front_cache/settings`, and similar endpoints for third-party plugins.

## Key Change

Centralizing authorization in `PluginsAdminController` ensures that **all plugin admin actions are protected without requiring per-controller opt-in**. Third-party plugins (loaded as Ruby gems like `cama_contact_form`, `cama_meta_tag`, etc.) automatically inherit authorization when inheriting from `PluginsAdminController`.

This is a fail-closed approach - any plugin admin controller that inherits from `PluginsAdminController` will now require `:manage, :plugins` permission by default, eliminating the risk of forgotten authorization checks in future plugins.