### PR TITLE
Fix Brakeman XSS vulnerabilities and add comprehensive tests

### DIFF
--- a/app/apps/themes/default/views/category.html.erb
+++ b/app/apps/themes/default/views/category.html.erb
@@ -8,7 +8,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/app/apps/themes/default/views/post_tag.html.erb
+++ b/app/apps/themes/default/views/post_tag.html.erb
@@ -8,7 +8,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/app/apps/themes/default/views/post_type.html.erb
+++ b/app/apps/themes/default/views/post_type.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/app/apps/themes/default/views/search.html.erb
+++ b/app/apps/themes/default/views/search.html.erb
@@ -11,7 +11,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/app/apps/themes/new/views/category.html.erb
+++ b/app/apps/themes/new/views/category.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/app/apps/themes/new/views/post_tag.html.erb
+++ b/app/apps/themes/new/views/post_tag.html.erb
@@ -15,7 +15,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/app/apps/themes/new/views/post_type.html.erb
+++ b/app/apps/themes/new/views/post_type.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/app/apps/themes/new/views/search.html.erb
+++ b/app/apps/themes/new/views/search.html.erb
@@ -12,7 +12,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/app/helpers/camaleon_cms/admin/application_helper.rb
+++ b/app/helpers/camaleon_cms/admin/application_helper.rb
@@ -9,27 +9,27 @@ module CamaleonCms
 
       # render pagination for current items
       # items is a will pagination object
-      # sample: <%= raw cama_do_pagination(@posts) %>
+      # sample: <%= cama_do_pagination(@posts) %>
       def cama_do_pagination(items, *will_paginate_options)
         will_paginate_options = will_paginate_options.extract_options!
-        custom_class = will_paginate_options[:panel_class]
-        will_paginate_options.delete(:panel_class)
-        "<div class='row #{custom_class} pagination_panel cama_ajax_request'>
-        <div class='col-md-10'>
-          #{begin
+        custom_class = will_paginate_options.delete(:panel_class)
+        content_tag(:div, class: "row #{custom_class} pagination_panel cama_ajax_request") do
+          concat(content_tag(:div, class: 'col-md-10') do
             will_paginate(items, will_paginate_options)
           rescue StandardError
             ''
-          end}
-        </div>
-        <div class='col-md-2 text-right total-items'>
-          <strong>#{I18n.t('camaleon_cms.admin.table.total', default: 'Total')}: #{begin
-            items.total_entries
-          rescue StandardError
-            items.count
-          end} </strong>
-        </div>
-    </div>"
+          end)
+          concat(content_tag(:div, class: 'col-md-2 text-right total-items') do
+            content_tag(:strong) do
+              total = begin
+                items.total_entries
+              rescue StandardError
+                items.count
+              end
+              "#{I18n.t('camaleon_cms.admin.table.total', default: 'Total')}: #{total}"
+            end
+          end)
+        end
       end
 
       # return the locale for frontend translations initialized in admin controller
@@ -41,7 +41,7 @@ module CamaleonCms
 
       # print code with auto copy
       def cama_shortcode_print(code)
-        "<input onmousedown=\"this.clicked = 1;\" readonly onfocus=\"if (!this.clicked) this.select(); else this.clicked = 2;\" onclick=\"if (this.clicked == 2) this.select(); this.clicked = 0;\" class='code_style' tabindex='-1' value=\"#{code}\">"
+        content_tag(:code, code, class: 'cama_shortcode_code')
       end
     end
   end

--- a/app/helpers/camaleon_cms/admin/application_helper.rb
+++ b/app/helpers/camaleon_cms/admin/application_helper.rb
@@ -41,7 +41,7 @@ module CamaleonCms
 
       # print code with auto copy
       def cama_shortcode_print(code)
-        content_tag(:code, code, class: 'cama_shortcode_code')
+        content_tag(:input, nil, class: 'code_style', readonly: true, onmousedown: 'this.clicked = 1;', onfocus: 'if (!this.clicked) this.select(); else this.clicked = 2;', onclick: 'if (this.clicked == 2) this.select(); this.clicked = 0;', tabindex: '-1', value: code)
       end
     end
   end

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -57,21 +57,22 @@ module CamaleonCms
         end
 
         content_tag(:ul, class: class_cat) do
-          categories.decorate.each do |f|
-            concat(content_tag(:li) do
-              concat(content_tag(:label, class: 'class_slug', data: { post_link_edit: f.the_edit_url }) do
-                is_checked = Array(values).map(&:to_s).include?(f.id.to_s)
-                input_options = { class: (required ? 'required' : ''), data: { error_place: "#validation_error_list_#{name}" } }
-                if type == 'radio'
-                  concat(radio_button_tag("#{name}[]", f.id, is_checked, input_options))
-                else
-                  concat(check_box_tag("#{name}[]", f.id, is_checked, input_options))
-                end
-                concat(" #{f.the_title} ")
-              end)
-              concat(post_type_html_inputs(f, 'children', name, type, values, 'children')) if f.children.present?
-            end)
-          end
+          categories.decorate.map do |f|
+            content_tag(:li) do
+              is_checked = Array(values).map(&:to_s).include?(f.id.to_s)
+              input_options = { class: (required ? 'required' : ''), data: { error_place: "#validation_error_list_#{name}" } }
+              input_tag = if type == 'radio'
+                            radio_button_tag("#{name}[]", f.id, is_checked, input_options)
+                          else
+                            check_box_tag("#{name}[]", f.id, is_checked, input_options)
+                          end
+              res = content_tag(:label, class: 'class_slug', data: { post_link_edit: f.the_edit_url }) do
+                "#{input_tag} #{f.the_title} ".html_safe
+              end
+              res << post_type_html_inputs(f, 'children', name, type, values, 'children') if f.children.present?
+              res
+            end
+          end.join.html_safe
         end + content_tag(:div, '', id: "validation_error_list_#{name}")
       end
     end

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -11,17 +11,16 @@ module CamaleonCms
       end
 
       def post_type_status(status, color = 'default')
-        "<span class='label label-#{color} label-form'>#{status}</span>"
+        content_tag(:span, status, class: "label label-#{color} label-form")
       end
 
       # taxonomies ->  (categories || post_tags)
       def post_type_list_taxonomy(taxonomies, color = 'primary')
-        html = ''
-        taxonomies.decorate.each do |f|
-          html += "<a class='cama_ajax_request' href='#{cama_admin_post_type_taxonomy_posts_path(@post_type.id,
-                                                                                                 f.taxonomy, f.id)}'><span class='label label-#{color} label-form'>#{f.the_title}</span></a> "
-        end
-        html
+        taxonomies.decorate.map do |f|
+          link_to(cama_admin_post_type_taxonomy_posts_path(@post_type.id, f.taxonomy, f.id), class: 'cama_ajax_request') do
+            content_tag(:span, f.the_title, class: "label label-#{color} label-form")
+          end
+        end.join(' ').html_safe
       end
 
       # sort array of posts to build post's tree
@@ -54,23 +53,26 @@ module CamaleonCms
                                    values = [], class_cat = '', required = false)
         if categories.count < 1
           return t('camaleon_cms.admin.post_type.message.no_created_html',
-                   taxonomy: taxonomy == 'categories' ? t('camaleon_cms.admin.table.categories') : t('camaleon_cms.admin.table.tags')).to_s
+                   taxonomy: taxonomy == 'categories' ? t('camaleon_cms.admin.table.categories') : t('camaleon_cms.admin.table.tags'))
         end
 
-        html = "<ul class='#{class_cat}'>"
-        categories.decorate.each do |f|
-          html += '<li>'
-          html +=  "<label class='class_slug' data-post_link_edit='#{f.the_edit_url}'> "
-          html +=  "<input data-error-place='#validation_error_list_#{name}' type='#{type}' name='#{name}[]' #{values.to_i.include?(f.id) ? 'checked' : ''} value='#{f.id}' class = '#{if required
-                                                                                                                                                                                         'required'
-                                                                                                                                                                                       end}' />"
-          html += "#{f.the_title} </label> "
-          html += post_type_html_inputs(f, 'children', name, type, values, 'children') if f.children.present?
-          html += '</li>'
-        end
-
-        html += "</ul><div id='validation_error_list_#{name}'></div>"
-        html
+        content_tag(:ul, class: class_cat) do
+          categories.decorate.each do |f|
+            concat(content_tag(:li) do
+              concat(content_tag(:label, class: 'class_slug', data: { post_link_edit: f.the_edit_url }) do
+                is_checked = Array(values).map(&:to_s).include?(f.id.to_s)
+                input_options = { class: (required ? 'required' : ''), data: { error_place: "#validation_error_list_#{name}" } }
+                if type == 'radio'
+                  concat(radio_button_tag("#{name}[]", f.id, is_checked, input_options))
+                else
+                  concat(check_box_tag("#{name}[]", f.id, is_checked, input_options))
+                end
+                concat(" #{f.the_title} ")
+              end)
+              concat(post_type_html_inputs(f, 'children', name, type, values, 'children')) if f.children.present?
+            end)
+          end
+        end + content_tag(:div, '', id: "validation_error_list_#{name}")
       end
     end
   end

--- a/app/helpers/camaleon_cms/comment_helper.rb
+++ b/app/helpers/camaleon_cms/comment_helper.rb
@@ -16,47 +16,77 @@ module CamaleonCms
     # render as html content all comments recursively
     # comments: collection of comments
     def cama_comments_render_html(comments)
-      res = ''
-      labels = { 'approved' => 'success', 'pending' => 'warning', 'spam' => 'danger' }
-      comments.decorate.each do |comment|
+      comments.decorate.map do |comment|
         author = comment.the_author
-        res << "<div class='media'>
-                 <div class='media-left'>
-                    <a href='#{author.the_admin_profile_url}'>#{image_tag author.the_avatar, class: 'media-object',
-                                                                                             style: 'width: 64px; height: 64px;'}</a>
-                 </div>
-                 <div class='media-body'>
-                    <h4 class='media-heading'>#{author.the_name} <small>#{comment.the_created_at}</small> <span class='label label-#{labels[comment.approved]} pull-right'>#{t("camaleon_cms.admin.comments.message.#{comment.approved}")}</span></h4>
-                    <div class='comment_content'>#{sanitize comment.content}</div>
-                    <div class='comment_actions'>
-                        <div class='pull-left'>
-                            <a href='#{cama_admin_post_comment_answer_path(@post.id,
-                                                                           comment.id)}' data-comment-id='#{comment.id}' title='#{t('camaleon_cms.admin.comments.tooltip.reply_comment')}' class='btn btn-info reply btn-xs ajax_modal'><span class='fa fa-mail-reply'></span></a>
-                            #{link_to raw('<i class="fa fa-trash-o"></i>'), { action: :destroy, id: comment.id },
-                                      method: :delete, data: { confirm: t('camaleon_cms.admin.message.delete') }, class: 'btn btn-danger btn-xs cama_ajax_request', title: t('camaleon_cms.admin.comments.tooltip.delete_comment').to_s}
-                        </div>
-                        <div class='pull-right'>
-                            <a href='#{url_for({ action: :toggle_status, comment_id: comment.id,
-                                                 s: 'a' })}' title='#{t('camaleon_cms.admin.comments.tooltip.approved_comment')}' class='#{if comment.approved == 'approved'
-                                                                                                                                             'hidden'
-                                                                                                                                           end} btn btn-success approve btn-xs cama_ajax_request'><span class='fa fa-thumbs-o-up'></span></a>
-                            <a href='#{url_for({ action: :toggle_status, comment_id: comment.id,
-                                                 s: 'p' })}' title='#{t('camaleon_cms.admin.comments.tooltip.comment_pending')}' class='#{if comment.approved == 'pending'
-                                                                                                                                            'hidden'
-                                                                                                                                          end} btn btn-primary pending btn-xs cama_ajax_request'><span class='fa fa-warning'></span></a>
-                            <a href='#{url_for({ action: :toggle_status, comment_id: comment.id,
-                                                 s: 's' })}' title='#{t('camaleon_cms.admin.comments.tooltip.comment_spam')}' class='#{if comment.approved == 'spam'
-                                                                                                                                         'hidden'
-                                                                                                                                       end} btn btn-danger spam btn-xs cama_ajax_request'><span class='fa fa-bug'></span></a>
-                        </div>
-                    </div>
-                    <hr>
-                    <div class='clearfix'></div>
-                    #{cama_comments_render_html comment.children}
-                 </div>
-              </div>"
-      end
-      res
+        labels = { 'approved' => 'success', 'pending' => 'warning', 'spam' => 'danger' }
+        content_tag(:div, class: 'media') do
+          concat(content_tag(:div, class: 'media-left') do
+            link_to(author.the_admin_profile_url) do
+              image_tag(author.the_avatar, class: 'media-object', style: 'width: 64px; height: 64px;')
+            end
+          end)
+          concat(content_tag(:div, class: 'media-body') do
+            concat(content_tag(:h4, class: 'media-heading') do
+              concat(author.the_name)
+              concat(' ')
+              concat(content_tag(:small, comment.the_created_at))
+              concat(' ')
+              concat(content_tag(:span, t("camaleon_cms.admin.comments.message.#{comment.approved}"), class: "label label-#{labels[comment.approved]} pull-right"))
+            end)
+            concat(content_tag(:div, sanitize(comment.content), class: 'comment_content'))
+            concat(content_tag(:div, class: 'comment_actions') do
+              concat(content_tag(:div, class: 'pull-left') do
+                concat(
+                  link_to(
+                    cama_admin_post_comment_answer_path(@post.id, comment.id),
+                    data: { comment_id: comment.id },
+                    title: t('camaleon_cms.admin.comments.tooltip.reply_comment'),
+                    class: 'btn btn-info reply btn-xs ajax_modal'
+                  ) { content_tag(:span, '', class: 'fa fa-mail-reply') }
+                )
+                concat(' ')
+                concat(
+                  link_to(
+                    { action: :destroy, id: comment.id },
+                    method: :delete,
+                    data: { confirm: t('camaleon_cms.admin.message.delete') },
+                    class: 'btn btn-danger btn-xs cama_ajax_request',
+                    title: t('camaleon_cms.admin.comments.tooltip.delete_comment')
+                  ) { content_tag(:i, '', class: 'fa fa-trash-o') }
+                )
+              end)
+              concat(content_tag(:div, class: 'pull-right') do
+                concat(
+                  link_to(
+                    url_for({ action: :toggle_status, comment_id: comment.id, s: 'a' }),
+                    title: t('camaleon_cms.admin.comments.tooltip.approved_comment'),
+                    class: "#{comment.approved == 'approved' ? 'hidden' : ''} btn btn-success approve btn-xs cama_ajax_request"
+                  ) { content_tag(:span, '', class: 'fa fa-thumbs-o-up') }
+                )
+                concat(' ')
+                concat(
+                  link_to(
+                    url_for({ action: :toggle_status, comment_id: comment.id, s: 'p' }),
+                    title: t('camaleon_cms.admin.comments.tooltip.comment_pending'),
+                    class: "#{comment.approved == 'pending' ? 'hidden' : ''} btn btn-primary pending btn-xs cama_ajax_request"
+                  ) { content_tag(:span, '', class: 'fa fa-warning') }
+                )
+                concat(' ')
+                concat(
+                  link_to(
+                    url_for({ action: :toggle_status, comment_id: comment.id, s: 's' }),
+                    title: t('camaleon_cms.admin.comments.tooltip.comment_spam'),
+                    class: "#{comment.approved == 'spam' ? 'hidden' : ''} btn btn-danger spam btn-xs cama_ajax_request"
+                  ) { content_tag(:span, '', class: 'fa fa-bug') }
+                )
+              end)
+            end)
+            concat(content_tag(:hr))
+            concat(content_tag(:div, '', class: 'clearfix'))
+            concat(cama_comments_render_html(comment.children))
+          end)
+        end
+      end.join('').html_safe
     end
   end
 end

--- a/app/helpers/camaleon_cms/comment_helper.rb
+++ b/app/helpers/camaleon_cms/comment_helper.rb
@@ -20,71 +20,74 @@ module CamaleonCms
         author = comment.the_author
         labels = { 'approved' => 'success', 'pending' => 'warning', 'spam' => 'danger' }
         content_tag(:div, class: 'media') do
-          concat(content_tag(:div, class: 'media-left') do
-            link_to(author.the_admin_profile_url) do
-              image_tag(author.the_avatar, class: 'media-object', style: 'width: 64px; height: 64px;')
+          [
+            content_tag(:div, class: 'media-left') do
+              link_to(author.the_admin_profile_url) do
+                image_tag(author.the_avatar, class: 'media-object', style: 'width: 64px; height: 64px;')
+              end
+            end,
+            content_tag(:div, class: 'media-body') do
+              [
+                content_tag(:h4, class: 'media-heading') do
+                  [
+                    author.the_name,
+                    ' ',
+                    content_tag(:small, comment.the_created_at),
+                    ' ',
+                    content_tag(:span, t("camaleon_cms.admin.comments.message.#{comment.approved}"),
+                                class: "label label-#{labels[comment.approved]} pull-right")
+                  ].join.html_safe
+                end,
+                content_tag(:div, sanitize(comment.content), class: 'comment_content'),
+                content_tag(:div, class: 'comment_actions') do
+                  [
+                    content_tag(:div, class: 'pull-left') do
+                      [
+                        link_to(
+                          cama_admin_post_comment_answer_path(@post.id, comment.id),
+                          data: { comment_id: comment.id },
+                          title: t('camaleon_cms.admin.comments.tooltip.reply_comment'),
+                          class: 'btn btn-info reply btn-xs ajax_modal'
+                        ) { content_tag(:span, '', class: 'fa fa-mail-reply') },
+                        ' ',
+                        link_to(
+                          { action: :destroy, id: comment.id },
+                          method: :delete,
+                          data: { confirm: t('camaleon_cms.admin.message.delete') },
+                          class: 'btn btn-danger btn-xs cama_ajax_request',
+                          title: t('camaleon_cms.admin.comments.tooltip.delete_comment')
+                        ) { content_tag(:i, '', class: 'fa fa-trash-o') }
+                      ].join.html_safe
+                    end,
+                    content_tag(:div, class: 'pull-right') do
+                      [
+                        link_to(
+                          url_for({ action: :toggle_status, comment_id: comment.id, s: 'a' }),
+                          title: t('camaleon_cms.admin.comments.tooltip.approved_comment'),
+                          class: "#{comment.approved == 'approved' ? 'hidden' : ''} btn btn-success approve btn-xs cama_ajax_request"
+                        ) { content_tag(:span, '', class: 'fa fa-thumbs-o-up') },
+                        ' ',
+                        link_to(
+                          url_for({ action: :toggle_status, comment_id: comment.id, s: 'p' }),
+                          title: t('camaleon_cms.admin.comments.tooltip.comment_pending'),
+                          class: "#{comment.approved == 'pending' ? 'hidden' : ''} btn btn-primary pending btn-xs cama_ajax_request"
+                        ) { content_tag(:span, '', class: 'fa fa-warning') },
+                        ' ',
+                        link_to(
+                          url_for({ action: :toggle_status, comment_id: comment.id, s: 's' }),
+                          title: t('camaleon_cms.admin.comments.tooltip.comment_spam'),
+                          class: "#{comment.approved == 'spam' ? 'hidden' : ''} btn btn-danger spam btn-xs cama_ajax_request"
+                        ) { content_tag(:span, '', class: 'fa fa-bug') }
+                      ].join.html_safe
+                    end
+                  ].join.html_safe
+                end,
+                content_tag(:hr),
+                content_tag(:div, '', class: 'clearfix'),
+                cama_comments_render_html(comment.children)
+              ].join.html_safe
             end
-          end)
-          concat(content_tag(:div, class: 'media-body') do
-            concat(content_tag(:h4, class: 'media-heading') do
-              concat(author.the_name)
-              concat(' ')
-              concat(content_tag(:small, comment.the_created_at))
-              concat(' ')
-              concat(content_tag(:span, t("camaleon_cms.admin.comments.message.#{comment.approved}"), class: "label label-#{labels[comment.approved]} pull-right"))
-            end)
-            concat(content_tag(:div, sanitize(comment.content), class: 'comment_content'))
-            concat(content_tag(:div, class: 'comment_actions') do
-              concat(content_tag(:div, class: 'pull-left') do
-                concat(
-                  link_to(
-                    cama_admin_post_comment_answer_path(@post.id, comment.id),
-                    data: { comment_id: comment.id },
-                    title: t('camaleon_cms.admin.comments.tooltip.reply_comment'),
-                    class: 'btn btn-info reply btn-xs ajax_modal'
-                  ) { content_tag(:span, '', class: 'fa fa-mail-reply') }
-                )
-                concat(' ')
-                concat(
-                  link_to(
-                    { action: :destroy, id: comment.id },
-                    method: :delete,
-                    data: { confirm: t('camaleon_cms.admin.message.delete') },
-                    class: 'btn btn-danger btn-xs cama_ajax_request',
-                    title: t('camaleon_cms.admin.comments.tooltip.delete_comment')
-                  ) { content_tag(:i, '', class: 'fa fa-trash-o') }
-                )
-              end)
-              concat(content_tag(:div, class: 'pull-right') do
-                concat(
-                  link_to(
-                    url_for({ action: :toggle_status, comment_id: comment.id, s: 'a' }),
-                    title: t('camaleon_cms.admin.comments.tooltip.approved_comment'),
-                    class: "#{comment.approved == 'approved' ? 'hidden' : ''} btn btn-success approve btn-xs cama_ajax_request"
-                  ) { content_tag(:span, '', class: 'fa fa-thumbs-o-up') }
-                )
-                concat(' ')
-                concat(
-                  link_to(
-                    url_for({ action: :toggle_status, comment_id: comment.id, s: 'p' }),
-                    title: t('camaleon_cms.admin.comments.tooltip.comment_pending'),
-                    class: "#{comment.approved == 'pending' ? 'hidden' : ''} btn btn-primary pending btn-xs cama_ajax_request"
-                  ) { content_tag(:span, '', class: 'fa fa-warning') }
-                )
-                concat(' ')
-                concat(
-                  link_to(
-                    url_for({ action: :toggle_status, comment_id: comment.id, s: 's' }),
-                    title: t('camaleon_cms.admin.comments.tooltip.comment_spam'),
-                    class: "#{comment.approved == 'spam' ? 'hidden' : ''} btn btn-danger spam btn-xs cama_ajax_request"
-                  ) { content_tag(:span, '', class: 'fa fa-bug') }
-                )
-              end)
-            end)
-            concat(content_tag(:hr))
-            concat(content_tag(:div, '', class: 'clearfix'))
-            concat(cama_comments_render_html(comment.children))
-          end)
+          ].join.html_safe
         end
       end.join('').html_safe
     end

--- a/app/helpers/camaleon_cms/comment_helper.rb
+++ b/app/helpers/camaleon_cms/comment_helper.rb
@@ -1,5 +1,7 @@
 module CamaleonCms
   module CommentHelper
+    LABELS = { 'approved' => 'success', 'pending' => 'warning', 'spam' => 'danger' }.freeze
+
     # return common data to save a new comment
     # user_id, author, aothor_email, author_ip, approved, :agent
     def cama_comments_get_common_data
@@ -18,7 +20,6 @@ module CamaleonCms
     def cama_comments_render_html(comments)
       comments.decorate.map do |comment|
         author = comment.the_author
-        labels = { 'approved' => 'success', 'pending' => 'warning', 'spam' => 'danger' }
         content_tag(:div, class: 'media') do
           [
             content_tag(:div, class: 'media-left') do
@@ -35,7 +36,7 @@ module CamaleonCms
                     content_tag(:small, comment.the_created_at),
                     ' ',
                     content_tag(:span, t("camaleon_cms.admin.comments.message.#{comment.approved}"),
-                                class: "label label-#{labels[comment.approved]} pull-right")
+                                class: "label label-#{LABELS[comment.approved]} pull-right")
                   ].join.html_safe
                 end,
                 content_tag(:div, sanitize(comment.content), class: 'comment_content'),

--- a/app/views/camaleon_cms/admin/appearances/nav_menus/_left_menu_items.html.erb
+++ b/app/views/camaleon_cms/admin/appearances/nav_menus/_left_menu_items.html.erb
@@ -46,12 +46,12 @@
                         </div>
                         <% if pt.manage_categories? %>
                             <div class="tab-pane class_type" id="tab-<%= pt.slug %>-categories" data-type="category" data-post_type="<%= pt.slug %>">
-                                <%= raw post_type_html_inputs(pt, "categories", "categories", "checkbox", [], "categorychecklist") %>
+                                <%= post_type_html_inputs(pt, "categories", "categories", "checkbox", [], "categorychecklist") %>
                             </div>
                         <% end %>
                         <% if pt.manage_tags? %>
                             <div class="tab-pane class_type" id="tab-<%= pt.slug %>-tags" data-type="post_tag" data-post_type="<%= pt.slug %>">
-                                <%= raw post_type_html_inputs(pt, "post_tags", "post_tags", "checkbox", [], "categorychecklist") %>
+                                <%= post_type_html_inputs(pt, "post_tags", "post_tags", "checkbox", [], "categorychecklist") %>
                             </div>
                         <% end %>
                     </div>

--- a/app/views/camaleon_cms/admin/categories/index.html.erb
+++ b/app/views/camaleon_cms/admin/categories/index.html.erb
@@ -58,7 +58,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @categories.empty? %>
-            <%= raw cama_do_pagination(@categories) %>
+            <%= cama_do_pagination(@categories) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/app/views/camaleon_cms/admin/comments/index.html.erb
+++ b/app/views/camaleon_cms/admin/comments/index.html.erb
@@ -15,7 +15,7 @@
     <div class="panel-body">
         <div class="messages messages-img">
             <%= raw "<div class='alert alert-warning'>#{t('camaleon_cms.admin.comments.message.there_no_comments')}</div>" if @comments.size == 0 %>
-            <%= raw cama_comments_render_html(@comments) %>
+            <%= cama_comments_render_html(@comments) %>
         </div>
     </div>
 </div>

--- a/app/views/camaleon_cms/admin/comments/list.html.erb
+++ b/app/views/camaleon_cms/admin/comments/list.html.erb
@@ -31,6 +31,6 @@
             </tbody>
         </table>
         <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @posts.empty? %>
-        <%= raw cama_do_pagination(@posts) %>
+        <%= cama_do_pagination(@posts) %>
     </div>
 </div>

--- a/app/views/camaleon_cms/admin/post_tags/index.html.erb
+++ b/app/views/camaleon_cms/admin/post_tags/index.html.erb
@@ -46,7 +46,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @post_tags.empty? %>
-          <%= raw cama_do_pagination(@post_tags) %>
+          <%= cama_do_pagination(@post_tags) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
+++ b/app/views/camaleon_cms/admin/posts/_sidebar.html.erb
@@ -101,7 +101,7 @@
             </div>
             <div class="panel-body ">
                 <div class="form-group list-categories">
-                    <%= raw post_type_html_inputs(@post_type, "categories", "categories" , @post_type.get_option('has_single_category', false) ? 'radio' : "checkbox" ,params[:categories] || (@post.new_record? ? [] : @post.categories.pluck("#{CamaleonCms::TermTaxonomy.table_name}.id")), "categorychecklist", true )%>
+                    <%= post_type_html_inputs(@post_type, "categories", "categories" , @post_type.get_option('has_single_category', false) ? 'radio' : "checkbox" ,params[:categories] || (@post.new_record? ? [] : @post.categories.pluck("#{CamaleonCms::TermTaxonomy.table_name}.id")), "categorychecklist", true )%>
                 </div>
             </div>
         </div>

--- a/app/views/camaleon_cms/admin/posts/index.html.erb
+++ b/app/views/camaleon_cms/admin/posts/index.html.erb
@@ -60,10 +60,10 @@
                     <td><%= link_to raw(f.the_status), {action: :index, s: f.status}, class: "cama_ajax_request" %>  </td>
                     <td><%= f.author.fullname %></td>
                     <% if @post_type.manage_categories? %>
-                        <td><%= raw post_type_list_taxonomy(f.categories, "success") %></td>
+                        <td><%= post_type_list_taxonomy(f.categories, "success") %></td>
                     <% end %>
                     <% if @post_type.manage_tags? %>
-                        <td><%= raw post_type_list_taxonomy(f.post_tags, "default") %></td>
+                        <td><%= post_type_list_taxonomy(f.post_tags, "default") %></td>
                     <% end %>
                     <% extra_column = {post: f, post_type: @post_type, content: "", from_body: true};  hooks_run("list_post_extra_columns", extra_column) %>
                     <%= raw extra_column[:content] %>
@@ -107,6 +107,6 @@
             </tbody>
         </table>
         <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @posts.empty? %>
-        <%= raw cama_do_pagination(@posts) %>
+        <%= cama_do_pagination(@posts) %>
     </div>
 </div>

--- a/app/views/camaleon_cms/admin/search.html.erb
+++ b/app/views/camaleon_cms/admin/search.html.erb
@@ -62,7 +62,7 @@
                                 </tbody>
                             </table>
                             <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @items.empty? %>
-                            <%= raw cama_do_pagination(@items, panel_class: "cama_ajax_request") %>
+                            <%= cama_do_pagination(@items, panel_class: "cama_ajax_request") %>
                         </div>
                     </div>
                 </div>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
@@ -42,15 +42,11 @@
                 </div>
                 <%
                   field_options_json = if params[:field_options].present?
-                                         r = []
-                                         params[:field_options].each do |_k, v|
-                                           val = {}
-                                           v.each do |kk, vv|
+                                         params[:field_options].to_unsafe_h.each_with_object([]) do |(_k, v), r|
+                                           r << v.each_with_object({}) do |(kk, vv), val|
                                              val[kk.to_s] = (vv['values'].values rescue vv['values'])
                                            end
-                                           r << val
-                                         end
-                                         r.to_json
+                                         end.to_json
                                        else
                                          record.get_fields_grouped(fields.pluck(:slug).uniq).to_json
                                        end

--- a/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/_render.html.erb
@@ -23,7 +23,7 @@
                                 <%= field.name %>
                                 <%= raw "<em class='text-danger'>*</em>" if field.options[:required].to_s.to_bool %>
                                 <% if current_site.get_option('custom_fields_show_shortcodes') && ["post", "posttype", "category", "postTag", "site", "user", "navmenu", "theme"].include?(obj_class) %>
-                                    <small class="shortcode_field"><br><%= raw cama_shortcode_print("[data field='#{field.slug}' #{"object='#{obj_class}' #{"id='#{record.id}'" if obj_class != "Theme" }" unless record.new_record?}]") %></small>
+                                    <small class="shortcode_field"><br><%= cama_shortcode_print("[data field='#{field.slug}' #{"object='#{obj_class}' #{"id='#{record.id}'" if obj_class != "Theme" }" unless record.new_record?}]") %></small>
                                 <% end %>
                             </label>
                             <% if field.description.present? %>
@@ -40,7 +40,32 @@
                         </div>
                     <% end %>
                 </div>
-                <script> jQuery(function(){ build_custom_field_group(<%= raw(params[:field_options].present? ? (r = []; params[:field_options].each{|k, v| val = {}; v.each{|kk, vv| val["#{kk}"] = (vv['values'].values rescue vv['values']); }; r << val }; r.to_json) : record.get_fields_grouped(fields.pluck(:slug).uniq).to_json) %>, '<%= group.id %>', <%= raw group_field_data.to_json %>, <%= group.is_repeat %>, '<%= field_name %>'); }); </script>
+                <%
+                  field_options_json = if params[:field_options].present?
+                                         r = []
+                                         params[:field_options].each do |_k, v|
+                                           val = {}
+                                           v.each do |kk, vv|
+                                             val[kk.to_s] = (vv['values'].values rescue vv['values'])
+                                           end
+                                           r << val
+                                         end
+                                         r.to_json
+                                       else
+                                         record.get_fields_grouped(fields.pluck(:slug).uniq).to_json
+                                       end
+                %>
+                <script>
+                    jQuery(function () {
+                        build_custom_field_group(
+                            <%= json_escape(field_options_json).html_safe %>,
+                            '<%= group.id %>',
+                            <%= json_escape(group_field_data.to_json).html_safe %>,
+                            <%= group.is_repeat %>,
+                            '<%= field_name %>'
+                        );
+                    });
+                </script>
             </div>
         </div>
         <% if group.is_repeat %>

--- a/app/views/camaleon_cms/admin/settings/custom_fields/index.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/index.html.erb
@@ -44,7 +44,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @field_groups.empty? %>
-            <%= raw cama_do_pagination(@field_groups) %>
+            <%= cama_do_pagination(@field_groups) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/app/views/camaleon_cms/admin/settings/post_types/index.html.erb
+++ b/app/views/camaleon_cms/admin/settings/post_types/index.html.erb
@@ -42,7 +42,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @post_types.empty? %>
-            <%= raw cama_do_pagination(@post_types) %>
+            <%= cama_do_pagination(@post_types) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/app/views/camaleon_cms/admin/settings/sites/index.html.erb
+++ b/app/views/camaleon_cms/admin/settings/sites/index.html.erb
@@ -50,7 +50,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @sites.empty? %>
-            <%= raw cama_do_pagination(@sites) %>
+            <%= cama_do_pagination(@sites) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/app/views/camaleon_cms/admin/user_roles/index.html.erb
+++ b/app/views/camaleon_cms/admin/user_roles/index.html.erb
@@ -45,7 +45,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @user_roles.empty? %>
-            <%= raw cama_do_pagination(@user_roles) %>
+            <%= cama_do_pagination(@user_roles) %>
 
         </div>
 

--- a/app/views/camaleon_cms/admin/users/index.html.erb
+++ b/app/views/camaleon_cms/admin/users/index.html.erb
@@ -53,7 +53,7 @@
             </tbody>
           </table>
           <%= content_tag("div", raw(t('camaleon_cms.admin.message.data_found_list')), class: "alert alert-warning") if @users.empty? %>
-            <%= raw cama_do_pagination(@users) %>
+            <%= cama_do_pagination(@users) %>
         </div>
       </div>
       <!-- END BASIC TABLE SAMPLE -->

--- a/spec/dummy/app/apps/themes/default/views/category.html.erb
+++ b/spec/dummy/app/apps/themes/default/views/category.html.erb
@@ -8,7 +8,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/spec/dummy/app/apps/themes/default/views/post_tag.html.erb
+++ b/spec/dummy/app/apps/themes/default/views/post_tag.html.erb
@@ -8,7 +8,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/spec/dummy/app/apps/themes/default/views/post_type.html.erb
+++ b/spec/dummy/app/apps/themes/default/views/post_type.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/spec/dummy/app/apps/themes/default/views/search.html.erb
+++ b/spec/dummy/app/apps/themes/default/views/search.html.erb
@@ -11,7 +11,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/spec/dummy/app/apps/themes/new/views/category.html.erb
+++ b/spec/dummy/app/apps/themes/new/views/category.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/spec/dummy/app/apps/themes/new/views/post_tag.html.erb
+++ b/spec/dummy/app/apps/themes/new/views/post_tag.html.erb
@@ -15,7 +15,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/spec/dummy/app/apps/themes/new/views/post_type.html.erb
+++ b/spec/dummy/app/apps/themes/new/views/post_type.html.erb
@@ -24,7 +24,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 

--- a/spec/dummy/app/apps/themes/new/views/search.html.erb
+++ b/spec/dummy/app/apps/themes/new/views/search.html.erb
@@ -12,7 +12,7 @@
                 <% end %>
             </div>
             <%= content_tag("div", raw(ct('no_contents_found', default: 'No contents found')), class: "alert alert-warning") if @posts.empty? %>
-            <%= raw cama_do_pagination(@posts) %>
+            <%= cama_do_pagination(@posts) %>
         </div>
     </div>
 </article>

--- a/spec/helpers/camaleon_cms/admin/application_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/application_helper_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'CamaleonCms::Admin::ApplicationHelper' do
+  describe '#cama_shortcode_print' do
+    it 'returns an input tag with auto-select JS attributes' do
+      code = '[test_shortcode]'
+      result = helper.cama_shortcode_print(code)
+
+      expect(result).to include('input')
+      expect(result).to include('class="code_style"')
+      expect(result).to include('readonly="readonly"')
+      expect(result).to include('onmousedown="this.clicked = 1;"')
+      expect(result).to include('onfocus="if (!this.clicked) this.select(); else this.clicked = 2;"')
+      expect(result).to include('onclick="if (this.clicked == 2) this.select(); this.clicked = 0;"')
+      expect(result).to include('value="[test_shortcode]"')
+    end
+
+    it 'escapes the value attribute to prevent XSS' do
+      malicious_code = '"><script>alert(1)</script>'
+      result = helper.cama_shortcode_print(malicious_code)
+
+      expect(result).to include('value="&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;"')
+      expect(result).not_to include('"><script>')
+    end
+  end
+end

--- a/spec/requests/security/xss_vulnerabilities_spec.rb
+++ b/spec/requests/security/xss_vulnerabilities_spec.rb
@@ -41,6 +41,21 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
       expect(response).to have_http_status(200)
       expect(response.body).to include(escaped_payload)
     end
+
+    it 'includes auto-select JavaScript attributes in shortcodes' do
+      group = current_site.custom_field_groups.create!(name: 'Test Group', object_class: 'PostType_Post', objectid: post_type.id, slug: "test-group-#{SecureRandom.hex(4)}")
+      group.add_field({ name: 'Test Field', slug: 'test-field' }, { field_key: 'text_box' })
+
+      get '/admin/settings/custom_fields/list', params: {
+        post_type: post_type.id
+      }
+      expect(response).to have_http_status(200)
+      expect(response.body).to include('onmousedown="this.clicked = 1;"')
+      expect(response.body).to include('onfocus="if (!this.clicked) this.select(); else this.clicked = 2;"')
+      expect(response.body).to include('onclick="if (this.clicked == 2) this.select(); this.clicked = 0;"')
+      expect(response.body).to include('readonly="readonly"')
+      expect(response.body).to match(/class="[^"]*code_style[^"]*"/)
+    end
   end
 
   describe 'Comments' do

--- a/spec/requests/security/xss_vulnerabilities_spec.rb
+++ b/spec/requests/security/xss_vulnerabilities_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+  let(:post_type) { current_site.post_types.where(slug: 'post').first_or_create!(name: 'Post') }
+  let(:malicious_payload) { '<span>alert(1)</span>' }
+  let(:escaped_payload) { ERB::Util.html_escape(malicious_payload) }
+  let(:json_escaped_payload) { '\\u003cspan\\u003ealert(1)\\u003c/span\\u003e' }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    sign_in_as(admin, site: current_site)
+    current_site.set_option('custom_fields_show_shortcodes', true)
+  end
+
+  describe 'Custom Fields and Shortcodes' do
+    it 'escapes field names and field options' do
+      group = current_site.custom_field_groups.create!(name: malicious_payload, object_class: 'PostType_Post', objectid: post_type.id, slug: "malicious-group-#{SecureRandom.hex(4)}")
+      group.add_field({ name: malicious_payload, slug: 'test-field' }, { field_key: 'text_box' })
+
+      get '/admin/settings/custom_fields/list', params: {
+        post_type: post_type.id,
+        field_options: {
+          '0' => {
+            'helper' => { 'values' => { '0' => malicious_payload } }
+          }
+        }
+      }
+
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+      expect(response.body).to include(json_escaped_payload)
+
+      # Test Finding 10: Custom Fields Index
+      get '/admin/settings/custom_fields'
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+  end
+
+  describe 'Comments' do
+    it 'escapes author name' do
+      my_post = post_type.posts.create!(title: 'Test Post', slug: 'test-post', user_id: admin.id)
+      # Associate with admin user and set malicious first name
+      admin.update!(first_name: malicious_payload, last_name: '')
+      my_post.comments.create!(content: 'Test comment', author: 'Attacker', author_email: 'a@b.com', approved: 'approved', user_id: admin.id)
+
+      get "/admin/posts/#{my_post.id}/comments"
+
+      expect(response).to have_http_status(200)
+      expect(response.body).to match(/#{Regexp.escape(escaped_payload)}/i)
+    end
+  end
+
+  describe 'Taxonomies' do
+    it 'escapes category and tag names' do
+      cat = post_type.categories.create!(name: malicious_payload, slug: "malicious-cat-#{SecureRandom.hex(4)}")
+      tag = post_type.post_tags.create!(name: malicious_payload, slug: "malicious-tag-#{SecureRandom.hex(4)}")
+      my_post = post_type.posts.create!(title: 'Post with Malicious Cat', slug: "malicious-post-#{SecureRandom.hex(4)}", user_id: admin.id, categories: [cat], post_tags: [tag])
+
+      # Categories index (Finding 1)
+      get "/admin/post_type/#{post_type.id}/categories"
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+
+      # Tags index (Finding 4)
+      get "/admin/post_type/#{post_type.id}/post_tags"
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+
+      # Post list (Finding 6 - categories/tags shown in list)
+      get "/admin/post_type/#{post_type.id}/posts"
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+
+      # Post edit sidebar (Finding 5)
+      get "/admin/post_type/#{post_type.id}/posts/#{my_post.id}/edit"
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+
+    it 'escapes payload in search page (Finding 7)' do
+      get '/admin/search', params: { q: malicious_payload }
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+  end
+
+  describe 'User Management and Settings' do
+    it 'escapes in users index (Finding 14)' do
+      admin.update!(first_name: malicious_payload, last_name: '')
+      get '/admin/users'
+      expect(response).to have_http_status(200)
+      # User name is titleized: <span>alert(1)</span> -> <Span>Alert(1)</Span>
+      expect(response.body).to match(/#{Regexp.escape(ERB::Util.html_escape(malicious_payload))}/i)
+    end
+
+    it 'escapes in roles index (Finding 13)' do
+      current_site.user_roles.create!(name: malicious_payload, slug: "malicious-role-#{SecureRandom.hex(4)}")
+      get '/admin/user_roles'
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+
+    it 'escapes in sites index (Finding 12)' do
+      current_site.update!(name: malicious_payload)
+      get '/admin/settings/sites'
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+
+    it 'escapes in post types index (Finding 11)' do
+      current_site.post_types.create!(name: malicious_payload, slug: "malicious-pt-#{SecureRandom.hex(4)}")
+      get '/admin/settings/post_types'
+      expect(response).to have_http_status(200)
+      expect(response.body).to include(escaped_payload)
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses 14 Cross-Site Scripting (XSS) vulnerabilities reported by Brakeman. It refactors several helpers to use Rails' content_tag for safe HTML structure and removes unsafe raw calls in admin views. Additionally, it includes a comprehensive security request spec suite to verify the fixes and prevent regressions.