### PR TITLE
Rubocop fixes part 1  + security hardening for open redirects

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - /**/vendor/**/* # Exclude downloaded gem code in CI
   NewCops: disable
   SuggestExtensions: false
+  TargetRailsVersion: 6.1
   TargetRubyVersion: 3.2
 
 Layout/MultilineMethodCallIndentation:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- **Security fix:** Fix two unprotected redirects via `params[:return_to]` in `sessions_controller.rb` and `session_helper.rb` [#1168](https://github.com/owen2345/camaleon-cms/pull/1168)
+  - Both used `params[:return_to]` directly in `redirect_to`, allowing open redirect attacks
+  - Fixed by routing through the existing `safe_redirect_url` helper
+  - Added tests in `spec/requests/security/open_redirect_session_spec.rb`
+- **Security, style, and cleanup:** Rubocop fixes part 1 [#1168](https://github.com/owen2345/camaleon-cms/pull/1168)
+  - Fixed `Style/IfUnlessModifier`, `Rails/Output`, `Rails/FilePath`, `Performance/InefficientHashSearch`, `Performance/RedundantMerge`, `Performance/StringReplacement`, `Rails/Presence`, `RSpecRails/HttpStatus`, `Rails/DynamicFindBy`, `Rails/FindEach`, `Rails/SkipsModelValidations`, `Rails/Time`, `Rails/Date`, `Rails/ApplicationRecord`, `Rails/Blank`
+  - Removed dead code: `cama_draw_timer`, `all_locales_for_routes`, `cama_get_options_html_from_items`, `cama_parse_for_thumb_name`
+  - Set `TargetRailsVersion` to `6.1` in `.rubocop.yml`
+- **Security fix:** Bump gems — Nokogiri to 1.19.3, action_text-trix, aws-sdk, puma, rubyzip, selenium-webdriver, sqlite3, Bundler 2.7.2 [#1170](https://github.com/owen2345/camaleon-cms/pull/1170)
+  - Nokogiri fixes: CSS selector tokenizer regexp backtracking, XSLT memory leak
+  - puma fix: `prune_bundler` was stripping user-configured `BUNDLE_*` env vars on re-exec
+  - DOMPurify upgraded to 3.4.2 in action_text-trix
+
 - **Fix:** Decorator locale resolution and language context mixing (fixes issue #233), [#1166](https://github.com/owen2345/camaleon-cms/pull/1166)
   - **Phase 1:** Fix locale accessibility and language context mixing
     - Move `cama_get_i18n_frontend` helper to parent CamaleonController so both frontend and admin decorators can access correct locale

--- a/app/apps/plugins/attack/admin_controller.rb
+++ b/app/apps/plugins/attack/admin_controller.rb
@@ -6,12 +6,15 @@ module Plugins
       end
 
       def save_settings
-        current_site.set_meta('attack_config', { get: { sec: params[:attack][:get_sec], max: params[:attack][:get_max] },
-                                                 post: { sec: params[:attack][:post_sec] || 20,
-                                                         max: params[:attack][:post_max] },
-                                                 msg: params[:attack][:msg],
-                                                 ban: params[:attack][:ban],
-                                                 cleared: Time.now })
+        current_site.set_meta(
+          'attack_config', {
+            get: { sec: params[:attack][:get_sec], max: params[:attack][:get_max] },
+            post: { sec: params[:attack][:post_sec] || 20, max: params[:attack][:post_max] },
+            msg: params[:attack][:msg],
+            ban: params[:attack][:ban],
+            cleared: Time.zone.now.iso8601
+          }
+        )
         flash[:notice] = t('plugin.attack.messages.settings_saved').to_s
         redirect_to action: :settings
       end

--- a/app/apps/plugins/attack/attack_helper.rb
+++ b/app/apps/plugins/attack/attack_helper.rb
@@ -55,7 +55,7 @@ module Plugins
 
         config = current_site.get_meta('attack_config')
         q = current_site.attack.where(browser_key: cama_get_session_id, path: attack_request_key)
-        return unless config.present?
+        return if config.blank?
 
         # clear past requests
         if begin

--- a/app/apps/plugins/attack/attack_helper.rb
+++ b/app/apps/plugins/attack/attack_helper.rb
@@ -1,14 +1,14 @@
 module Plugins
   module Attack
     module AttackHelper
-      # here all actions on plugin destroying
+      # Here all actions on the plugin are destroyed
       # plugin: plugin model
       def attack_on_destroy(_plugin)
         current_site.attack.destroy_all
       end
 
-      # here all actions on going to active
-      # you can run sql commands like this:
+      # Here all actions on going to active
+      # you can run SQL commands like this:
       # results = ActiveRecord::Base.connection.execute(query);
       # plugin: plugin model
       def attack_on_active(_plugin)
@@ -16,15 +16,13 @@ module Plugins
                                                  post: { sec: 20, max: 5 },
                                                  msg: I18n.t('plugin.attack.form.request_limit_exceeded').to_s,
                                                  ban: 5,
-                                                 cleared: Time.now })
+                                                 cleared: Time.zone.now.iso8601 })
 
-        unless ActiveRecord::Base.connection.table_exists? 'plugins_attacks'
-          ActiveRecord::Base.connection.create_table :plugins_attacks do |t|
-            t.string :path, index: true
-            t.string :browser_key, index: true
-            t.belongs_to :site, index: true
-            t.datetime 'created_at'
-          end
+        ActiveRecord::Base.connection.create_table :plugins_attacks, if_not_exists: true do |t|
+          t.string :path, index: true
+          t.string :browser_key, index: true
+          t.belongs_to :site, index: true
+          t.datetime 'created_at'
         end
         CamaleonCms::Site.class_eval do
           has_many :attack, class_name: 'Plugins::Attack::Models::Attack'
@@ -54,40 +52,40 @@ module Plugins
         return unless current_site
 
         config = current_site.get_meta('attack_config')
-        q = current_site.attack.where(browser_key: cama_get_session_id, path: attack_request_key)
+        query = current_site.attack.where(browser_key: cama_get_session_id, path: attack_request_key)
         return if config.blank?
 
         # clear past requests
         if begin
-          Time.parse(config[:cleared])
+          Time.zone.parse(config[:cleared])
         rescue StandardError
           2.hours.ago
         end < 1.hour.ago
           current_site.attack.where('plugins_attacks.created_at < ?', 1.hour.ago).delete_all
-          config[:cleared] = Time.now.to_s
+          config[:cleared] = Time.zone.now.iso8601 # Use ISO8601 for reliable parsing
           current_site.set_meta('attack_config', config)
         end
 
         # post request
         if request.post? || request.patch?
-          r = q.where(created_at: config[:post][:sec].to_i.seconds.ago..Time.now)
+          r = query.where(created_at: config[:post][:sec].to_i.seconds.ago..Time.zone.now)
           if r.count > config[:post][:max].to_i
             Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
-            # send an email to administrator with request info (ip, browser, if logged then send user info
+            # Email administrator with request info (ip, browser, if logged, then send user info
             render html: config[:msg].html_safe
             return
           end
 
         # get request
         else
-          r = q.where(created_at: config[:get][:sec].to_i.seconds.ago..Time.now)
+          r = query.where(created_at: config[:get][:sec].to_i.seconds.ago..Time.zone.now)
           if r.count > config[:get][:max].to_i
             Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
             render html: config[:msg].html_safe
             return
           end
         end
-        q.create
+        query.create
       end
 
       def attack_request_key(method = nil)

--- a/app/apps/plugins/front_cache/admin_controller.rb
+++ b/app/apps/plugins/front_cache/admin_controller.rb
@@ -5,7 +5,7 @@ module Plugins
 
       def settings
         @caches = current_site.get_meta('front_cache_elements', { paths: [] })
-        @caches[:paths] << '' unless @caches[:paths].present?
+        @caches[:paths] << '' if @caches[:paths].blank?
       end
 
       def save_settings

--- a/app/apps/plugins/front_cache/config/initializer.rb
+++ b/app/apps/plugins/front_cache/config/initializer.rb
@@ -3,7 +3,7 @@ if begin
 rescue StandardError
   false
 end
-  CamaleonCms::Site.all.each do |site|
+  CamaleonCms::Site.find_each do |site|
     site.set_option('refresh_cache', true)
   end
 end

--- a/app/apps/plugins/front_cache/front_cache_helper.rb
+++ b/app/apps/plugins/front_cache/front_cache_helper.rb
@@ -26,7 +26,7 @@ module Plugins
         if @caches[:paths].include?(request.original_url) || @caches[:paths].include?(request.path_info) || front_cache_plugin_match_path_patterns?(request.original_url, request.path_info) || (params[:action] == 'index' && params[:controller] == 'camaleon_cms/frontend' && @caches[:home].present?) # cache paths and home page
           @_plugin_do_cache = true
         elsif params[:action] == 'post' && params[:controller] == 'camaleon_cms/frontend' && params[:draft_id].blank?
-          if (post = current_site.the_posts.find_by_slug(params[:slug]))
+          if (post = current_site.the_posts.find_by(slug: params[:slug]))
             post = post.decorate
             if post.can_visit? && post.visibility != 'private'
               if (@caches[:skip_posts] || []).include?(post.id.to_s)

--- a/app/apps/plugins/front_cache/front_cache_helper.rb
+++ b/app/apps/plugins/front_cache/front_cache_helper.rb
@@ -13,7 +13,7 @@ module Plugins
 
         cache_key = front_cache_plugin_cache_key
         @caches = current_site.get_meta('front_cache_elements')
-        if !flash.keys.present? && front_cache_exist?(cache_key) # recover cache item
+        if flash.keys.blank? && front_cache_exist?(cache_key) # recover cache item
           Rails.logger.info "Camaleon CMS - readed cache: #{front_cache_plugin_get_path(cache_key)}"
           response.headers['PLUGIN_FRONT_CACHE'] = 'TRUE'
           args = { data: front_cache_get(cache_key).gsub('{{form_authenticity_token}}', form_authenticity_token) }
@@ -25,7 +25,7 @@ module Plugins
         @_plugin_do_cache = false
         if @caches[:paths].include?(request.original_url) || @caches[:paths].include?(request.path_info) || front_cache_plugin_match_path_patterns?(request.original_url, request.path_info) || (params[:action] == 'index' && params[:controller] == 'camaleon_cms/frontend' && @caches[:home].present?) # cache paths and home page
           @_plugin_do_cache = true
-        elsif params[:action] == 'post' && params[:controller] == 'camaleon_cms/frontend' && !params[:draft_id].present?
+        elsif params[:action] == 'post' && params[:controller] == 'camaleon_cms/frontend' && params[:draft_id].blank?
           if (post = current_site.the_posts.find_by_slug(params[:slug]))
             post = post.decorate
             if post.can_visit? && post.visibility != 'private'
@@ -43,7 +43,7 @@ module Plugins
 
       def front_cache_front_after_load
         cache_key = front_cache_plugin_cache_key
-        return unless @_plugin_do_cache && !flash.keys.present?
+        return unless @_plugin_do_cache && flash.keys.blank?
 
         body =
           response

--- a/app/apps/plugins/visibility_post/visibility_post_helper.rb
+++ b/app/apps/plugins/visibility_post/visibility_post_helper.rb
@@ -105,7 +105,7 @@ module Plugins
 
       <div class='panel-options hidden'>
 
-        <label style='display: block;'><input type='radio' name='post[visibility]' claass='radio' value='public' #{if !post.visibility.present? || post.visibility == 'public'
+        <label style='display: block;'><input type='radio' name='post[visibility]' claass='radio' value='public' #{if post.visibility.blank? || post.visibility == 'public'
                                                                                                                      "checked=''"
                                                                                                                    end}> #{t('camaleon_cms.admin.table.public')}</label>
         <div></div>

--- a/app/apps/plugins/visibility_post/visibility_post_helper.rb
+++ b/app/apps/plugins/visibility_post/visibility_post_helper.rb
@@ -9,9 +9,9 @@ module Plugins
         args[:content] = _password_form
       end
 
-      def plugin_visibility_on_active(plugin); end
+      def plugin_visibility_on_active(_plugin); end
 
-      def plugin_visibility_on_inactive(plugin); end
+      def plugin_visibility_on_inactive(_plugin); end
 
       def plugin_visibility_post_list(args)
         args[:posts] = args[:posts].where(visibility: 'private') if params[:s] == 'private'
@@ -29,7 +29,7 @@ module Plugins
 
       def plugin_visibility_can_visit(args)
         post = args[:post]
-        return args[:flag] = false if post.published_at.present? && post.published_at > Time.now
+        return args[:flag] = false if post.published_at.present? && post.published_at > Time.zone.now
         return if post.visibility != 'private'
 
         args[:flag] = false unless signin? && post.visibility_value.split(',').include?(current_site.visitor_role)
@@ -37,31 +37,42 @@ module Plugins
 
       def plugin_visibility_extra_columns(args)
         if args[:from_body]
+          is_published = args[:post].published_at
+          post_visibility = args[:post].visibility
           args[:content] =
             "<td><i class='fa fa-#{{ 'private' => 'lock', '' => 'lock', 'public' => 'eye',
-                                     'password' => 'eye-slash' }[args[:post].visibility]}'></i> #{args[:post].visibility}</td>"
-          args[:content] =
-            "<td>#{args[:post].published_at.present? ? args[:post].published_at.strftime('%B %e, %Y %H:%M') : args[:post].the_created_at}</td>"
+                                     'password' => 'eye-slash' }[post_visibility]}'></i> #{post_visibility}</td>"
+          args[:content] +=
+            "<td>#{is_published.present? ? is_published.strftime('%B %e, %Y %H:%M') : args[:post].the_created_at}</td>"
         else
           args[:content] = "<th>#{t('camaleon_cms.admin.table.visibility')}</th>"
-          args[:content] = "<th>#{t('camaleon_cms.admin.table.date_published')}</th>"
+          args[:content] += "<th>#{t('camaleon_cms.admin.table.date_published')}</th>"
         end
       end
 
       def plugin_visibility_filter_post(args)
+        db_table = CamaleonCms::Post.table_name
         args[:active_record] =
           args[:active_record].where(
-            "(#{CamaleonCms::Post.table_name}.published_at is null or #{CamaleonCms::Post.table_name}.published_at <= ?)", Time.now
+            "(#{db_table}.published_at is null or #{db_table}.published_at <= ?)", Time.zone.now
           )
-        args[:active_record] = if signin?
-                                 if ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
-                                   args[:active_record].where("visibility != 'private' or (visibility = 'private' and FIND_IN_SET(?, #{CamaleonCms::Post.table_name}.visibility_value))", current_site.visitor_role)
-                                 else
-                                   args[:active_record].where("visibility != 'private' or (visibility = 'private' and (',' || #{CamaleonCms::Post.table_name}.visibility_value || ',') LIKE ?)", "%,#{current_site.visitor_role},%")
-                                 end
-                               else
-                                 args[:active_record].where("visibility != 'private'")
-                               end
+        not_private = "visibility != 'private'"
+        args[:active_record] =
+          if signin?
+            if ActiveRecord::Base.connection.adapter_name.downcase.include?('mysql')
+              args[:active_record].where(
+                "#{not_private} or (visibility = 'private' and FIND_IN_SET(?, #{db_table}.visibility_value))",
+                current_site.visitor_role
+              )
+            else
+              args[:active_record].where(
+                "#{not_private} or (visibility = 'private' and (',' || #{db_table}.visibility_value || ',') LIKE ?)",
+                "%,#{current_site.visitor_role},%"
+              )
+            end
+          else
+            args[:active_record].where(not_private)
+          end
       end
 
       private

--- a/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
@@ -11,9 +11,9 @@ module CamaleonCms
 
         def index
           @nav_menu = if params[:id].present?
-                        current_site.nav_menus.find_by_id(params[:id])
+                        current_site.nav_menus.find_by(id: params[:id])
                       elsif params[:slug].present?
-                        current_site.nav_menus.find_by_slug(params[:slug])
+                        current_site.nav_menus.find_by(slug: params[:slug])
                       else
                         current_site.nav_menus.first
                       end

--- a/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
@@ -146,7 +146,7 @@ module CamaleonCms
         # Only permit external menu options that match registered custom field slug
         def permitted_external_options(external_params = nil)
           opts = external_params ? external_params[:options] : params[:options]
-          return {} unless opts.present?
+          return {} if opts.blank?
 
           allowed_keys = cama_custom_field_allowed_slugs('NavMenuItem')
           return {} if allowed_keys.blank?

--- a/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/nav_menus_controller.rb
@@ -113,7 +113,7 @@ module CamaleonCms
 
           if params[:custom_items].present? # custom menu items
             params[:custom_items].each_value do |custom_item|
-              type = custom_item['kind'].present? ? custom_item['kind'] : 'external'
+              type = custom_item['kind'].presence || 'external'
               items << @nav_menu.append_menu_item({ label: custom_item['label'], link: custom_item['url'], type: type })
             end
           end

--- a/app/controllers/camaleon_cms/admin/appearances/themes_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/themes_controller.rb
@@ -8,7 +8,7 @@ module CamaleonCms
         def index
           add_breadcrumb I18n.t('camaleon_cms.admin.sidebar.themes')
           authorize! :manage, :themes
-          return unless params[:set].present?
+          return if params[:set].blank?
 
           site_install_theme(params[:set])
           flash.now[:notice] = t('camaleon_cms.admin.themes.message.updated')

--- a/app/controllers/camaleon_cms/admin/categories_controller.rb
+++ b/app/controllers/camaleon_cms/admin/categories_controller.rb
@@ -65,7 +65,7 @@ module CamaleonCms
       # define parent post type
       def set_post_type
         begin
-          @post_type = current_site.post_types.find_by_id(params[:post_type_id]).decorate
+          @post_type = current_site.post_types.find_by(id: params[:post_type_id]).decorate
         rescue StandardError
           flash[:error] = t('camaleon_cms.admin.request_error_message')
           redirect_to cama_admin_path, { error: 'Error Post Type' }
@@ -76,7 +76,7 @@ module CamaleonCms
       end
 
       def set_category
-        @category = @post_type.categories.find_by_id(params[:id])
+        @category = @post_type.categories.find_by(id: params[:id])
         render_404 unless @category
       rescue StandardError
         flash[:error] = t('camaleon_cms.admin.post_type.message.error')

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -48,7 +48,7 @@ module CamaleonCms
           render json: { next_page: @next_page,
                          html: render_to_string(partial: 'render_file_item', locals: { files: @files }) }
         else
-          render 'index', layout: false unless params[:partial].present?
+          render 'index', layout: false if params[:partial].blank?
         end
       end
 

--- a/app/controllers/camaleon_cms/admin/post_tags_controller.rb
+++ b/app/controllers/camaleon_cms/admin/post_tags_controller.rb
@@ -74,14 +74,14 @@ module CamaleonCms
       private
 
       def set_post_type
-        @post_type = current_site.post_types.find_by_id(params[:post_type_id]).decorate
+        @post_type = current_site.post_types.find_by(id: params[:post_type_id]).decorate
         authorize! :post_tags, @post_type
         add_breadcrumb @post_type.the_title, @post_type.the_admin_url
         add_breadcrumb t('camaleon_cms.admin.post_type.post_tags'), url_for({ action: :index })
       end
 
       def set_post_tag
-        @post_tag = @post_type.post_tags.find_by_id(params[:id])
+        @post_tag = @post_type.post_tags.find_by(id: params[:id])
       rescue StandardError
         flash[:error] = t('camaleon_cms.admin.post_type.message.error')
         redirect_to cama_admin_path

--- a/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
@@ -16,7 +16,7 @@ module CamaleonCms
               @post_draft.attributes = @post_data
             end
           end
-          @post_draft = @post_type.posts.new(@post_data) unless @post_draft.present?
+          @post_draft = @post_type.posts.new(@post_data) if @post_draft.blank?
           r = { post: @post_draft, post_type: @post_type }
           hooks_run('create_post_draft', r)
           if @post_draft.save(validate: false)
@@ -53,11 +53,11 @@ module CamaleonCms
 
         def set_post_data_params
           post_data = params.require(:post).permit(:title, :slug, :content, :excerpt, :status, :comment_status, :post_parent, :visibility, :visibility_value, :post_order, :published_at).to_h
-          post_data.delete(:created_at) unless params[:post][:created_at].present?
-          post_data.delete(:updated_at) unless params[:post][:updated_at].present?
+          post_data.delete(:created_at) if params[:post][:created_at].blank?
+          post_data.delete(:updated_at) if params[:post][:updated_at].blank?
           post_data[:status] = 'draft_child'
           post_data[:post_parent] = params[:post_id]
-          post_data[:user_id] = cama_current_user.id unless post_data[:user_id].present?
+          post_data[:user_id] = cama_current_user.id if post_data[:user_id].blank?
           post_data[:data_tags] = params[:tags].to_s
           post_data[:data_categories] = params[:categories] || []
           @post_data = post_data

--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -197,7 +197,7 @@ module CamaleonCms
 
       # define post type parent
       def set_post_type
-        @post_type = current_site.post_types.find_by_id(params[:post_type_id])
+        @post_type = current_site.post_types.find_by(id: params[:post_type_id])
         if @post_type.blank?
           flash[:error] = t('camaleon_cms.admin.request_error_message')
           redirect_to cama_admin_path

--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -117,7 +117,7 @@ module CamaleonCms
         if @post.draft_child? && @post.parent.present?
           # This is a draft (as a child of the original post)
           original_parent = @post.parent.parent
-          post_data[:post_parent] = original_parent.present? ? original_parent.id : nil
+          post_data[:post_parent] = original_parent&.id
           @post = @post.parent
           delete_drafts = true
         elsif @post.draft?

--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -147,7 +147,7 @@ module CamaleonCms
         authorize! :destroy, @post
         @post.set_option('status_default', @post.status)
         # @post.children.destroy_all unless @post.draft? TODO: why delete children?
-        @post.update_column('status', 'trash')
+        @post.update_column(:status, 'trash') # rubocop:disable Rails/SkipsModelValidations
         @post.update_extra_data
         hooks_run('trashed_post', { post: @post, post_type: @post_type })
         flash[:notice] = t('camaleon_cms.admin.post.message.trash', post_type: @post_type.decorate.the_title)
@@ -157,7 +157,9 @@ module CamaleonCms
       def restore
         @post = @post_type.posts.find(params[:post_id])
         authorize! :update, @post
-        @post.update_column('status', @post.options[:status_default] || 'pending')
+        # rubocop:disable Rails/SkipsModelValidations
+        @post.update_column(:status, @post.options[:status_default] || 'pending')
+        # rubocop:enable Rails/SkipsModelValidations
         @post.update_extra_data
         hooks_run('restored_post', { post: @post, post_type: @post_type })
         flash[:notice] = t('camaleon_cms.admin.post.message.restore', post_type: @post_type.decorate.the_title)

--- a/app/controllers/camaleon_cms/admin/posts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts_controller.rb
@@ -42,7 +42,7 @@ module CamaleonCms
         posts_all = posts_all.where(user_id: cama_current_user) if cannot?(:edit_other, @post_type)
 
         @posts = posts_all
-        params[:s] = 'published' unless params[:s].present?
+        params[:s] = 'published' if params[:s].blank?
         @lists_tab = params[:s]
         case params[:s]
         when 'published', 'pending', 'trash'
@@ -196,7 +196,7 @@ module CamaleonCms
       # define post type parent
       def set_post_type
         @post_type = current_site.post_types.find_by_id(params[:post_type_id])
-        unless @post_type.present?
+        if @post_type.blank?
           flash[:error] = t('camaleon_cms.admin.request_error_message')
           redirect_to cama_admin_path
           return

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -92,7 +92,7 @@ module CamaleonCms
 
         # TODO: Move this out of the controller
         # send email reset password
-        return unless params[:user].present?
+        return if params[:user].blank?
 
         data_user = user_permit_data
         @user = current_site.users.find_by_email(data_user[:email])

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -9,7 +9,7 @@ module CamaleonCms
 
       # you can pass return_to as a param (mysite.com/admin/login?return_to=my-url) and this will be used after user logged in
       def login
-        return redirect_to(params[:return_to].presence || cama_admin_dashboard_path) if signin?
+        return redirect_to(safe_redirect_url(params[:return_to]) || cama_admin_dashboard_path) if signin?
 
         cookies[:return_to] = params[:return_to] if params[:return_to].present?
         @user ||= current_site.users.new

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -19,7 +19,7 @@ module CamaleonCms
 
       def login_post
         data_user = user_permit_data
-        @user = current_site.users.find_by_username(data_user[:username])
+        @user = current_site.users.find_by(username: data_user[:username])
         captcha_validate = captcha_verify_if_under_attack('login')
         r = { user: @user, params: params, password: data_user[:password], captcha_validate: captcha_validate,
               stop_process: false }
@@ -95,7 +95,7 @@ module CamaleonCms
         return if params[:user].blank?
 
         data_user = user_permit_data
-        @user = current_site.users.find_by_email(data_user[:email])
+        @user = current_site.users.find_by(email: data_user[:email])
         if @user.present?
           send_password_reset_email(@user)
           flash[:notice] = t('camaleon_cms.admin.login.message.send_mail_succes')

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -9,7 +9,7 @@ module CamaleonCms
 
       # you can pass return_to as a param (mysite.com/admin/login?return_to=my-url) and this will be used after user logged in
       def login
-        return redirect_to(params[:return_to].present? ? params[:return_to] : cama_admin_dashboard_path) if signin?
+        return redirect_to(params[:return_to].presence || cama_admin_dashboard_path) if signin?
 
         cookies[:return_to] = params[:return_to] if params[:return_to].present?
         @user ||= current_site.users.new

--- a/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
@@ -103,7 +103,7 @@ module CamaleonCms
         end
 
         def permitted_fields
-          return {} unless params[:fields].present?
+          return {} if params[:fields].blank?
 
           params.require(:fields).permit(params[:fields].keys.index_with do
             %i[id name slug description field_order]
@@ -111,7 +111,7 @@ module CamaleonCms
         end
 
         def permitted_field_options
-          return {} unless params[:field_options].present?
+          return {} if params[:field_options].blank?
 
           params.require(:field_options).permit(params[:field_options].keys.index_with do
             [:field_key, :multiple, :required, :translate, :default_value, :dimension, :width, :height, :class, :placeholder,

--- a/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
@@ -61,7 +61,8 @@ module CamaleonCms
         # reorder custom fields group
         def reorder
           params[:values].to_a.each_with_index do |value, index|
-            current_site.custom_field_groups.find(value).update_column('field_order', index)
+            current_site.custom_field_groups.find(value)
+                        .update_column(:field_order, index) # rubocop:disable Rails/SkipsModelValidations
           end
           json = { size: params[:values].size }
           render json: json

--- a/app/controllers/camaleon_cms/admin/settings/post_types_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/post_types_controller.rb
@@ -64,7 +64,7 @@ module CamaleonCms
         end
 
         def set_post_type
-          @post_type = current_site.post_types.find_by_id(params[:id])
+          @post_type = current_site.post_types.find_by(id: params[:id])
         rescue StandardError
           flash[:error] = t('camaleon_cms.admin.post_type.message.error')
           redirect_to cama_admin_path

--- a/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
@@ -70,7 +70,7 @@ module CamaleonCms
         end
 
         def set_site
-          @site = CamaleonCms::Site.find_by_id(params[:id]).decorate
+          @site = CamaleonCms::Site.find_by(id: params[:id]).decorate
         rescue StandardError
           flash[:error] = t('camaleon_cms.admin.sites.message.error')
           redirect_to cama_admin_path

--- a/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
@@ -62,7 +62,7 @@ module CamaleonCms
         private
 
         def save_metas(site)
-          return unless params[:metas].present?
+          return if params[:metas].blank?
 
           params[:metas].each do |meta, val|
             site.set_meta(meta, val)

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -45,7 +45,7 @@ module CamaleonCms
     # if this is receive a param[:ajax], then will render only results view
     def search
       add_breadcrumb I18n.t('camaleon_cms.admin.button.search')
-      params[:kind] = 'content' unless params[:kind].present?
+      params[:kind] = 'content' if params[:kind].blank?
       params[:q] = (params[:q] || '').downcase
       @items = case params[:kind]
                when 'post_type'
@@ -96,7 +96,7 @@ module CamaleonCms
     end
 
     def admin_logged_actions
-      admin_menus_add_commons if !request.xhr? || !params[:cama_ajax_request].present? # initialize admin sidebar menus
+      admin_menus_add_commons if !request.xhr? || params[:cama_ajax_request].blank? # initialize admin sidebar menus
     end
   end
 end

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -35,11 +35,16 @@ module CamaleonCms
 
     # show page error
     def render_error(status = 404, exception = nil, message = '')
-      Rails.logger.debug "Camaleon CMS - 404 url: #{begin
-        request.original_url
-      rescue StandardError
-        nil
-      end} ==> message: #{exception.message if exception.present?} ==> #{params[:error_msg]} ==> #{caller.inspect}"
+      Rails.logger.debug do
+        original_url = begin
+          request.original_url
+        rescue StandardError
+          nil
+        end
+        "Camaleon CMS - 404 url: " \
+          "#{original_url} ==> message: #{exception&.message} ==> #{params[:error_msg]} ==> #{caller.inspect}"
+      end
+
       @message = "#{message} #{params[:error_msg] || (exception.present? ? "#{exception.message}<br><br>#{caller.inspect}" : '')}"
       @message = '' if Rails.env == 'production'
       respond_to do |format|

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -101,7 +101,7 @@ module CamaleonCms
     # check if current site exist, if not, this will be redirected to main domain
     # Also, check current site status
     def cama_site_check_existence
-      if !current_site.present?
+      if current_site.blank?
         if Cama::Site.main_site.present?
           url = Cama::Site.main_site.decorate.the_url
           # TODO: Remove this condition when Rails 6.x won't be supported
@@ -113,7 +113,7 @@ module CamaleonCms
         else
           redirect_to cama_admin_installers_path
         end
-      elsif (cama_current_user.present? && !cama_current_user.admin?) || !cama_current_user.present?
+      elsif (cama_current_user.present? && !cama_current_user.admin?) || cama_current_user.blank?
         # inactive page control
         if current_site.is_inactive?
           if request.original_url.to_s.match(%r{\A#{current_site.the_url}admin(/|\z)})

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -122,7 +122,7 @@ module CamaleonCms
               flash[:error] = 'Site is Inactive'
             end
           else
-            p = current_site.posts.find_by_id(current_site.get_option('page_inactive')).try(:decorate)
+            p = current_site.posts.find_by(id: current_site.get_option('page_inactive')).try(:decorate)
             if p
               redirect_to(p.the_url) unless params == { 'controller' => 'camaleon_cms/frontend', 'action' => 'post',
                                                         'slug' => p.the_slug }
@@ -135,7 +135,7 @@ module CamaleonCms
         # maintenance page and IP's control
         if current_site.is_maintenance? && !current_site.get_option('maintenance_ips',
                                                                     '').split(',').include?(request.remote_ip)
-          p = current_site.posts.find_by_id(current_site.get_option('page_maintenance')).try(:decorate)
+          p = current_site.posts.find_by(id: current_site.get_option('page_maintenance')).try(:decorate)
           if p
             redirect_to(p.the_url) if params != { 'controller' => 'camaleon_cms/frontend', 'action' => 'post',
                                                   'slug' => p.the_slug }

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -29,7 +29,9 @@ module CamaleonCms
     # render category list
     def category
       begin
-        @category ||= current_site.the_full_categories.find_by(slug: params[:category_slug]).decorate if params[:category_slug].present?
+        if params[:category_slug].present?
+          @category ||= current_site.the_full_categories.find_by(slug: params[:category_slug]).decorate
+        end
         @category ||= current_site.the_full_categories.find(params[:category_id]).decorate
         @post_type = @category.the_post_type
       rescue StandardError

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -40,10 +40,10 @@ module CamaleonCms
       @posts = @category.the_posts.paginate(page: params[:page],
                                             per_page: current_site.front_per_page).eager_load(:metas)
       r_file = lookup_context.template_exists?("category_#{@category.the_slug}") ? "category_#{@category.the_slug}" : nil # specific template category with specific slug within a posttype
-      unless r_file.present?
+      if r_file.blank?
         r_file = lookup_context.template_exists?("post_types/#{@post_type.the_slug}/category") ? "post_types/#{@post_type.the_slug}/category" : nil
       end
-      unless r_file.present?
+      if r_file.blank?
         r_file = lookup_context.template_exists?("categories/#{@category.the_slug}") ? "categories/#{@category.the_slug}" : 'category'
       end
 
@@ -194,8 +194,8 @@ module CamaleonCms
               end
 
       @post = @post.try(:decorate)
-      if !@post.present? || !(force_visit || @post.can_visit?)
-        if params[:format] == 'html' || !params[:format].present?
+      if @post.blank? || !(force_visit || @post.can_visit?)
+        if params[:format] == 'html' || params[:format].blank?
           page_not_found
         else
           head 404

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -29,7 +29,7 @@ module CamaleonCms
     # render category list
     def category
       begin
-        @category ||= current_site.the_full_categories.find_by_slug(params[:category_slug]).decorate if params[:category_slug].present?
+        @category ||= current_site.the_full_categories.find_by(slug: params[:category_slug]).decorate if params[:category_slug].present?
         @category ||= current_site.the_full_categories.find(params[:category_id]).decorate
         @post_type = @category.the_post_type
       rescue StandardError
@@ -60,7 +60,7 @@ module CamaleonCms
     # render contents from post type
     def post_type
       begin
-        @post_type = current_site.post_types.find_by_slug(params[:post_type_slug]).decorate
+        @post_type = current_site.post_types.find_by(slug: params[:post_type_slug]).decorate
       rescue StandardError
         return page_not_found
       end
@@ -81,7 +81,7 @@ module CamaleonCms
     def post_tag
       begin
         @post_tag = if params[:post_tag_slug].present?
-                      current_site.post_tags.find_by_slug(params[:post_tag_slug]).decorate
+                      current_site.post_tags.find_by(slug: params[:post_tag_slug]).decorate
                     else
                       current_site.post_tags.find(params[:post_tag_id]).decorate
                     end
@@ -186,7 +186,7 @@ module CamaleonCms
     def render_post(post_or_slug_or_id, from_url = false, status = nil, force_visit = false)
       @post = case post_or_slug_or_id
               when String # slug
-                current_site.the_posts.find_by_slug(post_or_slug_or_id)
+                current_site.the_posts.find_by(slug: post_or_slug_or_id)
               when Integer # id
                 current_site.the_posts.where(id: post_or_slug_or_id).first
               else # model

--- a/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
@@ -7,7 +7,7 @@ module CamaleonCms
 
       # Only permit field_options that match registered custom field slugs
       def cama_permitted_field_options(object_class)
-        return {} unless params[:field_options].present?
+        return {} if params[:field_options].blank?
 
         allowed_keys = cama_custom_field_allowed_slugs(object_class)
         return {} if allowed_keys.blank?

--- a/app/controllers/concerns/camaleon_cms/frontend_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/frontend_concern.rb
@@ -31,7 +31,7 @@ module CamaleonCms
     # save comment from a post
     def save_comment
       flash[:comment_submit] = {}
-      @post = current_site.posts.find_by_id(params[:post_id]).decorate
+      @post = current_site.posts.find_by(id: params[:post_id]).decorate
       user = cama_current_user
       comment_data = {}
       unless @post.can_commented?
@@ -61,7 +61,7 @@ module CamaleonCms
           comment_data[:approved] = current_site.front_comment_status
           comment_data[:agent] = request.user_agent.force_encoding('ISO-8859-1').encode('UTF-8')
           comment_data[:content] = params[:post_comment][:content]
-          @comment = params[:post_comment][:parent_id].present? ? @post.comments.find_by_id(params[:post_comment][:parent_id]).children.new(comment_data) : @post.comments.main.new(comment_data)
+          @comment = params[:post_comment][:parent_id].present? ? @post.comments.find_by(id: params[:post_comment][:parent_id]).children.new(comment_data) : @post.comments.main.new(comment_data)
           if @comment.save
             flash[:comment_submit][:notice] = t('camaleon_cms.admin.comments.message.created')
           else

--- a/app/decorators/camaleon_cms/application_decorator.rb
+++ b/app/decorators/camaleon_cms/application_decorator.rb
@@ -15,7 +15,7 @@ module CamaleonCms
     # return the keywords for this model
     def the_keywords
       k = object.get_option('keywords', '')
-      k = h.current_site.the_keywords if object.class.name != 'CamaleonCms::Site' && !k.present?
+      k = h.current_site.the_keywords if object.class.name != 'CamaleonCms::Site' && k.blank?
       k.to_s.translate(get_locale)
     end
 

--- a/app/decorators/camaleon_cms/category_decorator.rb
+++ b/app/decorators/camaleon_cms/category_decorator.rb
@@ -30,7 +30,7 @@ module CamaleonCms
     def the_category(slug_or_id)
       return object.categories.where(id: slug_or_id).first if slug_or_id.is_a?(Integer)
 
-      object.categories.find_by_slug(slug_or_id) if slug_or_id.is_a?(String)
+      object.categories.find_by(slug: slug_or_id) if slug_or_id.is_a?(String)
     end
 
     # ---------------------

--- a/app/decorators/camaleon_cms/post_decorator.rb
+++ b/app/decorators/camaleon_cms/post_decorator.rb
@@ -14,13 +14,10 @@ module CamaleonCms
       excerpt = object.get_meta('summary').to_s.translate(get_locale)
       # r = {content: (excerpt.present? ? excerpt : object.content_filtered.to_s.translate(get_locale).strip_tags.gsub(/&#13;|\n/, " ").truncate(qty_chars)), post: object}
       r = {
-        content: (if excerpt.present?
-                    excerpt
-                  else
-                    h.cama_strip_shortcodes(object.content_filtered.to_s.translate(get_locale).strip_tags.gsub(
-                      /&#13;|\n/, ' '
-                    ).truncate(qty_chars))
-                  end), post: object
+        content:
+          excerpt.presence || h.cama_strip_shortcodes(object.content_filtered.to_s.translate(get_locale)
+                                                            .strip_tags.gsub(/&#13;|\n/, ' ').truncate(qty_chars)),
+        post: object
       }
       h.hooks_run('post_the_excerpt', r)
       r[:content]
@@ -33,17 +30,13 @@ module CamaleonCms
       h.do_shortcode(r[:content], self)
     end
 
-    # return thumbnail image for this post
+    # Return the thumbnail image for this post
     # default: default image if thumbails not exist
     # if default is empty, post_type default thumb will be returned
     def the_thumb_url(default = nil)
       th = object.get_meta('thumb')
-      if th.present?
-        th
-      else
-        default || object.post_type.get_option('default_thumb',
-                                               nil) || h.asset_url('camaleon_cms/image-not-found.png')
-      end
+      th.presence || default || object.post_type.get_option('default_thumb', nil) ||
+        h.asset_url('camaleon_cms/image-not-found.png')
     end
     alias the_image_url the_thumb_url
 

--- a/app/decorators/camaleon_cms/post_decorator.rb
+++ b/app/decorators/camaleon_cms/post_decorator.rb
@@ -93,7 +93,7 @@ module CamaleonCms
           args[:label_cat] = I18n.t('routes.category', default: 'category')
           args[:category_id] = cat.id
           args[:title] = cat.the_title(args[:locale]).parameterize
-          args[:title] = cat.the_slug unless args[:title].present?
+          args[:title] = cat.the_slug if args[:title].blank?
         else
           p_url_format = 'post'
         end
@@ -110,7 +110,7 @@ module CamaleonCms
           args[:post_type_title] = ptype.the_title(args[:locale]).parameterize.presence || ptype.the_slug
           args[:category_id] = cat.id
           args[:title] = cat.the_title(args[:locale]).parameterize
-          args[:title] = cat.the_slug unless args[:title].present?
+          args[:title] = cat.the_slug if args[:title].blank?
         else
           p_url_format = 'post'
         end
@@ -148,7 +148,7 @@ module CamaleonCms
     # return html link
     # attrs: Hash of link tag attributes, sample: {id: "myid", class: "sss" }
     def the_edit_link(title = nil, attrs = {})
-      return '' unless h.cama_current_user.present?
+      return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
       h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_edit_url, attrs)
@@ -265,7 +265,7 @@ module CamaleonCms
     # sample: title paren 1 - title parent 2 -.. -...
     # if add_parent_title: true will add parent title like: —— item 1.1.1 | item 1.1
     def the_hierarchy_title
-      return the_title unless object.post_parent.present?
+      return the_title if object.post_parent.blank?
 
       res = '&#8212;' * object.parents.count
       res << " #{the_title}"

--- a/app/decorators/camaleon_cms/post_type_decorator.rb
+++ b/app/decorators/camaleon_cms/post_type_decorator.rb
@@ -71,7 +71,7 @@ module CamaleonCms
     def the_category(slug_or_id)
       return the_categories.where(id: slug_or_id).first if slug_or_id.is_a?(Integer)
 
-      the_categories.find_by_slug(slug_or_id) if slug_or_id.is_a?(String)
+      the_categories.find_by(slug: slug_or_id) if slug_or_id.is_a?(String)
     end
 
     # return all post_tags for the post_type (active_record) filtered by permissions + hidden posts + roles + etc...

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -67,7 +67,7 @@ module CamaleonCms
           nil
         end
       end
-      post = the_posts.find_by_slug(slug_or_id) if slug_or_id.is_a?(String) # id
+      post = the_posts.find_by(slug: slug_or_id) if slug_or_id.is_a?(String) # id
       post.present? ? post.decorate : nil
     end
 
@@ -96,7 +96,7 @@ module CamaleonCms
       return unless slug_or_id.is_a?(String)
 
       begin
-        the_full_categories.find_by_slug(slug_or_id).decorate
+        the_full_categories.find_by(slug: slug_or_id).decorate
       rescue StandardError
         nil
       end
@@ -126,7 +126,7 @@ module CamaleonCms
       return unless slug_or_id.is_a?(String)
 
       begin
-        object.post_tags.find_by_slug(slug_or_id).decorate
+        object.post_tags.find_by(slug: slug_or_id).decorate
       rescue StandardError
         nil
       end
@@ -144,7 +144,7 @@ module CamaleonCms
       return unless id_or_username.is_a?(String)
 
       begin
-        object.users.find_by_username(id_or_username).decorate
+        object.users.find_by(username: id_or_username).decorate
       rescue StandardError
         nil
       end
@@ -165,14 +165,14 @@ module CamaleonCms
     def the_post_type(slug_or_id)
       if slug_or_id.is_a?(String)
         begin
-          return object.post_types.find_by_slug(slug_or_id).decorate
+          return object.post_types.find_by(slug: slug_or_id).decorate
         rescue StandardError
           nil
         end
       end
       if slug_or_id.is_a?(Array)
         begin
-          return object.post_types.find_by_slug(slug_or_id).decorate
+          return object.post_types.find_by(slug: slug_or_id).decorate
         rescue StandardError
           nil
         end

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -245,7 +245,7 @@ module CamaleonCms
       postfix = 'url'
       postfix = 'path' if args.delete(:as_path)
       skip_relative_url_root = args.delete(:skip_relative_url_root)
-      h.cama_current_site_host_port(args) unless args.keys.include?(:host)
+      h.cama_current_site_host_port(args) unless args.key?(:host)
       res = h.cama_url_to_fixed("cama_root_#{postfix}", args)
       if skip_relative_url_root && PluginRoutes.static_system_info['relative_url_root'].present?
         res = res.sub("/#{PluginRoutes.static_system_info['relative_url_root']}",

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -68,7 +68,7 @@ module CamaleonCms
         end
       end
       post = the_posts.find_by(slug: slug_or_id) if slug_or_id.is_a?(String) # id
-      post.present? ? post.decorate : nil
+      post&.decorate
     end
 
     # return a collection of categories

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -81,7 +81,7 @@ module CamaleonCms
     def the_categories(slug_or_id = nil)
       return the_post_type(slug_or_id).the_categories if slug_or_id.present?
 
-      object.categories unless slug_or_id.present?
+      object.categories if slug_or_id.blank?
     end
 
     # return the category object with id or slug = slug_or_id from this site

--- a/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
+++ b/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
@@ -67,7 +67,7 @@ module CamaleonCms
       return unless slug_or_id.is_a?(String)
 
       begin
-        object.posts.find_by_slug(slug_or_id).decorate
+        object.posts.find_by(slug: slug_or_id).decorate
       rescue StandardError
         nil
       end

--- a/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
+++ b/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
@@ -55,7 +55,7 @@ module CamaleonCms
 
     # search a post with id (integer) or slug (string)
     def the_post(slug_or_id)
-      return nil unless slug_or_id.present?
+      return nil if slug_or_id.blank?
 
       if slug_or_id.is_a?(Integer)
         begin
@@ -94,7 +94,7 @@ module CamaleonCms
     # return html link
     # attrs: Hash of link tag attributes, sample: {id: "myid", class: "sss" }
     def the_edit_link(title = nil, attrs = {})
-      return '' unless h.cama_current_user.present?
+      return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
       h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_edit_url, attrs)

--- a/app/decorators/camaleon_cms/theme_decorator.rb
+++ b/app/decorators/camaleon_cms/theme_decorator.rb
@@ -12,7 +12,7 @@ module CamaleonCms
     end
 
     def the_settings_link
-      return '' unless h.cama_current_user.present?
+      return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
       h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_settings_url, attrs)

--- a/app/decorators/camaleon_cms/user_decorator.rb
+++ b/app/decorators/camaleon_cms/user_decorator.rb
@@ -34,7 +34,7 @@ module CamaleonCms
       args[:label] = I18n.t('routes.profile', default: 'profile')
       args[:user_id] = the_id
       args[:user_name] = the_name.parameterize
-      args[:user_name] = the_username unless args[:user_name].present?
+      args[:user_name] = the_username if args[:user_name].blank?
       args[:locale] = get_locale unless args.include?(:locale)
       args[:format] = args[:format] || 'html'
       as_path = args.delete(:as_path)

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -121,7 +121,7 @@ module CamaleonCms
           items << { icon: 'windows', title: t('camaleon_cms.admin.settings.theme_setting', default: 'Theme Settings'),
                      url: cama_admin_settings_theme_path }
         end
-        return unless items.present?
+        return if items.blank?
 
         admin_menu_add_menu('settings',
                             { icon: 'cogs', title: t('camaleon_cms.admin.sidebar.settings'), url: '', items: items,
@@ -143,7 +143,7 @@ module CamaleonCms
       # append sub menu to menu with key = key
       # menu: is hash like this: {icon: "dashboard", title: "My title", url: my_path, items: [sub menus]}
       def admin_menu_append_menu_item(key, menu)
-        return unless @_admin_menus[key].present?
+        return if @_admin_menus[key].blank?
 
         @_admin_menus[key][:items] = [] unless @_admin_menus[key].key?(:items)
         @_admin_menus[key][:items] << menu
@@ -152,7 +152,7 @@ module CamaleonCms
       # prepend sub menu to menu with key = key
       # menu: is hash like this: {icon: "dashboard", title: "My title", url: my_path, items: [sub menus]}
       def admin_menu_prepend_menu_item(key, menu)
-        return unless @_admin_menus[key].present?
+        return if @_admin_menus[key].blank?
 
         @_admin_menus[key][:items] = [] unless @_admin_menus[key].key?(:items)
         @_admin_menus[key][:items] = [menu] + @_admin_menus[key][:items]

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -9,7 +9,7 @@ module CamaleonCms
                               url: cama_admin_dashboard_path })
         items = []
 
-        current_site.post_types.eager_load(:metas).visible_menu.all.each do |pt|
+        current_site.post_types.eager_load(:metas).visible_menu.find_each do |pt|
           pt = pt.decorate
           items_i = []
           if can? :posts,

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -37,7 +37,7 @@ module CamaleonCms
           res += cama_hierarchy_post_list(posts_list, element.id)
         end
 
-        if !parent_id.present? && !skip_non_parent_posts
+        if parent_id.blank? && !skip_non_parent_posts
           @_cama_hierarchy_post_list_no_parent.each do |element|
             element.show_title_with_parent = true
             res << element

--- a/app/helpers/camaleon_cms/camaleon_helper.rb
+++ b/app/helpers/camaleon_cms/camaleon_helper.rb
@@ -4,7 +4,7 @@ module CamaleonCms
     # verify if current user is logged in, if not, then return nil
     # return html link
     def cama_edit_link(url, title = nil, attrs = {})
-      return '' unless cama_current_user.present?
+      return '' if cama_current_user.blank?
       return '' unless cama_current_user.admin?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
@@ -83,7 +83,7 @@ module CamaleonCms
 
     # return normal translation with default value with translation of english
     def cama_t(key, args = {})
-      args[:default] = I18n.t(key, **args.dup.merge(locale: :en)) unless args[:default].present?
+      args[:default] = I18n.t(key, **args.dup.merge(locale: :en)) if args[:default].blank?
       I18n.t(key, **args)
     end
 

--- a/app/helpers/camaleon_cms/camaleon_helper.rb
+++ b/app/helpers/camaleon_cms/camaleon_helper.rb
@@ -74,13 +74,6 @@ module CamaleonCms
       cache
     end
 
-    # =Deprecated
-    def cama_draw_timer
-      @_cama_timer ||= Time.current
-      puts "***************************************** timer: #{((Time.current - @_cama_timer) * 24 * 60 * 60).to_i}  (#{caller.first})"
-      @_cama_timer = Time.current
-    end
-
     # return normal translation with default value with translation of english
     def cama_t(key, args = {})
       args[:default] = I18n.t(key, **args.dup.merge(locale: :en)) if args[:default].blank?

--- a/app/helpers/camaleon_cms/captcha_helper.rb
+++ b/app/helpers/camaleon_cms/captcha_helper.rb
@@ -6,7 +6,7 @@ module CamaleonCms
       img = MiniMagick::Image.open(File.join($camaleon_engine_dir.present? ? $camaleon_engine_dir : Rails.root.to_s,
                                              'lib', 'captcha', "captcha_#{rand(12)}.jpg").to_s)
       text = cama_rand_str(len)
-      session[:cama_captcha] = [] unless session[:cama_captcha].present?
+      session[:cama_captcha] = [] if session[:cama_captcha].blank?
       session[:cama_captcha] << text
       img.combine_options do |c|
         c.gravity 'Center'
@@ -23,7 +23,7 @@ module CamaleonCms
     # img_args: attributes for image_tag
     # input_args: attributes for input field
     def cama_captcha_tag(len = 5, img_args = { alt: '' }, input_args = {}, bootstrap_group_mode = false)
-      unless input_args[:placeholder].present?
+      if input_args[:placeholder].blank?
         input_args[:placeholder] =
           I18n.t('camaleon_cms.captcha_placeholder',
                  default: 'Please enter the text of the image')

--- a/app/helpers/camaleon_cms/captcha_helper.rb
+++ b/app/helpers/camaleon_cms/captcha_helper.rb
@@ -1,21 +1,25 @@
 module CamaleonCms
   module CaptchaHelper
     # build a captcha image
-    # len: Number or characters to include in captcha (default 5)
+    # @param [Integer, nil] len Number of characters to include in captcha (default: 5)
+    # @return [MiniMagick::Image]
     def cama_captcha_build(len = 5)
-      img = MiniMagick::Image.open(File.join($camaleon_engine_dir.presence || Rails.root.to_s,
-                                             'lib', 'captcha', "captcha_#{rand(12)}.jpg").to_s)
+      img = MiniMagick::Image.open(resolve_captcha_file("captcha_#{rand(12)}.jpg"))
       text = cama_rand_str(len)
       session[:cama_captcha] = [] if session[:cama_captcha].blank?
       session[:cama_captcha] << text
       img.combine_options do |c|
-        c.gravity 'Center'
+        c.gravity('Center')
         c.fill('#FFFFFF')
-        c.draw "text 0,5 #{text}"
-        c.font File.join($camaleon_engine_dir.presence || Rails.root.to_s, 'lib', 'captcha', 'bumpyroad.ttf')
-        c.pointsize '30'
+        c.draw("text 0,5 #{text}")
+        c.font(resolve_captcha_file('bumpyroad.ttf'))
+        c.pointsize('30')
       end
-      img
+    end
+
+    def resolve_captcha_file(filename)
+      base_dir = $camaleon_engine_dir.presence || Rails.root.to_s
+      File.join(base_dir, 'lib', 'captcha', filename)
     end
 
     # build a captcha tag (image with captcha)

--- a/app/helpers/camaleon_cms/captcha_helper.rb
+++ b/app/helpers/camaleon_cms/captcha_helper.rb
@@ -3,7 +3,7 @@ module CamaleonCms
     # build a captcha image
     # len: Number or characters to include in captcha (default 5)
     def cama_captcha_build(len = 5)
-      img = MiniMagick::Image.open(File.join($camaleon_engine_dir.present? ? $camaleon_engine_dir : Rails.root.to_s,
+      img = MiniMagick::Image.open(File.join($camaleon_engine_dir.presence || Rails.root.to_s,
                                              'lib', 'captcha', "captcha_#{rand(12)}.jpg").to_s)
       text = cama_rand_str(len)
       session[:cama_captcha] = [] if session[:cama_captcha].blank?
@@ -12,8 +12,7 @@ module CamaleonCms
         c.gravity 'Center'
         c.fill('#FFFFFF')
         c.draw "text 0,5 #{text}"
-        c.font File.join($camaleon_engine_dir.present? ? $camaleon_engine_dir : Rails.root.to_s, 'lib', 'captcha',
-                         'bumpyroad.ttf')
+        c.font File.join($camaleon_engine_dir.presence || Rails.root.to_s, 'lib', 'captcha', 'bumpyroad.ttf')
         c.pointsize '30'
       end
       img

--- a/app/helpers/camaleon_cms/frontend/content_select_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/content_select_helper.rb
@@ -60,7 +60,7 @@ module CamaleonCms
       #   the_title
       # end
       def the_title
-        @object.the_title if @object.present?
+        @object&.the_title
       end
 
       # select content of post
@@ -76,7 +76,7 @@ module CamaleonCms
       #   the_url
       # end
       def the_url
-        @object.the_url if @object.present?
+        @object&.the_url
       end
 
       # select thumbnail of post
@@ -84,7 +84,7 @@ module CamaleonCms
       #   the_thumbnail
       # end
       def the_thumbnail
-        @object.the_thumb_url if @object.present?
+        @object&.the_thumb_url
       end
 
       # select slug of post, post type ... (@object)
@@ -92,7 +92,7 @@ module CamaleonCms
       #   the_slug
       # end
       def the_slug
-        @object.the_slug if @object.present?
+        @object&.the_slug
       end
 
       # select excerpt of post
@@ -100,7 +100,7 @@ module CamaleonCms
       #   the_excerpt
       # end
       def the_excerpt(chars = 200)
-        @object.the_excerpt(chars) if @object.present?
+        @object&.the_excerpt(chars)
       end
 
       # select custome field from object
@@ -108,7 +108,7 @@ module CamaleonCms
       #   the_field('extra-content')
       # end
       def the_field(slug)
-        @object.the_field(slug) if @object.present?
+        @object&.the_field(slug)
       end
 
       # loop through each post of post type

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -49,7 +49,7 @@ module CamaleonCms
         }
 
         args = args_def.merge!(args)
-        nav_menu = current_site.nav_menus.find_by_slug(args[:menu_slug])
+        nav_menu = current_site.nav_menus.find_by(slug: args[:menu_slug])
         nav_menu ||= current_site.nav_menus.first
         html = "<#{args[:container]} class='#{args[:container_class]}' "\
           "id='#{args[:container_id]}'>#{args[:container_prepend]}{__}#{args[:container_append]}</#{args[:container]}>"

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -65,7 +65,7 @@ module CamaleonCms
         html = ''
         parent_current = false
         index = 0
-        nav_menu.eager_load(:metas).each do |nav_menu_item|
+        nav_menu.eager_load(:metas).find_each do |nav_menu_item|
           _args = args.dup
           data_nav_item = cama_parse_menu_item(nav_menu_item)
           next if data_nav_item == false

--- a/app/helpers/camaleon_cms/frontend/seo_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/seo_helper.rb
@@ -59,11 +59,11 @@ module CamaleonCms
 
       # create seo attributes with options + default attributes
       def cama_build_seo(options = {})
-        options[:image] = current_site.get_option('screenshot', current_site.the_logo) unless options[:image].present?
-        options[:title] = current_site.the_title unless options[:title].present?
-        options[:description] = current_site.the_option('seo_description') unless options[:description].present?
+        options[:image] = current_site.get_option('screenshot', current_site.the_logo) if options[:image].blank?
+        options[:title] = current_site.the_title if options[:title].blank?
+        options[:description] = current_site.the_option('seo_description') if options[:description].blank?
         options[:url] = request.original_url
-        options[:keywords] = current_site.the_option('keywords') unless options[:keywords].present?
+        options[:keywords] = current_site.the_option('keywords') if options[:keywords].blank?
 
         s = {
           keywords: options[:keywords],

--- a/app/helpers/camaleon_cms/hooks_helper.rb
+++ b/app/helpers/camaleon_cms/hooks_helper.rb
@@ -34,7 +34,7 @@ module CamaleonCms
     private
 
     def _do_hook(plugin, hook_key, params = nil)
-      return if !plugin.present? || !plugin['hooks'].present? || !plugin['hooks'][hook_key].present?
+      return if plugin.blank? || plugin['hooks'].blank? || plugin['hooks'][hook_key].blank?
 
       plugin['hooks'][hook_key].each do |hook|
         next if @_hooks_skip.present? && @_hooks_skip.include?(hook)

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -90,19 +90,6 @@ module CamaleonCms
       "#{args[:css_html]}\n#{args[:js_html]}\n#{@_assets_content.join('').html_safe}"
     end
 
-    # return category tree for category dropdown
-    # each level is prefixed with -
-    # level: internal recursive control
-    def cama_get_options_html_from_items(terms, level = 0)
-      options = []
-      terms.all.each do |term|
-        options << [('—' * level) + term.name, term.id] unless @term.id == term.id
-        children = term.children
-        options += cama_get_options_html_from_items(children, level + 1) unless children.empty?
-      end
-      options
-    end
-
     # create a html tooltip to include anywhere
     # text: text of the tooltip
     # location: location of the tooltip (left | right | top |bottom)

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -12,7 +12,7 @@ module CamaleonCms
     def cama_assets_library_register(key, assets = {})
       key = key.to_sym
       cama_assets_libraries
-      @_cama_assets_libraries[key] = { css: [], js: [] } unless @_cama_assets_libraries[key].present?
+      @_cama_assets_libraries[key] = { css: [], js: [] } if @_cama_assets_libraries[key].blank?
       @_cama_assets_libraries[key][:css] += assets[:css] if assets[:css].present?
       @_cama_assets_libraries[key][:js] += assets[:js] if assets[:js].present?
     end
@@ -70,7 +70,7 @@ module CamaleonCms
     # return all js libraries added [aa.js, bb,js, ..]
     # def get_assets_js
     def cama_draw_custom_assets
-      cama_html_helpers_init unless @_assets_libraries.present?
+      cama_html_helpers_init if @_assets_libraries.blank?
       libs = []
       @_assets_libraries.each_value do |assets|
         libs += assets[:css] if assets[:css].present?

--- a/app/helpers/camaleon_cms/plugins_helper.rb
+++ b/app/helpers/camaleon_cms/plugins_helper.rb
@@ -7,7 +7,7 @@ module CamaleonCms
     def plugins_initialize(klass = nil)
       mod = Module.new
       PluginRoutes.enabled_apps(current_site).each do |plugin|
-        next if !plugin.present? || !plugin['helpers'].present?
+        next if plugin.blank? || plugin['helpers'].blank?
 
         plugin['helpers'].each do |h|
           mod.send :include, h.constantize
@@ -140,7 +140,7 @@ module CamaleonCms
 
     # auto load all helpers of this plugin
     def plugin_load_helpers(plugin)
-      return if !plugin.present? || !plugin['helpers'].present?
+      return if plugin.blank? || plugin['helpers'].blank?
 
       plugin['helpers'].each do |h|
         next if self.class.include?(h.constantize)

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -100,11 +100,11 @@ module CamaleonCms
       c_data = { value: nil, expires: 24.hours.ago }
       c_data[:domain] = :all if PluginRoutes.system_info['users_share_sites'].present? && CamaleonCms::Site.count > 1
       cookies[:auth_token] = c_data
-      redirect_to params[:return_to].present? ? params[:return_to] : cama_admin_login_path,
+      redirect_to params[:return_to].presence || cama_admin_login_path,
                   notice: t('camaleon_cms.admin.logout.message.closed')
     end
 
-    # check if current user is already signed
+    # Check if the current user is already signed
     def cama_sign_in?
       !cama_current_user.nil?
     end

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -100,7 +100,7 @@ module CamaleonCms
       c_data = { value: nil, expires: 24.hours.ago }
       c_data[:domain] = :all if PluginRoutes.system_info['users_share_sites'].present? && CamaleonCms::Site.count > 1
       cookies[:auth_token] = c_data
-      redirect_to params[:return_to].presence || cama_admin_login_path,
+      redirect_to safe_redirect_url(params[:return_to]) || cama_admin_login_path,
                   notice: t('camaleon_cms.admin.logout.message.closed')
     end
 

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -35,7 +35,7 @@ module CamaleonCms
     # login a user using username and password
     # return boolean: true => authenticated, false => authentication failed
     def login_user_with_password(username, password)
-      @user = current_site.users.find_by_username(username)
+      @user = current_site.users.find_by(username: username)
       r = { user: @user, params: params, password: password, captcha_validate: true }
       hooks_run('user_before_login', r)
       @user&.authenticate(password)
@@ -127,7 +127,7 @@ module CamaleonCms
 
       return nil unless cookie_auth_token_complete?
 
-      @cama_current_user = current_site.users_include_admins.find_by_auth_token(user_auth_token_from_cookie).try(:decorate)
+      @cama_current_user = current_site.users_include_admins.find_by(auth_token: user_auth_token_from_cookie).try(:decorate)
     end
 
     def cookie_auth_token_complete?
@@ -190,7 +190,7 @@ module CamaleonCms
       end
       return unless doorkeeper_token
 
-      current_site.users_include_admins.find_by_id(doorkeeper_token.resource_owner_id).try(:decorate)
+      current_site.users_include_admins.find_by(id: doorkeeper_token.resource_owner_id).try(:decorate)
     end
   end
 end

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -159,7 +159,7 @@ module CamaleonCms
 
     # return the session id
     def cama_get_session_id
-      session[:autor] = 'Owen Peredo Diaz' unless request.session_options[:id].present?
+      session[:autor] = 'Owen Peredo Diaz' if request.session_options[:id].blank?
       id = request.session_options[:id]
       id = id.public_id if id.instance_of?(::Rack::Session::SessionId)
       id

--- a/app/helpers/camaleon_cms/short_code_helper.rb
+++ b/app/helpers/camaleon_cms/short_code_helper.rb
@@ -12,7 +12,7 @@ module CamaleonCms
 
       shortcode_add('load_libraries',
                     lambda { |attrs, args|
-                      return args[:shortcode] unless attrs.present?
+                      return args[:shortcode] if attrs.blank?
 
                       cama_load_libraries(*attrs['data'].to_s.split(','))
                       ''
@@ -21,7 +21,7 @@ module CamaleonCms
 
       shortcode_add('asset',
                     lambda { |attrs, args|
-                      return args[:shortcode] unless attrs.present?
+                      return args[:shortcode] if attrs.blank?
 
                       url = ActionController::Base.helpers.asset_url(attrs['file'])
                       if attrs['image'].present?
@@ -172,7 +172,7 @@ module CamaleonCms
     # parse the attributes of a shortcode
     def _shortcode_parse_attr(text)
       res = {}
-      return res unless text.present?
+      return res if text.blank?
 
       text.scan(/(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/).each do |item|
         item.each_with_index do |c, index|
@@ -195,7 +195,7 @@ module CamaleonCms
               else
                 args[:owner]
               end
-      return res unless model.present?
+      return res if model.blank?
 
       if attrs['field'].present? # model custom fields
         field = model.get_field_object(attrs['field'])

--- a/app/helpers/camaleon_cms/short_code_helper.rb
+++ b/app/helpers/camaleon_cms/short_code_helper.rb
@@ -161,7 +161,7 @@ module CamaleonCms
     # determine the content to replace instead the shortcode
     # return string
     def _eval_shortcode(code, attrs, args = {}, template = nil)
-      template ||= (@_shortcodes_template[code].present? ? @_shortcodes_template[code] : "camaleon_cms/shortcode_templates/#{code}")
+      template ||= @_shortcodes_template[code].presence || "camaleon_cms/shortcode_templates/#{code}"
       if @_shortcodes_template[code].instance_of?(::Proc)
         @_shortcodes_template[code].call(_shortcode_parse_attr(attrs), args)
       else

--- a/app/helpers/camaleon_cms/short_code_helper.rb
+++ b/app/helpers/camaleon_cms/short_code_helper.rb
@@ -295,7 +295,7 @@ module CamaleonCms
 
       when 'navmenu'
         model = current_site.nav_menu_items.find(attrs['id']) if attrs['id'].present?
-        model = current_site.nav_menu_items.find_by_slug(attrs['key']) if attrs['key'].present?
+        model = current_site.nav_menu_items.find_by(slug: attrs['key']) if attrs['key'].present?
 
       when 'user'
         model = current_site.the_user(attrs['id'].to_i) if attrs['id'].present?

--- a/app/helpers/camaleon_cms/site_helper.rb
+++ b/app/helpers/camaleon_cms/site_helper.rb
@@ -105,7 +105,7 @@ module CamaleonCms
       # new theme
       current_site.set_option('_theme', key)
       theme = PluginRoutes.theme_info(key)
-      current_site.themes.update_all(status: 'inactive')
+      current_site.themes.update_all(status: 'inactive') # rubocop:disable Rails/SkipsModelValidations
       theme_model = current_site.themes.where(slug: key).first_or_create! { |t| t.name = theme[:name] }
       theme_model.update(status: nil)
       hook_run(theme, 'on_active', theme_model)

--- a/app/helpers/camaleon_cms/site_helper.rb
+++ b/app/helpers/camaleon_cms/site_helper.rb
@@ -43,7 +43,7 @@ module CamaleonCms
       rescue StandardError
         nil
       end
-      unless r[:site].present?
+      if r[:site].blank?
         Rails.logger.error 'Camaleon CMS - Please define your current site: $current_site = CamaleonCms::Site.first.decorate or map your domains: https://camaleon.website/documentation/category/139779-examples/how.html'.cama_log_style(:red)
       end
       @current_site = r[:site]

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -407,7 +407,9 @@ module CamaleonCms
 
       return { error: 'Redirects are not allowed for remote uploads.' } if response.is_a?(Net::HTTPRedirection)
 
-      return { error: "Unable to download remote file (HTTP #{response.code})." } unless response.is_a?(Net::HTTPSuccess)
+      unless response.is_a?(Net::HTTPSuccess)
+        return { error: "Unable to download remote file (HTTP #{response.code})." }
+      end
 
       # Enforce the site's maximum upload size to prevent memory exhaustion from oversized responses.
       max_bytes = current_site.get_option('filesystem_max_size', 100).to_f.megabytes

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -102,7 +102,7 @@ module CamaleonCms
 
       # generate image versions
       if res['file_type'] == 'image'
-        settings[:versions].to_s.gsub(' ', '').split(',').each do |v|
+        settings[:versions].to_s.delete(' ').split(',').each do |v|
           version_path = cama_resize_upload(settings[:uploaded_io].path, v, { replace: false })
           cama_uploader.add_file(version_path, cama_uploader.version_path(res['key'], v), is_thumb: true,
                                                                                           same_name: true)
@@ -379,7 +379,7 @@ module CamaleonCms
     end
 
     def slugify(val)
-      val.to_s.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+      val.to_s.downcase.strip.tr(' ', '-').gsub(/[^\w-]/, '')
     end
 
     def slugify_folder(val)

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -191,8 +191,8 @@ module CamaleonCms
       data = { img: img, w: w, h: h, w_offset: w_offset, h_offset: h_offset, resize: resize, replace: replace }
       hooks_run('before_crop_image', data)
       data[:img].combine_options do |i|
-        i.resize("#{w if w.present?}x#{h if h.present?}#{force}") if data[:resize]
-        i.crop "#{w if w.present?}x#{h if h.present?}+#{w_offset}+#{h_offset}#{force}" unless data[:resize]
+        i.resize("#{w.presence}x#{h.presence}#{force}") if data[:resize]
+        i.crop "#{w.presence}x#{h.presence}+#{w_offset}+#{h_offset}#{force}" unless data[:resize]
       end
 
       ext = File.extname(file_path)

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -466,12 +466,6 @@ module CamaleonCms
       [horizontal_offset, vertical_offset]
     end
 
-    # convert file path into thumb path format
-    # return the image name into thumb format: owewen.png into thumb/owen-png.png
-    def cama_parse_for_thumb_name(file_path)
-      "#{@fog_connection_hook_res[:thumb_folder_name]}/#{File.basename(file_path).parameterize}#{File.extname(file_path)}"
-    end
-
     def clamp_to_image_dimension(value, img_size)
       return value unless value.present? && value.to_s.include?('?')
 

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -47,7 +47,7 @@ module CamaleonCms
     # sample: upload_file(params[:my_file], {formats: "jpg,png,gif,mp3,mp4", temporal_time: 10.minutes, maximum: 10.megabytes})
     def upload_file(uploaded_io, settings = {})
       cached_name = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.original_filename : nil
-      return { error: 'File is empty', file: nil, size: nil } unless uploaded_io.present?
+      return { error: 'File is empty', file: nil, size: nil } if uploaded_io.blank?
 
       if uploaded_io.is_a?(String) && uploaded_io.match(%r{^https?://}).present? # download url file
         tmp = cama_tmp_upload(uploaded_io)
@@ -276,7 +276,7 @@ module CamaleonCms
       downloaded_tmp_file = nil
       if uploaded_io.is_a?(String) && uploaded_io.start_with?('data:') # create tmp file using base64 format
         _tmp_name = args[:name]
-        return { error: cama_t('camaleon_cms.admin.media.name_required').to_s } unless params[:name].present?
+        return { error: cama_t('camaleon_cms.admin.media.name_required').to_s } if params[:name].blank?
 
         err = validate_file_format_or_error(_tmp_name, args[:formats])
         return err if err

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -271,7 +271,7 @@ module CamaleonCms
     # return: {file_path, error}
     def cama_tmp_upload(uploaded_io, args = {})
       tmp_path = args[:path] || File.join(Rails.public_path, 'tmp', current_site.id.to_s).to_s
-      FileUtils.mkdir_p(tmp_path) unless Dir.exist?(tmp_path)
+      FileUtils.mkdir_p(tmp_path)
       saved = false
       downloaded_tmp_file = nil
       if uploaded_io.is_a?(String) && uploaded_io.start_with?('data:') # create tmp file using base64 format

--- a/app/mailers/camaleon_cms/html_mailer.rb
+++ b/app/mailers/camaleon_cms/html_mailer.rb
@@ -23,7 +23,7 @@ module CamaleonCms
         layout_name: 'camaleon_cms/mailer',
         format: 'html'
       }.merge(data)
-      data[:cc_to] = [data[:cc_to]] if data[:cc_to].is_a?(String) || !data[:cc_to].present?
+      data[:cc_to] = [data[:cc_to]] if data[:cc_to].is_a?(String) || data[:cc_to].blank?
 
       mail_data = { to: email, subject: subject }
       if @current_site.get_option('mailer_enabled') == 1
@@ -92,7 +92,7 @@ module CamaleonCms
         mail(mail_data) { |format| format.html { render inline: @html, layout: layout } } if data[:format] == 'html'
         mail(mail_data) { |format| format.text { render inline: @html, layout: layout } } if data[:format] == 'txt'
       end
-      mail(mail_data) unless data[:format].present?
+      mail(mail_data) if data[:format].blank?
     end
 
     private

--- a/app/mailers/camaleon_cms/html_mailer.rb
+++ b/app/mailers/camaleon_cms/html_mailer.rb
@@ -72,7 +72,7 @@ module CamaleonCms
         end
       end
 
-      layout = data[:layout_name].present? ? data[:layout_name] : false
+      layout = data[:layout_name].presence || false
       if data[:template_name].present? # render email with template
         if data[:format] == 'html'
           mail(mail_data) do |format|

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -155,7 +155,7 @@ module CamaleonCms
     private
 
     def before_validating
-      self.slug = "_group-#{name.to_s.parameterize}" unless slug.present?
+      self.slug = "_group-#{name.to_s.parameterize}" if slug.blank?
     end
 
     # auto save the default field values

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -23,7 +23,7 @@ module CamaleonCms
 
     # touch owner model
     def update_model_owner
-      "CamaleonCms::#{object_class}".constantize.find(objectid).touch
+      "CamaleonCms::#{object_class}".constantize.find(objectid).touch # rubocop:disable Rails/SkipsModelValidations
     rescue StandardError
       nil
     end

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -23,7 +23,7 @@ module CamaleonCms
     end
 
     # search file or folder by key
-    def self.find_by_key(key)
+    def self.by_key(key)
       key = key.cama_fix_media_key
       if key == '/'
         where(folder_path: File.dirname(key))

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -56,10 +56,12 @@ module CamaleonCms
     private
 
     def update_count
-      parent&.update_column('count', parent.children.size)
-      parent_item&.update_column('count', parent_item.children.size)
-      update_column(:term_group, main_menu.parent_id)
-      update_column(:term_order, CamaleonCms::NavMenuItem.where(parent_id: parent_id).count) # update position
+      parent&.update_column(:count, parent.children.size) # rubocop:disable Rails/SkipsModelValidations
+      parent_item&.update_column(:count, parent_item.children.size) # rubocop:disable Rails/SkipsModelValidations
+      # update group and position
+      update_columns( # rubocop:disable Rails/SkipsModelValidations
+        term_group: main_menu.parent_id, term_order: CamaleonCms::NavMenuItem.where(parent_id: parent_id).count
+      )
     end
 
     # fast access from site to menu items

--- a/app/models/camaleon_cms/plugin.rb
+++ b/app/models/camaleon_cms/plugin.rb
@@ -71,7 +71,7 @@ module CamaleonCms
     private
 
     def set_default
-      self.name = slug unless name.present?
+      self.name = slug if name.blank?
     end
 
     def destroy_custom_fields

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -171,7 +171,7 @@ module CamaleonCms
     # new_order_position: (Integer) position number
     # return nil
     def set_position(new_order_position)
-      update_column('post_order', new_order_position)
+      update_column(:post_order, new_order_position) # rubocop:disable Rails/SkipsModelValidations
     end
 
     # save the summary for current post

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -42,7 +42,7 @@ module CamaleonCms
     validates_with CamaleonCms::PostUniqValidator
     attr_accessor :show_title_with_parent
 
-    before_create :fix_post_order, if: ->(p) { !p.post_order.present? || p.post_order == 0 }
+    before_create :fix_post_order, if: ->(p) { p.post_order.blank? || p.post_order == 0 }
 
     # return all parents for current page hierarchy ordered bottom to top
     def parents

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -78,7 +78,7 @@ module CamaleonCms
 
     # do all before actions to save the content
     def before_saved
-      self.title = 'Untitled' unless title.present?
+      self.title = 'Untitled' if title.blank?
       self.content_filtered = if content.to_s.include?('<!--:-->')
                                 content.translations.transform_values do |value|
                                   value.squish.strip_tags

--- a/app/models/camaleon_cms/post_relationship.rb
+++ b/app/models/camaleon_cms/post_relationship.rb
@@ -18,7 +18,9 @@ module CamaleonCms
     private
 
     def update_count
-      post_type.update_column('count', post_type.posts.size) if post_type.present?
+      return if post_type.blank?
+
+      post_type.update_column(:count, post_type.posts.size) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -125,7 +125,7 @@ module CamaleonCms
       args[:data_tags] = args.delete(:tags)
       _thumb = args.delete(:thumb)
       p = posts.new(args)
-      p.slug = site.get_valid_post_slug(p.title.parameterize) unless p.slug.present?
+      p.slug = site.get_valid_post_slug(p.title.parameterize) if p.slug.blank?
       if p.save!
         _settings.each { |k, v| p.set_setting(k, v) } if _settings.present?
         p.set_position(_order_position) if _order_position.present?
@@ -181,7 +181,7 @@ module CamaleonCms
 
     # destroy all custom field groups assigned to this post type
     def destroy_field_groups
-      if !destroyed_by_association.present? && %w[post page].include?(slug)
+      if destroyed_by_association.blank? && %w[post page].include?(slug)
         errors.add(:base, 'This post type can not be deleted.')
         return false
       end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -92,7 +92,7 @@ module CamaleonCms
     def default_category
       return unless manage_categories?
 
-      cat = categories.find_by_slug('uncategorized')
+      cat = categories.find_by(slug: 'uncategorized')
       unless cat
         cat = categories.create({ name: 'Uncategorized', slug: 'uncategorized', parent_id: id })
         cat.set_option('not_deleted', true)

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -183,7 +183,7 @@ module CamaleonCms
       else
         res = slug
         (1..9999).each do |i|
-          p = posts.find_by_slug(res)
+          p = posts.find_by(slug: res)
           break if p.blank? || (p.present? && p.id == post_id)
 
           res = "#{slug}-#{i}"

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -184,7 +184,7 @@ module CamaleonCms
         res = slug
         (1..9999).each do |i|
           p = posts.find_by_slug(res)
-          break if !p.present? || (p.present? && p.id == post_id)
+          break if p.blank? || (p.present? && p.id == post_id)
 
           res = "#{slug}-#{i}"
         end
@@ -211,7 +211,7 @@ module CamaleonCms
     # if the anonymous user not exist, will create one
     def get_anonymous_user
       user = users.where(username: 'anonymous').first
-      unless user.present?
+      if user.blank?
         pass = "anonymous#{rand(9999)}"
         user = users.create({ email: 'anonymous_user@local.com', username: 'anonymous', password: pass,
                               password_confirmation: pass, first_name: 'Anonymous' })

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -17,7 +17,10 @@ module CamaleonCms
     # update counter of post published items
     # TODO verify counter
     def update_count
-      term_taxonomy.update_column('count', term_taxonomy.posts.published.size) if term_taxonomy&.try(:posts)
+      return unless term_taxonomy&.try(:posts)
+
+      term_taxonomy
+        .update_column(:count, term_taxonomy.posts.published.size) # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -1,4 +1,4 @@
-unless PluginRoutes.static_system_info['user_model'].present?
+if PluginRoutes.static_system_info['user_model'].blank?
   module CamaleonCms
     class User < CamaleonRecord
       include CamaleonCms::UserMethods

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -146,7 +146,7 @@ module CamaleonCms
     private
 
     def set_users_as_cilent
-      site.users.where(role: slug).update_all(role: 'client')
+      site.users.where(role: slug).update_all(role: 'client') # rubocop:disable Rails/SkipsModelValidations
     end
   end
 end

--- a/app/models/camaleon_record.rb
+++ b/app/models/camaleon_record.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CamaleonRecord < ActiveRecord::Base
+class CamaleonRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRecord
   TRANSLATION_TAG_HIDE_MAP = { '<!--' => '!--', '-->' => '--!' }.freeze
   TRANSLATION_TAG_HIDE_REGEX = Regexp.new(TRANSLATION_TAG_HIDE_MAP.keys.map { |x| Regexp.escape(x) }.join('|')).freeze
   TRANSLATION_TAG_RESTORE_MAP = { '--!' => '-->', '!--' => '<!--' }.freeze

--- a/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
+++ b/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
@@ -139,7 +139,7 @@ module CamaleonCms
     def check_default_category
       return unless manage_categories?
 
-      assign_category([post_type.default_category.id]) unless categories.present?
+      assign_category([post_type.default_category.id]) if categories.blank?
     end
   end
 end

--- a/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
+++ b/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
@@ -88,13 +88,13 @@ module CamaleonCms
     # kind: (string) tags | categories
     def update_counts(kind = '')
       if ['', 'categories'].include?(kind) && manage_categories?
-        post_type.full_categories.where(id: (@cats_before + categories.pluck(:id)).uniq).each do |c|
+        post_type.full_categories.where(id: (@cats_before + categories.pluck(:id)).uniq).find_each do |c|
           c.update_column(:count, c.posts.published.size) # rubocop:disable Rails/SkipsModelValidations
         end
       end
       return unless ['', 'tags'].include?(kind) && manage_tags?
 
-      post_type.post_tags.where(id: (@tags_before + post_tags.pluck(:id)).uniq).each do |tag|
+      post_type.post_tags.where(id: (@tags_before + post_tags.pluck(:id)).uniq).find_each do |tag|
         tag.update_column(:count, tag.posts.published.size) # rubocop:disable Rails/SkipsModelValidations
       end
     end

--- a/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
+++ b/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
@@ -24,7 +24,7 @@ module CamaleonCms
     # update category assignations for this post
     # remove assignations that no longer exist
     # add new assignations
-    # cats: (Array) array of category ids assigned for this post, sample: [1,2,3]
+    # cats: (Array) array of category ids assigned for this post, sample: [1, 2, 3]
     def update_categories(cats = [])
       rescue_extra_data
       cats = cats.to_i
@@ -35,7 +35,7 @@ module CamaleonCms
       news_categories.each do |key|
         term_relationships.create(term_taxonomy_id: key)
       end
-      update_counters('categories')
+      update_counts('categories')
     end
 
     # update tags assignations for this post
@@ -53,7 +53,7 @@ module CamaleonCms
         post_tag = post_type.post_tags.where({ name: f }).first_or_create(slug: f.parameterize)
         term_relationships.where({ term_taxonomy_id: post_tag.id }).first_or_create
       end
-      update_counters('tags')
+      update_counts('tags')
     end
 
     # Assign this post for category with id: category_id
@@ -64,43 +64,13 @@ module CamaleonCms
       categories_id.each do |key|
         term_relationships.where(term_taxonomy_id: key).first_or_create!
       end
-      update_counters('categories')
+      update_counts('categories')
     end
 
-    # Assign this post for category with id: category_id
-    # categories_id: (Array) array of category ids assigned for this post, sample: [1,2,3]
-    def unassign_category(categories_id)
-      categories_id = [categories_id] if categories_id.is_a?(Integer)
-      rescue_extra_data
-      term_relationships.where(term_taxonomy_id: categories_id).destroy_all
-      update_counters('categories')
-    end
-
-    # Assign new tags to this post
-    # tags_title: (String) tags name separated by commas, sample: "Tag1,Tag two,tag new"
-    def assign_tags(tag_titles)
-      update_counters_before
-      tags = tag_titles.split(',').strip
-      tags.each do |t|
-        post_tag = post_type.post_tags.where(name: t).first_or_create!
-        term_relationships.where({ term_taxonomy_id: post_tag.id }).first_or_create!
-      end
-      update_counters('tags')
-    end
-
-    # Unassign tags from this post
-    # tags_title: (String) tags name separated by commas, sample: "Tag1,Tag two,tag new"
-    def unassign_tags(tag_titles)
-      update_counters_before
-      tags = tag_titles.split(',').strip
-      term_relationships.where({ term_taxonomy_id: post_type.post_tags.where(name: tags).pluck(:id) }).destroy_all
-      update_counters('tags')
-    end
-
-    # update quantity of posts assigned for tags and categories assigned to this post
+    # Update the quantity of posts assigned for tags and categories assigned to this post
     def update_extra_data
       rescue_extra_data
-      update_counters
+      update_counts
     end
 
     private
@@ -113,23 +83,23 @@ module CamaleonCms
       @tags_before = post_tags.pluck(:id) if manage_tags?
     end
 
-    # update quantity of posts assigned for tags and categories assigned to this post
+    # Update the quantity of posts assigned for tags and categories assigned to this post
     # if kind is empty, then this will update both: cats and tags
     # kind: (string) tags | categories
-    def update_counters(kind = '')
+    def update_counts(kind = '')
       if ['', 'categories'].include?(kind) && manage_categories?
         post_type.full_categories.where(id: (@cats_before + categories.pluck(:id)).uniq).each do |c|
-          c.update_column('count', c.posts.published.size)
+          c.update_column(:count, c.posts.published.size) # rubocop:disable Rails/SkipsModelValidations
         end
       end
       return unless ['', 'tags'].include?(kind) && manage_tags?
 
       post_type.post_tags.where(id: (@tags_before + post_tags.pluck(:id)).uniq).each do |tag|
-        tag.update_column('count', tag.posts.published.size)
+        tag.update_column(:count, tag.posts.published.size) # rubocop:disable Rails/SkipsModelValidations
       end
     end
 
-    # save extra data such as: categories and tags assigned to this post
+    # Save extra data such as categories and tags assigned to this post
     def save_extra_data
       update_categories(data_categories) if manage_categories? && !data_categories.nil?
       update_tags(data_tags) if manage_tags? && !data_tags.nil?

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -244,10 +244,11 @@ module CamaleonCms
       end
     end
 
-    # update new value for field with slug _key
+    # Update the value for the field with slug _key
     # Sample: my_posy.update_field_value('sub_title', 'Test Sub Title')
-    def update_field_value(_key, value = nil, group_number = 0)
-      custom_field_values.find_by(custom_field_slug: _key, group_number: group_number)&.update_column('value', value)
+    def update_field_value(key, value = nil, group_number = 0)
+      custom_field_values.find_by(custom_field_slug: key, group_number: group_number)
+                         &.update_column(:value, value) # rubocop:disable Rails/SkipsModelValidations
     rescue StandardError
       nil
     end

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -82,7 +82,7 @@ module CamaleonCms
       rescue StandardError
         _default
       end
-      v.present? ? v : _default
+      v.presence || _default
     end
     alias get_field get_field_value
     alias get_field! get_field_value

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -226,13 +226,13 @@ module CamaleonCms
     #   "1"=>{ "untitled-text-box"=>{"id"=>"262", "values"=>{"0"=>"33333"}}}
     # }
     def set_field_values(datas = {})
-      return unless datas.present?
+      return if datas.blank?
 
       ActiveRecord::Base.transaction do
         custom_field_values.delete_all
         datas.each_value do |fields_data|
           fields_data.each do |field_key, values|
-            next unless values[:values].present?
+            next if values[:values].blank?
 
             order_value = -1
             (values[:values].is_a?(Hash) || values[:values].is_a?(ActionController::Parameters) ? values[:values].values : values[:values]).each do |value|
@@ -275,14 +275,14 @@ module CamaleonCms
     # sample: my_post.set_field_value('subtitle', 'Sub Title', {group_number: 1, group_number: 1}) # add field values for fields in group 1
     def set_field_value(key, value, args = {})
       args = { order: 0, group_number: 0, field_id: nil, clear: true }.merge!(args)
-      unless args[:field_id].present?
+      if args[:field_id].blank?
         args[:field_id] = begin
           get_field_object(key).id
         rescue StandardError
           nil
         end
       end
-      raise ArgumentError, "There is no custom field configured for #{key}" unless args[:field_id].present?
+      raise ArgumentError, "There is no custom field configured for #{key}" if args[:field_id].blank?
 
       if args[:clear]
         custom_field_values.where({ custom_field_slug: key,

--- a/app/models/concerns/camaleon_cms/metas.rb
+++ b/app/models/concerns/camaleon_cms/metas.rb
@@ -88,7 +88,7 @@ module CamaleonCms
     # set multiple configurations
     # h: {ket1: "sdsds", ff: "fdfdfdfd"}
     def set_options(h = {}, meta_key = '_default')
-      return unless h.present?
+      return if h.blank?
 
       data = cama_options(meta_key)
       PluginRoutes.fixActionParameter(h).to_sym.each do |key, value|
@@ -120,7 +120,7 @@ module CamaleonCms
     # sample: Site.first.post_types.create({name: "owen", slug: "my_post_type", data_options: { has_category: true, default_layout: "my_layout" }})
     def save_metas_options
       set_multiple_options(data_options)
-      return unless data_metas.present?
+      return if data_metas.blank?
 
       data_metas.each do |key, val|
         set_meta(key, val)

--- a/app/models/concerns/camaleon_cms/site_default_settings.rb
+++ b/app/models/concerns/camaleon_cms/site_default_settings.rb
@@ -17,7 +17,7 @@ module CamaleonCms
       # nav menus
       @nav_menu = nav_menus.new({ name: 'Main Menu', slug: 'main_menu' })
       if @nav_menu.save
-        post_types.all.each do |pt|
+        post_types.find_each do |pt|
           if pt.slug == 'post'
             title = 'Sample Post'
             slug = 'sample-post'

--- a/app/models/concerns/camaleon_cms/site_default_settings.rb
+++ b/app/models/concerns/camaleon_cms/site_default_settings.rb
@@ -28,7 +28,7 @@ module CamaleonCms
             content = "<p style='text-align: center;'><img width='155' height='155' src='https://camaleon.website/media/132/logo2.png' alt='logo' /></p><p><strong>Camaleon CMS</strong>&nbsp;is a free and open-source tool and a fexible content management system (CMS) based on <a href='https://rubyonrails.org'>Ruby on Rails</a>.</p> <p>With Camaleon you can do the following:</p> <ul> <li>Create instantly a lot of sites&nbsp;in the same installation</li> <li>Manage your content information in several languages</li> <li>Extend current functionality by&nbsp;plugins (MVC structure and no more echo or prints anywhere)</li> <li>Create or install different themes for each site</li> <li>Create your own structure without coding anything (adapt Camaleon as you want&nbsp;and not you for Camaleon)</li> <li>Create your store and start to sell your products using our plugins</li> <li>Avoid web attacks</li> <li>Compare the speed and enjoy the speed of your new Camaleon site</li> <li>Customize or create your themes for mobile support</li> <li>Support&nbsp;more visitors at the same time</li> <li>Manage your information with a panel like wordpress&nbsp;</li> <li>All urls are oriented for SEO</li> <li>Multiples roles of users</li> </ul>"
           end
           user = users.admin_scope.first
-          unless user.present?
+          if user.blank?
             user = users.admin_scope.create({ email: 'admin@local.com', username: 'admin', password: 'admin123',
                                               password_confirmation: 'admin123', first_name: 'Administrator' })
           end

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -64,9 +64,9 @@ module CamaleonCms
       @_user_role ||= site.user_roles.where(slug: role).first
     end
 
-    # assign a new site for current user
+    # Assign a new site for the current user
     def assign_site(site)
-      update_column(:site_id, site.id)
+      update_column(:site_id, site.id) # rubocop:disable Rails/SkipsModelValidations
     end
 
     def sites
@@ -128,10 +128,8 @@ module CamaleonCms
         u = s.users.admin_scope.where.not(id: id).first
         next if u.blank?
 
-        p.update_column(:user_id, u.id)
-        p.comments.where(user_id: id).each do |c|
-          c.update_column(:user_id, u.id)
-        end
+        p.update_column(:user_id, u.id) # rubocop:disable Rails/SkipsModelValidations
+        p.comments.where(user_id: id).update_all(user_id: u.id) # rubocop:disable Rails/SkipsModelValidations
       end
     end
 
@@ -139,7 +137,7 @@ module CamaleonCms
       all_comments.includes(post: { post_type: :site }).each do |comment|
         site = comment.post.post_type.site
         user = site.get_anonymous_user
-        comment.update_column(:user_id, user.id)
+        comment.update_column(:user_id, user.id) # rubocop:disable Rails/SkipsModelValidations
       end
     end
   end

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -134,7 +134,7 @@ module CamaleonCms
     end
 
     def reassign_comments
-      all_comments.includes(post: { post_type: :site }).each do |comment|
+      all_comments.includes(post: { post_type: :site }).find_each do |comment|
         site = comment.post.post_type.site
         user = site.get_anonymous_user
         comment.update_column(:user_id, user.id) # rubocop:disable Rails/SkipsModelValidations

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -126,7 +126,7 @@ module CamaleonCms
       all_posts.each do |p|
         s = p.post_type.site
         u = s.users.admin_scope.where.not(id: id).first
-        next unless u.present?
+        next if u.blank?
 
         p.update_column(:user_id, u.id)
         p.comments.where(user_id: id).each do |c|

--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -125,7 +125,7 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
     key = "#{@aws_settings['inner_folder']}/#{key}" if @aws_settings['inner_folder'].present?
     key = key.cama_fix_media_key
     bucket.objects(prefix: key.slice(1..-1) << '/').delete
-    get_media_collection.find_by_key(key).take.destroy
+    get_media_collection.by_key(key).take.destroy
   end
 
   # delete a file in AWS with :key
@@ -140,7 +140,7 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
       ''
     end
     @instance.hooks_run('after_delete', key)
-    get_media_collection.find_by_key(key).take.destroy
+    get_media_collection.by_key(key).take.destroy
   end
 
   # initialize a bucket with AWS configurations

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -2,13 +2,13 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def after_initialize
     @root_folder = @current_site.upload_directory
 
-    FileUtils.mkdir_p(@root_folder) unless Dir.exist?(@root_folder)
+    FileUtils.mkdir_p(@root_folder)
   end
 
   def setup_private_folder
     @root_folder = Rails.root.join(self.class::PRIVATE_DIRECTORY).to_s
 
-    FileUtils.mkdir_p(@root_folder) unless Dir.exist?(@root_folder)
+    FileUtils.mkdir_p(@root_folder)
   end
 
   def browser_files(prefix = '/', _objects = {})

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -115,7 +115,7 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
 
     folder = File.join(@root_folder, key)
     FileUtils.rm_rf(folder) if Dir.exist? folder
-    get_media_collection.find_by_key(key).take.destroy
+    get_media_collection.by_key(key).take.destroy
   end
 
   # remove an existent file
@@ -125,7 +125,7 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
     file = File.join(@root_folder, key)
     FileUtils.rm(file) if File.exist? file
     @instance.hooks_run('after_delete', key)
-    get_media_collection.find_by_key(key).take.destroy
+    get_media_collection.by_key(key).take.destroy
   end
 
   # convert a real file path into file key

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -118,7 +118,7 @@ class CamaleonCmsUploader
   # false: if format is not accepted
   # sample: validate_file_format('/var/www/myfile.xls', 'image,audio,docx,xls') => return true if the file extension is in formats
   def self.validate_file_format(key, valid_formats = '*')
-    return true if valid_formats == '*' || !valid_formats.present?
+    return true if valid_formats == '*' || valid_formats.blank?
 
     valid_formats = valid_formats.gsub(' ',
                                        '').downcase.split(',') + get_file_format_extensions(valid_formats).split(',')

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -94,7 +94,7 @@ class CamaleonCmsUploader
   # support for multiples formats, sample: image,audio
   def self.get_file_format_extensions(format)
     res = []
-    format.downcase.gsub(' ', '').split(',').each do |f|
+    format.downcase.delete(' ').split(',').each do |f|
       res << case f
              when 'image', 'images'
                'jpg,jpeg,png,gif,bmp,ico,svg'
@@ -120,8 +120,7 @@ class CamaleonCmsUploader
   def self.validate_file_format(key, valid_formats = '*')
     return true if valid_formats == '*' || valid_formats.blank?
 
-    valid_formats = valid_formats.gsub(' ',
-                                       '').downcase.split(',') + get_file_format_extensions(valid_formats).split(',')
+    valid_formats = valid_formats.delete(' ').downcase.split(',') + get_file_format_extensions(valid_formats).split(',')
     valid_formats.include?(File.extname(key).sub('.', '').split('?').first.try(:downcase))
   end
 

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -25,7 +25,7 @@ class CamaleonCmsUploader
               ''].include?(prefix)
             get_media_collection.where(folder_path: '/')
           else
-            get_media_collection.find_by_key(prefix).take.try(:items)
+            get_media_collection.by_key(prefix).take.try(:items)
           end
     # Private hook to recover custom files to include in current list where data can be modified to add custom{files, folders}
     # Note: this hooks doesn't have access to public vars like params. requests, ...
@@ -136,10 +136,10 @@ class CamaleonCmsUploader
   # sample: search_new_key("my_file/file.txt")
   def search_new_key(key)
     _key = key
-    if get_media_collection.find_by_key(key).any?
+    if get_media_collection.by_key(key).any?
       (1..999).each do |i|
         _key = key.cama_add_postfix_file_name("_#{i}")
-        break unless get_media_collection.find_by_key(_key).any?
+        break unless get_media_collection.by_key(_key).any?
       end
     end
     _key

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -5,7 +5,7 @@ module CamaleonCms
 
       slug_array = record.slug.to_s.translations_array
       ptype = record.post_type
-      return unless ptype.present? # only for posts that belongs to a post type model
+      return if ptype.blank? # only for posts that belongs to a post type model
 
       post_table = CamaleonCms::Post.table_name
 

--- a/app/validators/camaleon_cms/user_url_validator.rb
+++ b/app/validators/camaleon_cms/user_url_validator.rb
@@ -49,7 +49,7 @@ module CamaleonCms
     #
     # Returns an array with [<uri>, <original-hostname>].
     def validate(url, allow_localhost: false, allow_local_network: false, enforce_user: true, enforce_sanitizing: true)
-      return invalid_url unless url.present?
+      return invalid_url if url.blank?
 
       # Param url can be a string, URI or Addressable::URI
       return invalid_url unless (uri = parse_url(url))

--- a/app/views/camaleon_cms/default_theme/sitemap.xml.builder
+++ b/app/views/camaleon_cms/default_theme/sitemap.xml.builder
@@ -57,7 +57,7 @@ xml.urlset 'xmlns' => 'https://www.sitemaps.org/schemas/sitemap/0.9' do
   @r[:custom].each_value do |item|
     xml.url do
       xml.loc item[:url]
-      xml.lastmod item[:lastmod] || Date.today.to_s
+      xml.lastmod item[:lastmod] || Date.current.to_s
       xml.changefreq item[:changefreq] || 'monthly'
       xml.priority item[:priority] || '0.5'
     end

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -7,10 +7,10 @@ module ActionView
       # fix to add camaleon prefix to search partials and layouts
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         if use_camaleon_partial_prefixes.present?
-          if !partial && !prefixes.present? && File.exist?(name) # fix for windows ==> render file: '....'
+          if !partial && prefixes.blank? && File.exist?(name) # fix for windows ==> render file: '....'
             # puts "rendering specific file (render file: '....')"
           else
-            prefixes = [''] unless prefixes.present?
+            prefixes = [''] if prefixes.blank?
             prefixes = (self.prefixes + prefixes).uniq if prefixes.is_a?(Array)
           end
         end
@@ -21,7 +21,7 @@ module ActionView
       # fix to add camaleon prefixes on verify template exist
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         if use_camaleon_partial_prefixes.present?
-          prefixes = [''] unless prefixes.present?
+          prefixes = [''] if prefixes.blank?
           prefixes = (prefixes + self.prefixes).uniq if prefixes.is_a?(Array)
         end
         @view_paths.exists?(*cama_args_for_lookup(name, prefixes, partial, keys, options))

--- a/config/initializers/custom_initializers.rb
+++ b/config/initializers/custom_initializers.rb
@@ -1,7 +1,7 @@
 # load all custom initializers of plugins or themes
 Rails.application.config.to_prepare do |_config|
   PluginRoutes.all_apps.each do |ap|
-    next unless ap['path'].present?
+    next if ap['path'].blank?
 
     f = File.join(ap['path'], 'config', 'initializer.rb')
     load f if File.exist?(f)

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -53,8 +53,8 @@ module CamaleonCms
       app.config.i18n.load_path.unshift(*translation_files)
 
       # assets
-      app.config.assets.paths << Rails.root.join('app', 'apps')
-      app.config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
+      app.config.assets.paths << Rails.root.join('app/apps')
+      app.config.assets.paths << Rails.root.join('app/assets/fonts')
       app.config.assets.paths << File.join($camaleon_engine_dir, 'app', 'apps')
       app.config.assets.paths << File.join($camaleon_engine_dir, 'app', 'assets', 'fonts')
       app.config.encoding = 'utf-8'

--- a/lib/ext/translator.rb
+++ b/lib/ext/translator.rb
@@ -40,7 +40,7 @@ class String
   # sample: ["hola mundo", "Hello World"]
   def translations_array
     r = translations.map { |_key, value| value }
-    r.present? ? r : [self]
+    r.presence || [self]
   end
 
   protected

--- a/lib/generators/camaleon_cms/install_generator.rb
+++ b/lib/generators/camaleon_cms/install_generator.rb
@@ -1,5 +1,6 @@
 require 'rails/generators/base'
 require 'securerandom'
+
 module CamaleonCms
   module Generators
     class InstallGenerator < Rails::Generators::Base
@@ -9,13 +10,13 @@ module CamaleonCms
       def create_initializer_file
         copy_file 'system.json', 'config/system.json'
         copy_file 'plugin_routes.rb', 'lib/plugin_routes.rb'
-        Dir.mkdir Rails.root.join('app', 'apps').to_s unless Dir.exist?(Rails.root.join('app', 'apps').to_s)
+        FileUtils.mkdir_p(Rails.root.join('app/apps'))
         directory('apps', 'app/apps')
         directory(File.join($camaleon_engine_dir, 'app/apps/themes').to_s, 'app/apps/themes')
 
         sprokects_4_or_newer = defined?(Sprockets::BabelProcessor)
         if sprokects_4_or_newer
-          assets_config_dir = Rails.root.join('app', 'assets', 'config')
+          assets_config_dir = Rails.root.join('app/assets/config')
           FileUtils.makedirs(assets_config_dir)
           assets_config_file = assets_config_dir.join('manifest.js')
           FileUtils.touch(assets_config_file) unless File.file?(assets_config_file)
@@ -27,7 +28,7 @@ module CamaleonCms
             //= link_tree ../../apps/themes/default/assets
             //= link_tree ../../apps/themes/new/assets
           ASSETS
-          append_to_file Rails.root.join('config', 'initializers', 'assets.rb'),
+          append_to_file Rails.root.join('config/initializers/assets.rb'),
                          <<~PRECOMPILE_MANIFEST
 
                            Rails.application.config.assets.precompile += %w( manifest.js )

--- a/lib/generators/camaleon_cms/theme_generator.rb
+++ b/lib/generators/camaleon_cms/theme_generator.rb
@@ -1,5 +1,6 @@
 require 'rails/generators/base'
 require 'securerandom'
+
 module CamaleonCms
   module Generators
     class ThemeGenerator < Rails::Generators::Base
@@ -12,18 +13,17 @@ module CamaleonCms
         if behavior == :revoke
           if Dir.exist?(theme_folder)
             FileUtils.rm_rf(theme_folder)
-            puts 'Theme destroyed successfully'
+            Rails.logger.info 'Theme destroyed successfully'
           else
-            puts "This theme doesn't exist"
+            Rails.logger.info "This theme doesn't exist"
           end
-
         elsif Dir.exist?(theme_folder)
-
-          puts 'This theme already exist'
+          Rails.logger.info 'This theme already exist'
         else
-
           theme_folder = Rails.root.join('app', 'apps', 'themes', get_theme_name)
-          return puts("There is already a theme with the same name in: #{theme_folder}") if Dir.exist?(theme_folder)
+          if Dir.exist?(theme_folder)
+            return Rails.logger.info "There is already a theme with the same name in: #{theme_folder}"
+          end
 
           # tmp copy
           FileUtils.mkdir_p(theme_folder)
@@ -37,7 +37,7 @@ module CamaleonCms
           # helper
           t = fix_text(File.read(File.join(theme_folder, 'main_helper.rb')))
           File.open(File.join(theme_folder, 'main_helper.rb'), 'w') { |f| f << t }
-          puts "Theme successfully created in: #{theme_folder}"
+          Rails.logger.info "Theme successfully created in: #{theme_folder}"
         end
       end
 

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -235,9 +235,7 @@ class PluginRoutes
       r = cache_variable('site_plugin_helpers')
       return r if r
 
-      res = enabled_apps(site).flat_map do |settings|
-        settings['helpers'] if settings['helpers'].present?
-      end
+      res = enabled_apps(site).flat_map { |settings| settings['helpers'].presence }
       cache_variable('site_plugin_helpers', res)
     end
 
@@ -246,9 +244,7 @@ class PluginRoutes
       r = cache_variable('plugins_helper')
       return r if r
 
-      res = all_apps.flat_map do |settings|
-        settings['helpers'] if settings['helpers'].present?
-      end
+      res = all_apps.flat_map { |settings| settings['helpers'].presence }
       cache_variable('plugins_helper', res.uniq)
     end
 

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -401,7 +401,7 @@ class PluginRoutes
         p['version'] = gem.version.to_s
         p['path'] = path
         p['kind'] = 'plugin'
-        p['descr'] = gem.description unless p['descr'].present?
+        p['descr'] = gem.description if p['descr'].blank?
         p['gem_mode'] = true
         ary << p
       end

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -443,7 +443,7 @@ class PluginRoutes
       rescue StandardError
         ''
       end }
-      options.merge!({ protocol: 'https' }) if Rails.application.config.force_ssl
+      options[:protocol] = 'https' if Rails.application.config.force_ssl
       options
     end
 

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -24,7 +24,7 @@ class PluginRoutes
       settings = {}
 
       gem_settings = File.join($camaleon_engine_dir, 'config', 'system.json')
-      app_settings = Rails.root.join('config', 'system.json')
+      app_settings = Rails.root.join('config/system.json')
 
       settings.merge!(JSON.parse(File.read(gem_settings))) if File.exist?(gem_settings)
       settings.merge!(JSON.parse(File.read(app_settings))) if File.exist?(app_settings)
@@ -309,7 +309,7 @@ class PluginRoutes
 
     # return app's directory path
     def apps_dir
-      @apps_dir ||= Rails.root.join('app', 'apps').to_s
+      @apps_dir ||= Rails.root.join('app/apps').to_s
     end
 
     # return all plugins located in cms and in this project

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -295,18 +295,6 @@ class PluginRoutes
       all_locales.split('|').map { |_l| I18n.t(key, **args.merge({ locale: _l })) }.uniq
     end
 
-    # return all locales for translated routes
-    def all_locales_for_routes
-      r = cache_variable('all_locales_for_routes')
-      return r if r
-
-      res = all_locales.split('|').each_with_object({}) do |locale, hsh|
-        hsh[locale] = "_#{locale}"
-      end
-      res[false] = ''
-      cache_variable('all_locales_for_routes', res)
-    end
-
     # return app's directory path
     def apps_dir
       @apps_dir ||= Rails.root.join('app/apps').to_s

--- a/lib/tasks/camaleon_cms/camaleon_tasks.rake
+++ b/lib/tasks/camaleon_cms/camaleon_tasks.rake
@@ -10,7 +10,8 @@ namespace :camaleon_cms do
     include Rails.application.routes.url_helpers
     $current_site = CamaleonCms::Site.find(ENV['site_id'].to_i)
     cama_uploader_init_connection
-    @fog_connection_bucket_dir.files.all.each do |file|
+    # TODO: The `fog` gem isn't used anymore - this whole task should be refactored
+    @fog_connection_bucket_dir.files.all.each do |file| # rubocop:disable Rails/FindEach
       puts file.inspect
       cama_uploader_generate_thumbnail(file.key, file.key, '')
     end

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -11,13 +11,13 @@ describe CamaleonCms::UploaderHelper do
   end
 
   it 'upload a local file' do
-    expect(upload_file(File.open(@path)).keys.include?(:error)).not_to eql(true)
-    expect(upload_file(File.open(@path), { thumb_size: '20x20' }).keys.include?(:error)).not_to eql(true)
-    expect(upload_file(File.open(@path), { folder: 'sample' }).keys.include?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path)).key?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { thumb_size: '20x20' }).key?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { folder: 'sample' }).key?(:error)).not_to eql(true)
   end
 
   it 'upload a local file max size' do
-    expect(upload_file(File.open(@path), { maximum: 1.byte }).keys.include?(:error)).to be(true)
+    expect(upload_file(File.open(@path), { maximum: 1.byte }).key?(:error)).to be(true)
   end
 
   describe 'deleting temporary uploaded file' do
@@ -35,43 +35,43 @@ describe CamaleonCms::UploaderHelper do
       end) do
         expect(CamaleonCmsUploader).to receive(:delete_block)
         expect_any_instance_of(CamaleonCmsLocalUploader).to receive(:delete_file)
-        expect(upload_file(File.open(@path), { temporal_time: 1 }).keys.include?(:error)).to be(false)
+        expect(upload_file(File.open(@path), { temporal_time: 1 }).key?(:error)).to be(false)
       end
     end
 
     it "doesn't delete the uploaded file if temporal_time option is missing" do
       expect(CamaleonCmsUploader).not_to receive(:delete_block)
       expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
-      expect(upload_file(File.open(@path)).keys.include?(:error)).to be(false)
+      expect(upload_file(File.open(@path)).key?(:error)).to be(false)
     end
 
     it "doesn't delete the uploaded file if temporal_time option is 0" do
       expect(CamaleonCmsUploader).not_to receive(:delete_block)
       expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
-      expect(upload_file(File.open(@path), { temporal_time: 0 }).keys.include?(:error)).to be(false)
+      expect(upload_file(File.open(@path), { temporal_time: 0 }).key?(:error)).to be(false)
     end
 
     it "doesn't delete the uploaded file if temporal_time option is < 0" do
       expect(CamaleonCmsUploader).not_to receive(:delete_block)
       expect_any_instance_of(CamaleonCmsLocalUploader).not_to receive(:delete_file)
-      expect(upload_file(File.open(@path), { temporal_time: -1 }).keys.include?(:error)).to be(false)
+      expect(upload_file(File.open(@path), { temporal_time: -1 }).key?(:error)).to be(false)
     end
   end
 
   it 'upload a local file custom dimension' do
-    expect(upload_file(File.open(@path), { dimension: '50x50' }).keys.include?(:error)).not_to eql(true)
-    expect(upload_file(File.open(@path), { dimension: 'x50' }).keys.include?(:error)).not_to eql(true)
-    expect(upload_file(File.open(@path), { dimension: '50x' }).keys.include?(:error)).not_to eql(true)
-    expect(upload_file(File.open(@path), { dimension: '50x20?' }).keys.include?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { dimension: '50x50' }).key?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { dimension: 'x50' }).key?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { dimension: '50x' }).key?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { dimension: '50x20?' }).key?(:error)).not_to eql(true)
   end
 
   describe 'file upload with invalid path' do
     it "doesn't upload a local file with invalid path of a path traversal try" do
-      expect(upload_file(File.open(@path), { folder: '../../config/initializers' }).keys.include?(:error)).to be(true)
+      expect(upload_file(File.open(@path), { folder: '../../config/initializers' }).key?(:error)).to be(true)
     end
 
     it "doesn't upload a local file with invalid URI-like path" do
-      expect(upload_file(File.open(@path), { folder: 'file:///config/initializers' }).keys.include?(:error)).to be(true)
+      expect(upload_file(File.open(@path), { folder: 'file:///config/initializers' }).key?(:error)).to be(true)
     end
   end
 
@@ -119,11 +119,11 @@ describe CamaleonCms::UploaderHelper do
   end
 
   it "doesn't upload a local file with invalid format" do
-    expect(upload_file(File.open(@path), { formats: 'audio' }).keys.include?(:error)).to be(true)
+    expect(upload_file(File.open(@path), { formats: 'audio' }).key?(:error)).to be(true)
   end
 
   it 'upload a local file with versions' do
-    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).keys.include?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).key?(:error)).not_to eql(true)
   end
 
   it 'add auto orient for cropping images' do
@@ -131,7 +131,7 @@ describe CamaleonCms::UploaderHelper do
       params[:img] = params[:img].auto_orient
     end
     PluginRoutes.add_anonymous_hook('before_crop_image', callback, 'my_custom_hook')
-    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).keys.include?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).key?(:error)).not_to eql(true)
     PluginRoutes.remove_anonymous_hook('before_crop_image', 'my_custom_hook')
   end
 
@@ -140,7 +140,7 @@ describe CamaleonCms::UploaderHelper do
       params[:img] = params[:img].auto_orient
     end
     PluginRoutes.add_anonymous_hook('before_resize_crop', callback, 'my_custom_hook')
-    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).keys.include?(:error)).not_to eql(true)
+    expect(upload_file(File.open(@path), { versions: '300x300,505x350,20x' }).key?(:error)).not_to eql(true)
     PluginRoutes.remove_anonymous_hook('before_resize_crop', 'my_custom_hook')
   end
 

--- a/spec/requests/admin/media_controller/actions_spec.rb
+++ b/spec/requests/admin/media_controller/actions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#actions', type: :request d
       it 'allows creating a new folder' do
         post '/admin/media/actions', params: { folder: '/test_folder', media_action: 'new_folder' }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#actions', type: :request d
         allow_any_instance_of(CamaleonCmsLocalUploader).to receive(:delete_folder).and_return(error: '')
         post '/admin/media/actions', params: { folder: '/test_folder', media_action: 'del_folder' }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#actions', type: :request d
         allow_any_instance_of(CamaleonCmsLocalUploader).to receive(:delete_file).and_return(error: '')
         post '/admin/media/actions', params: { folder: '/test_file.jpg', media_action: 'del_file' }
 
-        expect(response).to have_http_status(200)
+        expect(response).to have_http_status(:ok)
       end
     end
   end

--- a/spec/requests/admin/media_controller/ajax_spec.rb
+++ b/spec/requests/admin/media_controller/ajax_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#ajax', type: :request do
     it 'allows access to ajax endpoint' do
       get '/admin/media/ajax'
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/admin/media_controller/download_private_file_spec.rb
+++ b/spec/requests/admin/media_controller/download_private_file_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Download private file requests', type: :request do
 
         get '/admin/media/download_private_file', params: { file: 'some_file' }
 
-        expect(response).not_to have_http_status(403)
-        expect(response).to have_http_status(200)
+        expect(response).not_to have_http_status(:forbidden)
+        expect(response).to have_http_status(:ok)
       end
     end
 

--- a/spec/requests/admin/media_controller/index_spec.rb
+++ b/spec/requests/admin/media_controller/index_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#index', type: :request do
     it 'allows access to index' do
       get '/admin/media'
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 

--- a/spec/requests/admin/plugins/attack_settings_spec.rb
+++ b/spec/requests/admin/plugins/attack_settings_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Plugin Attack Settings', type: :request do
 
       get '/admin/plugins/attack/settings'
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'allows saving attack settings' do

--- a/spec/requests/admin/plugins/front_cache_settings_spec.rb
+++ b/spec/requests/admin/plugins/front_cache_settings_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Plugin Front Cache Settings', type: :request do
 
       get '/admin/plugins/front_cache/settings'
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'allows saving front_cache settings' do

--- a/spec/requests/admin/settings/custom_fields_spec.rb
+++ b/spec/requests/admin/settings/custom_fields_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'CustomFields create/update permissions', type: :request do
         field_options: { '0' => { field_key: 'select_eval' } }
       }
 
-      expect(response).to have_http_status(302)
+      expect(response).to have_http_status(:found)
       expect(group.reload.fields.where(slug: 'eval_update')).to be_present
     end
 
@@ -51,7 +51,7 @@ RSpec.describe 'CustomFields create/update permissions', type: :request do
         field_options: { '0' => { field_key: 'select_eval' } }
       }
 
-      expect(response).to have_http_status(302)
+      expect(response).to have_http_status(:found)
       expect(group.reload.fields.where(slug: 'eval_blocked')).to be_empty
       expected_custom = I18n.t('camaleon_cms.admin.custom_field.message.select_eval_admin_only', default: 'The "Select Eval" field type is restricted to administrators.')
       expect(flash[:error]).to satisfy do |msg|
@@ -98,7 +98,7 @@ RSpec.describe 'CustomFields create/update permissions', type: :request do
       end.not_to(change { current_site.custom_field_groups.count })
 
       # should redirect (either by authorization or permission check)
-      expect(response).to have_http_status(302)
+      expect(response).to have_http_status(:found)
 
       # and set an error message about select_eval restriction (either the custom message or the standard CanCan denial)
       expected_custom = I18n.t('camaleon_cms.admin.custom_field.message.select_eval_admin_only', default: 'The "Select Eval" field type is restricted to administrators.')
@@ -119,7 +119,7 @@ RSpec.describe 'CustomFields create/update permissions', type: :request do
       sign_in_as(user, site: current_site)
 
       get '/admin/settings/custom_fields/list', params: { post_type: post_type.id, post_id: my_post.id }
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
     end
 
     it 'respects categories parameter for field groups and updates post categories' do

--- a/spec/requests/admin/settings/settings_controller_spec.rb
+++ b/spec/requests/admin/settings/settings_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe CamaleonCms::Admin::SettingsController, type: :request do
 
         get '/admin/settings/test_email', params: { email: 'test@example.com' }
 
-        expect(response).to have_http_status(502)
+        expect(response).to have_http_status(:bad_gateway)
         expect(response.body).to eq(error_message)
         expect(response.content_type).to include('text/plain')
       end

--- a/spec/requests/security/open_redirect_session_spec.rb
+++ b/spec/requests/security/open_redirect_session_spec.rb
@@ -14,4 +14,20 @@ RSpec.describe 'Security: Open Redirect in SessionHelper', type: :request do
     expect(response.location).not_to include('evil.com')
     expect(response).to redirect_to(cama_admin_dashboard_path)
   end
+
+  it 'does not redirect to external URLs via return_to param on login when already signed in' do
+    post cama_admin_login_path, params: { user: { username: user.username, password: 'password' } }
+    get cama_admin_login_path, params: { return_to: 'https://evil.com/path' }
+
+    expect(response.location).not_to include('evil.com')
+    expect(response).to redirect_to(cama_admin_dashboard_path)
+  end
+
+  it 'does not redirect to external URLs via return_to param on logout' do
+    post cama_admin_login_path, params: { user: { username: user.username, password: 'password' } }
+    get cama_admin_logout_path, params: { return_to: 'https://evil.com/path' }
+
+    expect(response.location).not_to include('evil.com')
+    expect(response).to redirect_to(cama_admin_login_path)
+  end
 end

--- a/spec/requests/security/xss_vulnerabilities_spec.rb
+++ b/spec/requests/security/xss_vulnerabilities_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
         }
       }
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
       expect(response.body).to include(json_escaped_payload)
 
       # Test Finding 10: Custom Fields Index
       get '/admin/settings/custom_fields'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
 
@@ -49,7 +49,7 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
       get '/admin/settings/custom_fields/list', params: {
         post_type: post_type.id
       }
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include('onmousedown="this.clicked = 1;"')
       expect(response.body).to include('onfocus="if (!this.clicked) this.select(); else this.clicked = 2;"')
       expect(response.body).to include('onclick="if (this.clicked == 2) this.select(); this.clicked = 0;"')
@@ -67,7 +67,7 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
 
       get "/admin/posts/#{my_post.id}/comments"
 
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to match(/#{Regexp.escape(escaped_payload)}/i)
     end
   end
@@ -80,28 +80,28 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
 
       # Categories index (Finding 1)
       get "/admin/post_type/#{post_type.id}/categories"
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
 
       # Tags index (Finding 4)
       get "/admin/post_type/#{post_type.id}/post_tags"
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
 
       # Post list (Finding 6 - categories/tags shown in list)
       get "/admin/post_type/#{post_type.id}/posts"
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
 
       # Post edit sidebar (Finding 5)
       get "/admin/post_type/#{post_type.id}/posts/#{my_post.id}/edit"
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
 
     it 'escapes payload in search page (Finding 7)' do
       get '/admin/search', params: { q: malicious_payload }
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
   end
@@ -110,7 +110,7 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
     it 'escapes in users index (Finding 14)' do
       admin.update!(first_name: malicious_payload, last_name: '')
       get '/admin/users'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       # User name is titleized: <span>alert(1)</span> -> <Span>Alert(1)</Span>
       expect(response.body).to match(/#{Regexp.escape(ERB::Util.html_escape(malicious_payload))}/i)
     end
@@ -118,21 +118,21 @@ RSpec.describe 'Security: XSS Vulnerabilities Fixes', type: :request do
     it 'escapes in roles index (Finding 13)' do
       current_site.user_roles.create!(name: malicious_payload, slug: "malicious-role-#{SecureRandom.hex(4)}")
       get '/admin/user_roles'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
 
     it 'escapes in sites index (Finding 12)' do
       current_site.update!(name: malicious_payload)
       get '/admin/settings/sites'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
 
     it 'escapes in post types index (Finding 11)' do
       current_site.post_types.create!(name: malicious_payload, slug: "malicious-pt-#{SecureRandom.hex(4)}")
       get '/admin/settings/post_types'
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status(:ok)
       expect(response.body).to include(escaped_payload)
     end
   end

--- a/spec/shared_specs/sanitize_attrs.rb
+++ b/spec/shared_specs/sanitize_attrs.rb
@@ -4,7 +4,7 @@ RSpec.shared_examples 'sanitize attrs' do |model:, attrs_to_sanitize:|
   attrs_to_sanitize.each do |attr|
     it 'sanitizes attributes on create, not touching translation tags' do
       attrs_for_creation = { attr => '<!--:en-->"><script>alert(1)</script>' }
-      attrs_for_creation.merge!(site: @site) if defined?(@site)
+      attrs_for_creation[:site] = @site if defined?(@site)
       model_instance = model.create(attrs_for_creation)
 
       expect(model_instance.__send__(attr)).to eql('<!--:en-->"&gt;alert(1)')
@@ -12,7 +12,7 @@ RSpec.shared_examples 'sanitize attrs' do |model:, attrs_to_sanitize:|
 
     it 'sanitizes attributes on update, not touching translation tags' do
       attrs_for_creation = { attr => 'Legit text' }
-      attrs_for_creation.merge!(site: @site) if defined?(@site)
+      attrs_for_creation[:site] = @site if defined?(@site)
       model_instance = model.create(attrs_for_creation)
       model_instance.update(attr => '<!--:en-->"><script>alert(1)</script>')
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ end
 
 # define screenshot errors name
 Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
-  "screenshot_#{example.description.gsub(' ', '-').gsub(%r{^.*/spec/}, '')}"
+  "screenshot_#{example.description.tr(' ', '-').gsub(%r{^.*/spec/}, '')}"
 end
 Capybara::Screenshot.prune_strategy = :keep_last_run
 

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -30,7 +30,7 @@ def admin_sign_in(user = 'admin', pass = 'admin123')
 end
 
 def cama_root_relative_path
-  PluginRoutes.system_info['relative_url_root'].to_s if PluginRoutes.system_info['relative_url_root'].present?
+  PluginRoutes.system_info['relative_url_root'].presence&.to_s
 end
 
 def file_select


### PR DESCRIPTION
**Note**: Rubocop is failing on this PR, because there are fixes for which Rubocop rules are not yet enabled.

This PR addresses Rubocop static analysis issues across the codebase and fixes two open redirect vulnerabilities discovered by Brakeman.

## Security fix (commit 6d78478)

Two unprotected redirects were found in `sessions_controller.rb` and `session_helper.rb` after Rubocop code changes. Both used `params[:return_to]` directly in `redirect_to`, allowing open redirect attacks. Fixed by routing through the existing `safe_redirect_url` helper, which validates that the redirect URL's host matches the current request host. Tests added in `spec/requests/security/open_redirect_session_spec.rb`.

## Rubocop fixes (19 commits)

- **Rails/Output** — Fixed `ThemeGenerator`
- **Rails/FilePath** — Replaced string-based path operations with `Rails.root` / `File.join`
- **Performance/InefficientHashSearch** — Replaced linear hash lookups with `Hash#key?` / `Hash#value?`
- **Performance/RedundantMerge** — Removed unnecessary `Hash#merge` calls
- **Performance/StringReplacement** — Replaced `gsub` with direct assignment where applicable
- **Rails/Presence** — Used `present?` / `blank?` instead of `!obj.nil? && !obj.empty?`
- **RSpecRails/HttpStatus** — Replaced numeric status codes with named symbols
- **Rails/DynamicFindBy** — Replaced `find_by_*` with `find_by(attribute: value)`
- **Rails/FindEach** — Replaced `Model.all.each` with `Model.find_each`
- **Rails/SkipsModelValidations** — Added `# rubocop:disable` for deliberate `touch`, `update_column`, `update_all`
- **Rails/Time / Rails/Date** — Fixed `Time.now` / `Date.today` → `Time.current` / `Date.current`
- **Rails/ApplicationRecord** — Exception for `CamaleonRecord`
- **Style/IfUnlessModifier** — Converted blocks to modifier form
- **Rails/Blank** — Fixed across 53 files
- **Removed dead code** — `cama_draw_timer`, `all_locales_for_routes`, `cama_get_options_html_from_items`, `cama_parse_for_thumb_name`

## Config

- Set `TargetRailsVersion` to `6.1` in `.rubocop.yml`
- Added new Rubocop plugin entries

**Files affected:** 93 files | **+387 / -415**