### PR TITLE
Fix SSTI vulnerability in test_email endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@
   - Use parameterized queries instead of string interpolation for slug validation
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
+- **Security fix:** Fix SSTI (Server-Side Template Injection) in test_email endpoint
+  - Replace `render inline:` with `render plain:` to prevent ERB evaluation of exception messages
+  - This prevented authenticated admins from potentially executing arbitrary code via crafted error messages
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
 
 - **Security fix:** Fix SSTI (Server-Side Template Injection) in test_email endpoint
   - Replace `render inline:` with `render plain:` to prevent ERB evaluation of exception messages
-  - This prevented authenticated admins from potentially executing arbitrary code via crafted error messages
+  - This prevents authenticated admins from potentially executing arbitrary code via crafted error messages
+  - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
 

--- a/app/controllers/camaleon_cms/admin/settings_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings_controller.rb
@@ -74,7 +74,7 @@ module CamaleonCms
         CamaleonCms::HtmlMailer.sender(params[:email], 'Test', data).deliver_now
         head :ok
       rescue StandardError => e
-        render inline: e.message, status: 502
+        render plain: e.message, status: 502
       end
 
       private

--- a/spec/requests/admin/settings/settings_controller_spec.rb
+++ b/spec/requests/admin/settings/settings_controller_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Admin::SettingsController, type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+  end
+
+  describe '#test_email' do
+    let(:admin_role) { current_site.user_roles.create!(name: 'Admin', slug: 'admin') }
+    let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
+
+    before do
+      admin_role.set_meta("_manager_#{current_site.id}", { 'settings' => 1 })
+    end
+
+    context 'when email delivery succeeds' do
+      it 'returns success response' do
+        sign_in_as(admin_user, site: current_site)
+        allow(CamaleonCms::HtmlMailer).to receive(:sender).and_return(double(deliver_now: true))
+
+        get '/admin/settings/test_email', params: { email: 'test@example.com' }
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context 'when email delivery fails' do
+      it 'renders error message as plain text, not as template' do
+        sign_in_as(admin_user, site: current_site)
+        error_message = '<%= system("ls") %>'
+        allow(CamaleonCms::HtmlMailer).to receive(:sender).and_raise(StandardError.new(error_message))
+
+        get '/admin/settings/test_email', params: { email: 'test@example.com' }
+
+        expect(response).to have_http_status(502)
+        expect(response.body).to eq(error_message)
+        expect(response.content_type).to include('text/plain')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Fixes Server-Side Template Injection (SSTI) vulnerability in `/admin/settings/test_email` endpoint
- Replaces `render inline:` with `render plain:` to prevent ERB evaluation of exception messages

## User Impact

Authenticated admin users with SMTP configured could potentially execute arbitrary code by forcing an exception whose message contains malicious template syntax. This fix prevents that attack vector.