### PR TITLE
Fix Stored XSS (CWE-79) in the_content helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
   - Changed `set_category` to scope lookup to authorized `@post_type` instead of global lookup
   - Thanks, Seoyoung Kang for reporting this
 
+- **Security fix:** Fix Stored XSS (CWE-79) in the_content helper
+  - The `the_content` helper was using `.html_safe` which bypassed Rails' XSS protection
+  - Changed to use `sanitize()` which uses Rails' allowlist approach
+  - Thanks, Pratik Karan for reporting this
+
 - Fix: rewind Tempfile after scanning to avoid 0-byte uploads (regression fixed; tests added).
 
 - Add `AGENTS.md` and AI agent documentation in `docs/ai/` for agent behavior, Rails/RSpec conventions, and project guidance

--- a/app/helpers/camaleon_cms/frontend/content_select_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/content_select_helper.rb
@@ -68,7 +68,7 @@ module CamaleonCms
       #   the_content
       # end
       def the_content
-        @object.the_content.html_safe if @object.present?
+        sanitize(@object.the_content) if @object.present?
       end
 
       # select url of post

--- a/spec/helpers/repro_xss_in_content_spec.rb
+++ b/spec/helpers/repro_xss_in_content_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CamaleonCms::Frontend::ContentSelectHelper do
+  let(:site) { create(:site) }
+  let(:post_type) { create(:post_type, slug: 'post', site: site) }
+
+  let(:xss_payload) { '<script>alert("xss")</script>' }
+
+  let!(:post) do
+    create(:post, post_type: post_type, title: 'Malicious Post', content: xss_payload, status: 'published').decorate
+  end
+
+  describe '#the_content' do
+    it 'sanitizes XSS payload in post content' do
+      @object = post
+
+      output = the_content
+
+      expect(output).not_to include('<script>')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Fixes Stored XSS vulnerability in the the_content helper method
- Changed from .html_safe to sanitize() using Rails allowlist approach
- PoC test included proving vulnerability is fixed

## User-Visible Impact
None - internal security fix, no API/UI changes

## What and Why
The the_content helper used .html_safe which marks content as pre-escaped, bypassing Rails built-in XSS protection. This allowed low-privileged users (Authors) to inject JavaScript that executes when admins view posts.

Fixed by using sanitize() which strips dangerous HTML tags (script, iframe, etc.) using Rails allowlist approach.