### PR TITLE
Security bump of gems - Nokogiri to 1.19.3 and others, use Bundler 2.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -109,7 +109,7 @@ GEM
       public_suffix (>= 2.0.2, < 8.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1241.0)
+    aws-partitions (1.1246.0)
     aws-sdk-core (3.246.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -118,10 +118,10 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.123.0)
+    aws-sdk-kms (1.124.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.220.0)
+    aws-sdk-s3 (1.221.0)
       aws-sdk-core (~> 3, >= 3.244.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -185,7 +185,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
@@ -220,7 +220,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.4)
+    json (2.19.5)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -245,7 +245,7 @@ GEM
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
-    minitest (6.0.5)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     mutex_m (0.3.0)
@@ -261,11 +261,11 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-arm64-darwin)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     non-digest-assets (2.6.0)
       activesupport (>= 6.0, < 8.2)
@@ -293,7 +293,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.0)
+    puma (8.0.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -394,7 +394,7 @@ GEM
       rubocop (~> 1.81)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    rubyzip (2.4.1)
+    rubyzip (3.3.0)
     sass-embedded (1.99.0-arm64-darwin)
       google-protobuf (~> 4.31)
     sass-embedded (1.99.0-x86_64-darwin)
@@ -404,11 +404,11 @@ GEM
     sassc-embedded (1.80.8)
       sass-embedded (~> 1.80)
     securerandom (0.4.1)
-    selenium-webdriver (4.23.0)
+    selenium-webdriver (4.43.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
-      rubyzip (>= 1.2.2, < 3.0)
+      rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -418,9 +418,9 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.9.3-arm64-darwin)
-    sqlite3 (2.9.3-x86_64-darwin)
-    sqlite3 (2.9.3-x86_64-linux-gnu)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
     stringio (3.2.0)
     tempfile (0.3.1)
     thor (1.5.0)
@@ -480,4 +480,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.6.5
+   2.7.2


### PR DESCRIPTION
#### Changes:

- action_text-trix 2.1.19 (was 2.1.18)
  - upgrade DOMPurify to 3.4.2 from 3.2.7
  - Addresses several security advisories (see https://github.com/cure53/DOMPurify/security/advisories?state=published)
- aws-partitions 1.1246.0 (was 1.1241.0)
- aws-sdk-kms 1.124.0 (was 1.123.0)
- aws-sdk-s3 1.221.0 (was 1.220.0)
- factory_bot 6.6.0 (was 6.5.6)
- json 2.19.5 (was 2.19.4)
- minitest 6.0.6 (was 6.0.5)
- nokogiri 1.19.3 (x86_64-darwin) (was 1.19.2) fixes:
  - [Nokogiri CSS selector tokenizer has regular expression backtracking](https://github.com/owen2345/camaleon-cms/security/dependabot/89)
  - [Nokogiri XSLT transform has a memory leak](https://github.com/owen2345/camaleon-cms/security/dependabot/90)
- puma 8.0.1 (was 8.0.0)
  - Fix prune_bundler stripping user-configured BUNDLE_* env vars (e.g. BUNDLE_WITHOUT) on re-exec, which caused workers to crash on boot ([https://github.com/puma/puma/pull/3929])
- rubyzip 3.3.0 (was 2.4.1)
- selenium-webdriver 4.43.0 (was 4.23.0)
- sqlite3 2.9.4 (was 2.9.3)
  - Vendored sqlite is updated to [v3.53.1](https://www.sqlite.org/releaselog/3_53_1.html) (from v3.53.0)
