### PR TITLE
Fix IDOR vulnerability in CategoriesController (CWE-639)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Change Log
 
-## Unreleased
+## Unreleased [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2)
 
-# [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2)
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**
 
 - **BREAKING CHANGE** - Add permissions for Custom Fields management in the admin area
@@ -31,6 +30,11 @@
   - All endpoints now protected by centralized `before_action :verify_media_authorization`
   - Thanks, Seoyoung Kang for reporting this
 
+- **Security fix:** Fix IDOR (CWE-639) in CategoriesController
+  - Users with category management permission for one Post Type could modify/delete categories from other Post Types by manipulating request parameters
+  - Changed `set_category` to scope lookup to authorized `@post_type` instead of global lookup
+  - Thanks, Seoyoung Kang for reporting this
+
 - Fix: rewind Tempfile after scanning to avoid 0-byte uploads (regression fixed; tests added).
 
 - Add `AGENTS.md` and AI agent documentation in `docs/ai/` for agent behavior, Rails/RSpec conventions, and project guidance
@@ -53,7 +57,7 @@
   - This prevents authenticated admins from potentially executing arbitrary code via crafted error messages
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
-# [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.0) (2025-01-06)
+# [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.1) (2025-03-15)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**
 

--- a/app/controllers/camaleon_cms/admin/categories_controller.rb
+++ b/app/controllers/camaleon_cms/admin/categories_controller.rb
@@ -73,7 +73,8 @@ module CamaleonCms
       end
 
       def set_category
-        @category = CamaleonCms::Category.find_by_id(params[:id])
+        @category = @post_type.categories.find_by_id(params[:id])
+        render_404 unless @category
       rescue StandardError
         flash[:error] = t('camaleon_cms.admin.post_type.message.error')
         redirect_to cama_admin_path

--- a/spec/requests/admin/categories_controller/idor_spec.rb
+++ b/spec/requests/admin/categories_controller/idor_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Admin::CategoriesController, '#set_category', type: :request do
+  let(:site) { create(:site) }
+  let(:post_type_a) { create(:post_type, site: site) }
+  let(:post_type_b) { create(:post_type, site: site) }
+  let!(:category_b) { CamaleonCms::Category.create!(name: 'Category B', site_id: site.id, parent_id: post_type_b.id, taxonomy: :category, status: post_type_b.id) }
+
+  let(:role_a) { site.user_roles.create!(name: 'Role A', slug: 'role_a') }
+  let(:user_a) { create(:user, site: site, role: role_a.slug) }
+
+  before do
+    role_a.set_meta("_manager_#{site.id}", { 'categories' => 1 })
+    role_a.set_meta("_post_type_#{post_type_a.id}", { 'categories' => 1 })
+  end
+
+  describe 'PATCH #update' do
+    context 'when user has permission for post_type_a but tries to modify category from post_type_b' do
+      before do
+        role_a.set_meta("_post_type_#{post_type_a.id}", { 'categories' => 1 })
+        sign_in_as(user_a, site: site)
+      end
+
+      it 'prevents IDOR attack - category not found' do
+        patch "/admin/post_type/#{post_type_a.id}/categories/#{category_b.id}", params: {
+          category: { name: 'IDOR_MODIFIED' }
+        }
+
+        category_b.reload
+
+        expect(category_b.name).not_to eq('IDOR_MODIFIED')
+        expect(response).to redirect_to(/admin/)
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    context 'when user has permission for post_type_a but tries to delete category from post_type_b' do
+      before do
+        role_a.set_meta("_post_type_#{post_type_a.id}", { 'categories' => 1 })
+        sign_in_as(user_a, site: site)
+      end
+
+      it 'prevents IDOR attack - category not deleted' do
+        expect do
+          delete "/admin/post_type/#{post_type_a.id}/categories/#{category_b.id}"
+        end.not_to(change { CamaleonCms::Category.exists?(category_b.id) })
+
+        expect(response).to redirect_to(/admin/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes an IDOR vulnerability where users with category management permission for one Post Type could modify/delete categories belonging to other Post Types by manipulating request parameters
- Changes `set_category` method to scope the category lookup to the authorized `@post_type` instead of using a global lookup

## What and Why
The vulnerability existed because `set_category` used `CamaleonCms::Category.find_by_id(params[:id])` which loads the category globally without verifying it belongs to the authorized Post Type. The fix scopes the lookup to `@post_type.categories.find_by_id(params[:id])` matching the pattern used in PostTagsController.

## User-Visible Impact
Users with category permissions for one Post Type can no longer modify or delete categories belonging to other Post Types by manipulating request parameters.