### PR TITLE
Fix Brakeman vulnerabilities: dangerous eval, path traversal, SQL injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
   - This prevents authenticated admins from potentially executing arbitrary code via crafted error messages
   - Thanks, Amir Aliu and Enrik Mustafa for reporting this
 
+- **Security fix:** Fix Brakeman vulnerabilities: dangerous eval in plugin_routes, path traversal in MediaController, and SQL injection in visibility_post_helper, [#1160](https://github.com/owen2345/camaleon-cms/pull/1160)
+
 # [2.9.1](https://github.com/owen2345/camaleon-cms/tree/2.9.1) (2025-03-15)
 
 **This release is fixing several security vulnerabilities! Please, upgrade ASAP!**

--- a/app/apps/plugins/visibility_post/visibility_post_helper.rb
+++ b/app/apps/plugins/visibility_post/visibility_post_helper.rb
@@ -57,7 +57,7 @@ module Plugins
                                  if ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
                                    args[:active_record].where("visibility != 'private' or (visibility = 'private' and FIND_IN_SET(?, #{CamaleonCms::Post.table_name}.visibility_value))", current_site.visitor_role)
                                  else
-                                   args[:active_record].where("visibility != 'private' or (visibility = 'private' and (',' || #{CamaleonCms::Post.table_name}.visibility_value || ',') LIKE '%,#{current_site.visitor_role},%')")
+                                   args[:active_record].where("visibility != 'private' or (visibility = 'private' and (',' || #{CamaleonCms::Post.table_name}.visibility_value || ',') LIKE ?)", "%,#{current_site.visitor_role},%")
                                  end
                                else
                                  args[:active_record].where("visibility != 'private'")

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -28,11 +28,14 @@ module CamaleonCms
       def download_private_file
         cama_uploader.enable_private_mode!
 
-        file = cama_uploader.fetch_file("private/#{params[:file]}")
+        sanitize_private_filename!
+        return render(plain: 'Invalid file', status: :forbidden) unless @private_file_path
 
-        return render plain: helpers.sanitize(file[:error]) if file.is_a?(Hash) && file[:error].present?
+        fetched = cama_uploader.fetch_file(@private_file_path)
 
-        send_file file, disposition: 'inline'
+        return render plain: helpers.sanitize(fetched[:error]) if fetched.is_a?(Hash) && fetched[:error].present?
+
+        send_file fetched, disposition: 'inline'
       end
 
       # render media for modal content
@@ -106,6 +109,13 @@ module CamaleonCms
 
       def verify_media_authorization
         authorize! :manage, :media
+      end
+
+      # Sanitizes the private file parameter to prevent path traversal.
+      # Sets @private_file_path if valid, nil otherwise.
+      def sanitize_private_filename!
+        name = File.basename(params[:file].to_s)
+        @private_file_path = ("private/#{name}" if name.present? && name == params[:file].to_s)
       end
 
       # init basic media variables

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -174,12 +174,12 @@ class PluginRoutes
     @@all_sites = nil
     @@_vars.each { |v| class_variable_set("@@cache_#{v}", nil) }
     Rails.application.reload_routes!
-    @@_after_reload.uniq.each { |r| eval(r) }
+    @@_after_reload.uniq.each(&:call)
   end
 
-  # permit to add extra actions for reload routes
+  # Add a callable (Proc/Lambda) to run after routes reload; strings are not supported.
   def self.add_after_reload_routes(command)
-    @@_after_reload << command
+    @@_after_reload << (command.is_a?(String) ? raise(ArgumentError, 'Expected a callable (Proc/Lambda), not a String') : command)
   end
 
   # return all enabled plugins []

--- a/spec/helpers/plugins/visibility_post/visibility_post_helper_spec.rb
+++ b/spec/helpers/plugins/visibility_post/visibility_post_helper_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plugins::VisibilityPost::VisibilityPostHelper, type: :helper do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:post_type) { current_site.post_types.first }
+
+  before do
+    # Include required helpers so signin? and current_site work
+    helper.extend(CamaleonCms::SessionHelper)
+    allow(helper).to receive(:current_site).and_return(current_site)
+  end
+
+  describe '#plugin_visibility_filter_post' do
+    let(:base_scope) { CamaleonCms::Post.where(post_type_id: post_type.id) }
+
+    context 'when user is not signed in' do
+      before { allow(helper).to receive(:signin?).and_return(false) }
+
+      it 'excludes private posts' do
+        args = { active_record: base_scope }
+        helper.plugin_visibility_filter_post(args)
+
+        sql = args[:active_record].to_sql
+        expect(sql).to include("visibility != 'private'")
+        expect(sql).not_to include('LIKE')
+      end
+    end
+
+    context 'when user is signed in' do
+      before do
+        allow(helper).to receive(:signin?).and_return(true)
+        allow(current_site).to receive(:visitor_role).and_return('post_editor')
+      end
+
+      it 'parameterizes the visitor_role in the query' do
+        args = { active_record: base_scope }
+        helper.plugin_visibility_filter_post(args)
+
+        # The role value should be bound as a parameter, not interpolated into SQL
+        sql = args[:active_record].to_sql
+        expect(sql).to include('LIKE')
+        expect(sql).to include('%,post_editor,%')
+      end
+
+      it 'does not allow SQL injection through visitor_role' do
+        malicious_role = "admin' OR '1'='1"
+        allow(current_site).to receive(:visitor_role).and_return(malicious_role)
+
+        args = { active_record: base_scope }
+        helper.plugin_visibility_filter_post(args)
+
+        sql = args[:active_record].to_sql
+        # The malicious string should be escaped/quoted, not raw SQL
+        expect(sql).not_to include("OR '1'='1'")
+      end
+    end
+  end
+end

--- a/spec/lib/plugin_routes_spec.rb
+++ b/spec/lib/plugin_routes_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PluginRoutes do
+  describe '.add_after_reload_routes' do
+    after do
+      # Clean up the class variable to avoid polluting other tests
+      described_class.class_variable_set(:@@_after_reload, []) # rubocop:disable Style/ClassVars
+    end
+
+    it 'accepts a Proc' do
+      callable = proc { 'hello' }
+      expect { described_class.add_after_reload_routes(callable) }.not_to raise_error
+    end
+
+    it 'accepts a Lambda' do
+      callable = -> { 'hello' }
+      expect { described_class.add_after_reload_routes(callable) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError for a String' do
+      expect { described_class.add_after_reload_routes('puts "hello"') }
+        .to raise_error(ArgumentError, /callable/)
+    end
+  end
+
+  describe '.reload' do
+    it 'calls each registered callable' do
+      callback = instance_double(Proc)
+      described_class.class_variable_set(:@@_after_reload, [callback]) # rubocop:disable Style/ClassVars
+
+      allow(Rails.application).to receive(:reload_routes!)
+      expect(callback).to receive(:call)
+
+      described_class.reload
+
+      # Clean up
+      described_class.class_variable_set(:@@_after_reload, []) # rubocop:disable Style/ClassVars
+    end
+  end
+end

--- a/spec/requests/admin/media_controller/download_private_file_spec.rb
+++ b/spec/requests/admin/media_controller/download_private_file_spec.rb
@@ -38,10 +38,18 @@ RSpec.describe 'Download private file requests', type: :request do
     end
 
     context 'when file path is invalid' do
-      it 'returns invalid file path error' do
+      it 'rejects path traversal attempts' do
         get '/admin/media/download_private_file', params: { file: './../../../../../etc/passwd' }
 
-        expect(response.body).to include('Invalid file path')
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include('Invalid file')
+      end
+
+      it 'rejects filenames containing directory separators' do
+        get '/admin/media/download_private_file', params: { file: 'subdir/secret.txt' }
+
+        expect(response).to have_http_status(:forbidden)
+        expect(response.body).to include('Invalid file')
       end
     end
 


### PR DESCRIPTION
### What this PR does

Fixes all 3 Brakeman-reported vulnerabilities:

1. **Dangerous Eval** (`lib/plugin_routes.rb`): Replaced `eval(r)` with `r.call`; `add_after_reload_routes` now requires a callable (Proc/Lambda) and raises `ArgumentError` for strings.

2. **File Access / Path Traversal** (`app/controllers/camaleon_cms/admin/media_controller.rb`): Added `sanitize_private_filename!` that validates `params[:file]` via `File.basename` to prevent path traversal, rejecting any input containing directory separators.

3. **SQL Injection** (`app/apps/plugins/visibility_post/visibility_post_helper.rb`): Parameterized the `visitor_role` value in the SQL LIKE clause instead of string interpolation.

### Tests

- New specs for all three fixes (12 examples, 0 failures)
- `bin/brakeman --no-pager` reports zero warnings
- `bin/rubocop` reports zero offenses on changed files
