### PR TITLE
Fix mass assignment and open redirect vulnerabilities in SitesController

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@
 - **Security:** `bin/brakeman --no-pager`
 - **Verify load:** `bin/rails zeitwerk:check`
 
+**Security Fixes:** Vulnerability fixes MUST include tests that reproduce the vulnerability (unless infeasible). All code changes must be covered by specs. See `docs/ai/workflows.md` Step 4.
+
 ## 3. Quick Reference
 
 | Path | Purpose |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@
 - **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController
   - Replace `permit!` with strong `site_params` allowing only `:name`, `:slug`, `:description`
   - Redirect to `cama_admin_path` instead of `@site.the_admin_url` to prevent open redirect
-  - See PR #1152
+  - See [PR #1152](https://github.com/owen2345/camaleon-cms/pull/1152)
 
 - **Security fix:** Fix Stored XSS in post title rendering
   - Add HTML escaping to post titles when displayed in admin views (e.g., drafts list)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,10 +49,9 @@
   - Remove `params[:meta]` from user registration to prevent arbitrary meta injection
   - Thanks, Aryan Bhagat for reporting this
 
-- **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController
+- **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController, [#1152](https://github.com/owen2345/camaleon-cms/pull/1152)
   - Replace `permit!` with strong `site_params` allowing only `:name`, `:slug`, `:description`
   - Redirect to `cama_admin_path` instead of `@site.the_admin_url` to prevent open redirect
-  - See [PR #1152](https://github.com/owen2345/camaleon-cms/pull/1152)
 
 - **Security fix:** Fix Stored XSS in post title rendering
   - Add HTML escaping to post titles when displayed in admin views (e.g., drafts list)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
   - Remove `params[:meta]` from user registration to prevent arbitrary meta injection
   - Thanks, Aryan Bhagat for reporting this
 
+- **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController
+  - Replace `permit!` with strong `site_params` allowing only `:name`, `:slug`, `:description`
+  - Redirect to `cama_admin_path` instead of `@site.the_admin_url` to prevent open redirect
+  - See PR #1152
+
 - **Security fix:** Fix Stored XSS in post title rendering
   - Add HTML escaping to post titles when displayed in admin views (e.g., drafts list)
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this

--- a/README.md
+++ b/README.md
@@ -180,17 +180,9 @@ RAILS_ENV=test bundle exec rake app:db:migrate
 RAILS_ENV=test bundle exec rake app:db:test:prepare
 ```
 
-- Run the tests
-`bin/rspec`
-
-  - If the `rspec` binstub is not present:
-
-```bash
-bundle exec rspec
-```
-
-  - But better generate the binstub, patch it to always set RAILS_ENV=test, like it is done in this repo
-  - And then run with `bin/rspec`
+- Run the tests: `bin/rspec`
+  - If the `rspec` binstub is not present, generate it: `bundle binstubs rspec-core`
+    - And then still run `bin/rspec`
 
 ## Permissions (Manager roles)
 

--- a/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
@@ -23,11 +23,11 @@ module CamaleonCms
 
         def update
           tmp = @site.slug
-          if @site.update(params.require(:site).permit!)
+          if @site.update(site_params)
             save_metas(@site)
             flash[:notice] = t('camaleon_cms.admin.sites.message.updated')
             if @site.id == Cama::Site.main_site.id && tmp != @site.slug
-              redirect_to @site.the_admin_url
+              redirect_to(cama_admin_path)
             else
               redirect_to action: :index
             end
@@ -43,8 +43,7 @@ module CamaleonCms
         end
 
         def create
-          site_data = params.require(:site).permit!
-          @site = CamaleonCms::Site.new(site_data)
+          @site = CamaleonCms::Site.new(site_params)
           if @site.save
             save_metas(@site)
             site_after_install(@site, @site.get_theme_slug)
@@ -83,6 +82,10 @@ module CamaleonCms
 
           flash[:error] = t('camaleon_cms.admin.sites.message.unauthorized')
           redirect_to cama_admin_path
+        end
+
+        def site_params
+          params.require(:site).permit(:name, :slug, :description)
         end
       end
     end

--- a/docs/ai/mechanical_overrides.md
+++ b/docs/ai/mechanical_overrides.md
@@ -32,6 +32,14 @@ bin/rspec
 
 - If a checker is not configured for the task context, state that explicitly.
 
+5. **Mandatory spec coverage for code changes**
+   - **ALL code changes must be covered by specs**, except:
+     - Pure refactoring with equivalent behavior (same inputs → same outputs)
+     - Documentation-only changes
+     - Configuration changes with no code path modifications
+   - Do not submit code changes without tests. If writing tests is infeasible, state why explicitly.
+   - Security vulnerability fixes have stricter requirements: see `docs/ai/workflows.md` Step 4.
+
 ## Context Management
 
 5. **Sub-agent swarming**

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -48,6 +48,15 @@ State your finding to the user. You must pick one:
 1. Create a branch following the `security/` prefix (e.g., `security/fix-sqli-in-comments`).
 2. Follow the standard "Goal-Driven Execution": **Write a failing test that reproduces the risk** (if possible) before applying the fix.
 
+### Step 4: Mandatory Test Coverage for Vulnerability Fixes
+**CRITICAL:** Fixing a vulnerability MUST include spec coverage:
+1. **Write a test that exposes the vulnerability** before applying the fix (unless reproducing is infeasible).
+2. **All code changes fixing the vulnerability must be covered by specs.** Exceptions:
+   - Pure refactoring with no behavioral change (same inputs → same outputs)
+   - Configuration-only changes with no code path modification
+3. **Do not skip tests to "get the fix out faster."** Security fixes require the same test rigor as features.
+4. **Integration/feature specs are preferred over controller specs** for vulnerability reproduction (e.g., testing that a mass-assignment guard prevents attribute injection).
+
 ## Metadata Maintenance
 If you change setup, test, or CI commands, you are **REQUIRED** to update:
 1. `AGENTS.md`

--- a/spec/features/admin/sites_spec.rb
+++ b/spec/features/admin/sites_spec.rb
@@ -6,7 +6,6 @@ def create_site
   visit "#{cama_root_relative_path}/admin/settings/sites"
   expect(page).to have_content('List Sites')
 
-  # create user role
   within '#admin_content' do
     click_link 'Add Site'
   end
@@ -51,34 +50,30 @@ describe 'the Sites', :js do
     confirm_dialog
     expect(page).to have_css('.alert-success')
   end
-end
 
-describe 'Sites mass assignment protection' do
-  it 'site_params only permits name, slug, description' do
-    controller = CamaleonCms::Admin::Settings::SitesController.new
-    params = ActionController::Parameters.new(
-      site: {
-        name: 'Test Site',
-        slug: 'test-slug',
-        description: 'Test description',
-        term_group: 999,
-        parent_id: 999,
-        user_id: 999
-      }
-    )
-    allow(controller).to receive(:params).and_return(params)
+  describe 'Sites mass assignment protection' do
+    it 'site_params only permits name, slug, description' do
+      controller = CamaleonCms::Admin::Settings::SitesController.new
+      params = ActionController::Parameters.new(
+        site: {
+          name: 'Test Site',
+          slug: 'test-slug',
+          description: 'Test description',
+          term_group: 999,
+          parent_id: 999,
+          user_id: 999
+        }
+      )
+      allow(controller).to receive(:params).and_return(params)
 
-    permitted = controller.send(:site_params).permit!
+      permitted = controller.send(:site_params).permit!
 
-    expect(permitted.to_h.keys).to match_array(%w[name slug description])
-    expect(permitted['term_group']).to be_nil
-    expect(permitted['parent_id']).to be_nil
-    expect(permitted['user_id']).to be_nil
+      expect(permitted.to_h.keys).to match_array(%w[name slug description])
+      expect(permitted['term_group']).to be_nil
+      expect(permitted['parent_id']).to be_nil
+      expect(permitted['user_id']).to be_nil
+    end
   end
-end
-
-describe 'SitesController redirects to safe path', :js do
-  init_site
 
   it 'redirects to safe admin path instead of site URL after main site slug change' do
     main_site = CamaleonCms::Site.first

--- a/spec/features/admin/sites_spec.rb
+++ b/spec/features/admin/sites_spec.rb
@@ -52,3 +52,40 @@ describe 'the Sites', :js do
     expect(page).to have_css('.alert-success')
   end
 end
+
+describe 'Sites mass assignment protection' do
+  it 'site_params only permits name, slug, description' do
+    controller = CamaleonCms::Admin::Settings::SitesController.new
+    params = ActionController::Parameters.new(
+      site: {
+        name: 'Test Site',
+        slug: 'test-slug',
+        description: 'Test description',
+        term_group: 999,
+        parent_id: 999,
+        user_id: 999
+      }
+    )
+    allow(controller).to receive(:params).and_return(params)
+
+    permitted = controller.send(:site_params).permit!
+
+    expect(permitted.to_h.keys).to match_array(%w[name slug description])
+    expect(permitted['term_group']).to be_nil
+    expect(permitted['parent_id']).to be_nil
+    expect(permitted['user_id']).to be_nil
+  end
+end
+
+describe 'SitesController redirects to safe path', :js do
+  init_site
+
+  it 'redirects to safe admin path instead of site URL after main site slug change' do
+    main_site = CamaleonCms::Site.first
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/settings/sites/#{main_site.id}/edit"
+    fill_in 'site_slug', with: "#{main_site.slug}-updated"
+    click_button 'Submit'
+    expect(current_path).not_to eq("/#{main_site.slug}")
+  end
+end


### PR DESCRIPTION
## Summary
- Fix mass assignment vulnerability by replacing `permit!` with strong `site_params` allowing only `:name`, `:slug`, `:description`
- Fix open redirect vulnerability by redirecting to `cama_admin_path` instead of `@site.the_admin_url` after main site slug change
- Add specs verifying mass assignment protection and safe redirect behavior
- Document mandatory spec coverage requirement for security fixes