### PR TITLE
Fix XSS vulnerability in flash messages via params[:info]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@
   - Third-party plugins (via Ruby gems like `cama_contact_form`, `cama_meta_tag`) automatically protected when inheriting from `PluginsAdminController`
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
+- **Security fix:** Fix reflected XSS vulnerability via `params[:info]` in flash messages, [#1154](https://github.com/owen2345/camaleon-cms/pull/1154)
+
 - **BREAKING CHANGE - Security fix:** Fix Broken Access Control (CWE-862) in MediaController
   - Add consistent authorization checks to all MediaController endpoints requiring `:manage, :media` permission
   - Previously, only `index` and `ajax` actions checked authorization; other endpoints (`upload`, `download_private_file`, `crop`, `actions`) only checked authentication

--- a/app/views/layouts/camaleon_cms/admin/_flash_messages.html.erb
+++ b/app/views/layouts/camaleon_cms/admin/_flash_messages.html.erb
@@ -6,11 +6,11 @@
         </div>
     </div>
 <% end %>
-<% if params[:info] %>
+<% if flash[:info].present? %>
     <div class="flash_messages">
         <div class="alert alert-info">
             <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-            <%= raw(params[:info]) %>
+            <%= flash[:info] %>
         </div>
     </div>
 <% end %>

--- a/spec/requests/security/xss_flash_params_spec.rb
+++ b/spec/requests/security/xss_flash_params_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Security: XSS via params[:info] in flash messages', type: :request do
+  let(:site) { create(:site) }
+  let(:admin_role) { site.user_roles.create!(name: 'Admin', slug: 'admin') }
+  let(:admin_user) { create(:user, role: admin_role.slug, site: site) }
+  let(:decorated_site) { site.decorate }
+
+  before do
+    admin_role.set_meta("_manager_#{site.id}", { 'posts' => 1, 'sites' => 1 })
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(decorated_site)
+    sign_in_as(admin_user, site: site)
+  end
+
+  it 'does not render unescaped XSS payload from params[:info] (vulnerability fixed)' do
+    xss_payload = '<script>alert("XSS")</script>'
+
+    get '/admin/dashboard', params: { info: xss_payload }
+
+    expect(response.body).not_to include(xss_payload)
+  end
+end


### PR DESCRIPTION
## User-Visible Impact
Prevents reflected XSS attacks via the `info` query parameter in admin pages.

## What and Why
Replaces `raw(params[:info])` with escaped `flash[:info]` in `app/views/layouts/camaleon_cms/admin/_flash_messages.html.erb`. The `params[:info]` value comes directly from the URL query string and was rendered without escaping, allowing reflected XSS. Since `:info` is already a registered flash type (`add_flash_types :info` in `CamaleonController`), controllers can use `redirect_to path, info: "message"` and the value will be auto-escaped by Rails' ERB output. 

Includes a regression test in `spec/requests/security/xss_flash_params_spec.rb`.
