### PR TITLE
Fix SQL Injection in PostUniqValidator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@
 # [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2)
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**
 
-- **Security fix:** Fix SQL Injection in `PostUniqValidator` (authenticated, boolean-based blind SQLi via post slug)
-  - Use parameterized queries instead of string interpolation for slug validation
-  - Thanks, SecurifySec for reporting this
-
 - Add permissions for Custom Fields management in the admin area
   - Existing installs upgrading to 2.9.2 should review the [migration guide](docs/upgrading-to-2.9.2.md)
 
@@ -40,6 +36,10 @@
 
 - **Security fix:** Fix Stored XSS in post title rendering
   - Add HTML escaping to post titles when displayed in admin views (e.g., drafts list)
+  - Thanks, Amir Aliu and Enrik Mustafa for reporting this
+
+- **Security fix:** Fix SQL Injection in `PostUniqValidator` (authenticated, boolean-based blind SQLi via post slug)
+  - Use parameterized queries instead of string interpolation for slug validation
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 # [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2)
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**
 
+- **Security fix:** Fix SQL Injection in `PostUniqValidator` (authenticated, boolean-based blind SQLi via post slug)
+  - Use parameterized queries instead of string interpolation for slug validation
+  - Thanks, SecurifySec for reporting this
+
 - Add permissions for Custom Fields management in the admin area
   - Existing installs upgrading to 2.9.2 should review the [migration guide](docs/upgrading-to-2.9.2.md)
 

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -5,7 +5,7 @@ module CamaleonCms
 
       slug_array = record.slug.to_s.translations_array
       ptype = record.post_type
-      return unless ptype.present?
+      return unless ptype.present? # only for posts that belongs to a post type model
 
       post_table = CamaleonCms::Post.table_name
 
@@ -25,7 +25,7 @@ module CamaleonCms
       posts = ptype.site.posts
                    .where(where_clause, *params)
                    .where.not(id: record.id)
-                   .where.not(status: %w[draft draft_child trash])
+                   .where.not(status: %i[draft draft_child trash])
       unless posts.empty?
         record.errors[:base] <<
           if slug_array.size > 1
@@ -39,6 +39,7 @@ module CamaleonCms
           end
       end
 
+      # avoid recursive page parent
       return unless record.post_parent.present? && ptype.manage_hierarchy? &&
                     record.parents.cama_pluck(:id).include?(record.id)
 

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -5,14 +5,25 @@ module CamaleonCms
 
       slug_array = record.slug.to_s.translations_array
       ptype = record.post_type
-      return unless ptype.present? # only for posts that belongs to a post type model
+      return unless ptype.present?
 
       post_table = CamaleonCms::Post.table_name
+
+      conditions = []
+      params = []
+
+      slug_array.each do |s|
+        conditions << "#{post_table}.slug LIKE ?"
+        params << "%-->#{s}<!--%"
+      end
+
+      conditions << "#{post_table}.slug = ?"
+      params << record.slug
+
+      where_clause = "(#{conditions.join(' OR ')})"
+
       posts = ptype.site.posts
-                   .where(
-                     "(#{slug_array.map { |s| "#{post_table}.slug LIKE '%-->#{s}<!--%'" }
-                                        .join(' OR ')} ) OR #{post_table}.slug = ?", record.slug
-                   )
+                   .where(where_clause, *params)
                    .where.not(id: record.id)
                    .where.not(status: %i[draft draft_child trash])
       unless posts.empty?
@@ -28,7 +39,6 @@ module CamaleonCms
           end
       end
 
-      # avoid recursive page parent
       return unless record.post_parent.present? && ptype.manage_hierarchy? &&
                     record.parents.cama_pluck(:id).include?(record.id)
 

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -25,7 +25,7 @@ module CamaleonCms
       posts = ptype.site.posts
                    .where(where_clause, *params)
                    .where.not(id: record.id)
-                   .where.not(status: %i[draft draft_child trash])
+                   .where.not(status: %w[draft draft_child trash])
       unless posts.empty?
         record.errors[:base] <<
           if slug_array.size > 1

--- a/spec/validators/post_uniq_validator_spec.rb
+++ b/spec/validators/post_uniq_validator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::PostUniqValidator, type: :model do
+  init_site
+
+  let(:post_type) { create(:post_type, slug: 'test-pt', site: @site) }
+
+  def validate_post(post)
+    validator = described_class.new
+    validator.validate(post)
+    post.errors[:base]
+  end
+
+  describe '#validate' do
+    context 'when post is a draft' do
+      it 'skips validation' do
+        post = create(:post, post_type: post_type, slug: 'test-slug', status: 'draft')
+        expect(validate_post(post)).to be_empty
+      end
+    end
+
+    context 'when post has unique slug' do
+      it 'passes validation' do
+        post = create(:post, post_type: post_type, slug: 'unique-slug')
+        expect(validate_post(post)).to be_empty
+      end
+    end
+
+    context 'with SQL injection attempts in slug' do
+      it 'does not execute injected SQL - boolean based' do
+        create(:post, post_type: post_type, slug: 'legit-slug', status: 'published')
+        post = create(:post, post_type: post_type, slug: "' OR '1'='1")
+
+        expect { validate_post(post) }.not_to raise_error
+        expect(validate_post(post)).to be_empty
+      end
+
+      it 'handles SQL injection with UNION attempt' do
+        post = create(:post, post_type: post_type, slug: "test' UNION SELECT")
+
+        expect { validate_post(post) }.not_to raise_error
+        result = validate_post(post)
+        expect(result).to be_empty.or contain_exactly(match(/requires_different_slug/))
+      end
+
+      it 'handles malicious slug with comment injection' do
+        post = create(:post, post_type: post_type, slug: "test'--")
+
+        expect { validate_post(post) }.not_to raise_error
+        result = validate_post(post)
+        expect(result).to be_empty.or contain_exactly(match(/requires_different_slug/))
+      end
+
+      it 'handles slug with semicolon and multiple statements' do
+        post = create(:post, post_type: post_type, slug: "test'; DROP TABLE posts; --")
+
+        expect { validate_post(post) }.not_to raise_error
+        result = validate_post(post)
+        expect(result).to be_empty.or contain_exactly(match(/requires_different_slug/))
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fix authenticated SQL Injection vulnerability in `PostUniqValidator`
- Uses parameterized queries instead of string interpolation for slug validation
- Prevents authenticated boolean-based blind SQL injection via post slug parameter

Fixes reported vulnerability: CVSS 6.5 | CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N

Thanks, Amir Aliu and Enrik Mustafa for reporting this!
