### PR TITLE
Optimize PluginRoutes.draw_gems and `apps_dir` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - Refactor class variables (`@@`) to class instance variables (`@`) with `Monitor` for thread-safe route reloading and cache access
   - Fix `return` in blocks by using `find` instead of `each`
   - Add 27 tests for `PluginRoutes`, `plugins`, and `themes` controllers
+- **Optimize PluginRoutes.draw_gems and apps_dir methods** Micro-optimizations for memory consumption and performance, [#1164](https://github.com/owen2345/camaleon-cms/pull/1164)
 
 ## [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2) (2026-05-01)
 

--- a/lib/generators/camaleon_cms/install_template/plugin_routes.rb
+++ b/lib/generators/camaleon_cms/install_template/plugin_routes.rb
@@ -2,22 +2,15 @@ require 'json'
 class PluginRoutes
   # draw "all" gems registered for the plugins or themes and camaleon gems
   def self.draw_gems
-    res = []
-    dirs = [] + Dir["#{apps_dir}/plugins/*"] + Dir["#{apps_dir}/themes/*"]
+    gemfiles = Dir["#{apps_dir}/{plugins,themes}/*/config/Gemfile"]
 
-    dirs.each do |path|
-      next if ['.', '..'].include?(path)
-
-      g = File.join(path, 'config', 'Gemfile')
-      res << File.read(g) if File.exist?(g)
-    end
-    res.join("\n")
+    # map + read + join is very memory efficient for strings
+    # Ensuring a newline between files prevents syntax errors if a file lacks a trailing newline
+    gemfiles.map { |gem| File.read(gem, encoding: 'UTF-8') }.join("\n\n")
   end
 
   # return apps directory path
   def self.apps_dir
-    dir = File.dirname(__FILE__).to_s.split('/')
-    dir.pop
-    "#{dir.join('/')}/app/apps"
+    File.join(File.dirname(__dir__), 'app', 'apps')
   end
 end

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -313,7 +313,7 @@ class PluginRoutes
 
     # return app's directory path
     def apps_dir
-      Rails.root.join('app', 'apps').to_s
+      @apps_dir ||= Rails.root.join('app', 'apps').to_s
     end
 
     # return all plugins located in cms and in this project


### PR DESCRIPTION
### Changes:
- Memoize `apps_dir` method in the gem's PluginRoutes

#### In the PluginRoutes, generated when installing `camaleon_cms` into the application:

- Use the `apps_dir` based on non-Rails methods , because it is run at the Gemfile end, when Rails is not available yet, and even the `camaleon_cms` is not yet loaded
- Skip File.exist?: Just call File.read. In Ruby, it is often faster to attempt the read and rescue the error (or use a glob that guarantees existence) than to check existence first and then read.
- Target the Gemfiles directly: Instead of getting all directory paths and then appending /config/Gemfile, let the Dir[] glob find the Gemfiles. This eliminates the each loop logic and the File.join overhead.
- Guard against missing trailing newlines: If a plugin author forgets to put a newline at the end of their Gemfile, joining them might result in a syntax error (e.g., the last line of one file and the first line of the next merging together).
- Enforce file reading in UTF-8: Since Gemfiles are technically Ruby code, they are usually UTF-8. To be extremely safe and prevent "invalid byte sequence" errors in rare environments, let's can force the encoding: File.read(gem, encoding: 'UTF-8')