### PR TITLE
Refactor HTML in Ruby code to Rails tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Style & testability:** Refactor HTML in Ruby code to Rails tags [#1172](https://github.com/owen2345/camaleon-cms/pull/1172)
+  - Replaced raw HTML string concatenation with Rails helpers (`content_tag`, `tag`, `image_tag`, `link_to`, `safe_join`, `StringScanner`) across 12 files
+  - Helpers refactored: `nav_menu_helper`, `html_helper`, `short_code_helper`, `captcha_helper`, `menus_helper`, `admin_controller`
+  - Plugins refactored: `authoring_post_helper`, `visibility_post_helper`
+  - Models: use `ActionController::Base.helpers` for default site content generation in `site_default_settings`; fix nil-handling in `fix_post_order`
+  - Added FactoryBot factories for `nav_menu` and `nav_menu_item`
+  - Added full specs for captcha helper, nav menu helper, and post `fix_post_order`
+
 - **Security fix:** Fix two unprotected redirects via `params[:return_to]` in `sessions_controller.rb` and `session_helper.rb` [#1168](https://github.com/owen2345/camaleon-cms/pull/1168)
   - Both used `params[:return_to]` directly in `redirect_to`, allowing open redirect attacks
   - Fixed by routing through the existing `safe_redirect_url` helper
@@ -10,10 +18,8 @@
   - Fixed `Style/IfUnlessModifier`, `Rails/Output`, `Rails/FilePath`, `Performance/InefficientHashSearch`, `Performance/RedundantMerge`, `Performance/StringReplacement`, `Rails/Presence`, `RSpecRails/HttpStatus`, `Rails/DynamicFindBy`, `Rails/FindEach`, `Rails/SkipsModelValidations`, `Rails/Time`, `Rails/Date`, `Rails/ApplicationRecord`, `Rails/Blank`
   - Removed dead code: `cama_draw_timer`, `all_locales_for_routes`, `cama_get_options_html_from_items`, `cama_parse_for_thumb_name`
   - Set `TargetRailsVersion` to `6.1` in `.rubocop.yml`
+
 - **Security fix:** Bump gems — Nokogiri to 1.19.3, action_text-trix, aws-sdk, puma, rubyzip, selenium-webdriver, sqlite3, Bundler 2.7.2 [#1170](https://github.com/owen2345/camaleon-cms/pull/1170)
-  - Nokogiri fixes: CSS selector tokenizer regexp backtracking, XSLT memory leak
-  - puma fix: `prune_bundler` was stripping user-configured `BUNDLE_*` env vars on re-exec
-  - DOMPurify upgraded to 3.4.2 in action_text-trix
 
 - **Fix:** Decorator locale resolution and language context mixing (fixes issue #233), [#1166](https://github.com/owen2345/camaleon-cms/pull/1166)
   - **Phase 1:** Fix locale accessibility and language context mixing
@@ -26,12 +32,13 @@
     - Cleaner code: removed try-rescue overhead, direct I18n.locale fallback
   - Result: Decorators now correctly use site's frontend language in frontend context, admin language in admin context
   - Add 8 comprehensive locale resolution tests
-  - All 388 specs pass, RuboCop: 0 violations
+
 - **Bug fix:** Fix thread-safety issues with `PluginRoutes.reload` causing persistent 500 errors, [#1163](https://github.com/owen2345/camaleon-cms/pull/1163)
   - Remove unnecessary `PluginRoutes.reload` from `plugins#index` and `themes#index` actions
   - Refactor class variables (`@@`) to class instance variables (`@`) with `Monitor` for thread-safe route reloading and cache access
   - Fix `return` in blocks by using `find` instead of `each`
   - Add 27 tests for `PluginRoutes`, `plugins`, and `themes` controllers
+
 - **Optimize PluginRoutes.draw_gems and apps_dir methods** Micro-optimizations for memory consumption and performance, [#1164](https://github.com/owen2345/camaleon-cms/pull/1164)
 
 ## [2.9.2](https://github.com/owen2345/camaleon-cms/tree/2.9.2) (2026-05-01)

--- a/app/apps/plugins/authoring_post/authoring_post_helper.rb
+++ b/app/apps/plugins/authoring_post/authoring_post_helper.rb
@@ -28,7 +28,8 @@ module Plugins
 
         label = tag.label(t('camaleon_cms.admin.table.author'), class: 'control-label')
         select = content_tag(
-          :select, safe_join(plugin_authoring_authors_list(post)), id: 'post_user_id', name: 'post[user_id]',
+          :select, safe_join(plugin_authoring_authors_list(post)),
+          id: 'post_user_id', name: 'post[user_id]',
           class: 'form-control select valid', disabled: disabled, 'aria-invalid' => 'false'
         )
 

--- a/app/apps/plugins/authoring_post/authoring_post_helper.rb
+++ b/app/apps/plugins/authoring_post/authoring_post_helper.rb
@@ -24,27 +24,30 @@ module Plugins
       private
 
       def plugin_authoring_form_html(post)
-        "
-    <div class='form-group'>
-      <label class='control-label'>#{t('camaleon_cms.admin.table.author')}</label>
-      <select id='post_user_id' #{if can?(:edit_other,
-                                          post.post_type) && (can?(:edit_publish,
-                                                                   post.post_type) || !post.published?)
-                                    ''
-                                  else
-                                    'disabled'
-                                  end} name='post[user_id]' class='form-control select valid' aria-invalid='false'>#{plugin_authoring_authors_list(post)}</select>
-    </div>
-    "
+        disabled = !(can?(:edit_other, post.post_type) && (can?(:edit_publish, post.post_type) || !post.published?))
+
+        label = tag.label(t('camaleon_cms.admin.table.author'), class: 'control-label')
+        select = content_tag(
+          :select, safe_join(plugin_authoring_authors_list(post)), id: 'post_user_id', name: 'post[user_id]',
+          class: 'form-control select valid', disabled: disabled, 'aria-invalid' => 'false'
+        )
+
+        tag.div(safe_join([label, select]), class: 'form-group')
       end
 
       def plugin_authoring_authors_list(post)
         author_id = post.new_record? ? cama_current_user.id : post.author.id
-        ret = ''
-        current_site.users.where('role <> ?', 'client').order(:username).each do |user|
-          ret += "<option value='#{user.id}' #{user.id.eql?(author_id) ? 'selected' : ''}>#{user.username.titleize}#{user.fullname.eql?(user.username.titleize) ? '' : " (#{user.fullname})"}</option>"
+
+        current_site.users.where('role <> ?', 'client').order(:username).map do |user|
+          selected = user.id == author_id
+          titleized_username = user.username.titleize
+          display = if user.fullname == titleized_username
+                      titleized_username
+                    else
+                      "#{titleized_username} (#{user.fullname})"
+                    end
+          tag.option(display, value: user.id, selected: selected)
         end
-        ret
       end
     end
   end

--- a/app/apps/plugins/visibility_post/visibility_post_helper.rb
+++ b/app/apps/plugins/visibility_post/visibility_post_helper.rb
@@ -99,57 +99,85 @@ module Plugins
 
       def form_html(post)
         append_asset_libraries({ 'plugin_visibility' => { js: [plugin_asset_path('js/form.js')] } })
-        "
-    <div class='form-group'>
-                  <label class='control-label'>#{t('camaleon_cms.admin.post_type.published_date')}</label>
-                  <div id='published_from' data-locale='#{current_locale}' class='input-group date'>
-                      <input type='text' name='post[published_at]' data-format='yyyy-MM-dd hh:mm:ss' class='form-control ' value='#{@post[:published_at]}' />
-                      <span class='add-on input-group-addon'><span class='glyphicon glyphicon-calendar'></span></span>
-                  </div>
-    </div><!-- calendar for published at -->
 
-    <div id='panel-post-visibility' class='form-group'>
+        html = []
+        html << tag.div(class: 'form-group') do
+          tag.label(t('camaleon_cms.admin.post_type.published_date'), class: 'control-label') +
+            tag.div(id: 'published_from', data: { locale: current_locale }, class: 'input-group date') do
+              tag.input(
+                name: 'post[published_at]', data: { format: 'yyyy-MM-dd hh:mm:ss' },
+                class: 'form-control ', value: @post[:published_at]
+              ) +
+                tag.span(class: 'add-on input-group-addon') { tag.span(class: 'glyphicon glyphicon-calendar') }
+            end
+        end
 
-      <label class='control-label'>#{t('camaleon_cms.admin.table.visibility')}: <span class='visibility_label'></span></label> -
+        html << tag.div(id: 'panel-post-visibility', class: 'form-group') do
+          tag.label(class: 'control-label') do
+            "#{t('camaleon_cms.admin.table.visibility')}: ".html_safe + tag.span(class: 'visibility_label')
+          end << ' - ' <<
+            tag.a(href: '#') { tag.span(t('camaleon_cms.admin.button.edit'), 'aria-hidden': 'true') } <<
+              tag.div(class: 'panel-options hidden') do
+                public_checked = post.visibility.blank? || post.visibility == 'public'
+                private_checked = post.visibility == 'private'
+                password_checked = post.visibility == 'password'
 
-      <a class='edit-visibility' href='#'><span aria-hidden='true'>#{t('camaleon_cms.admin.button.edit')}</span></a>
+                result = []
+                result << tag.label(style: 'display: block;') do
+                  tag.input(
+                    name: 'post[visibility]', class: 'radio', type: 'radio', value: 'public', checked: public_checked
+                  ) + " #{t('camaleon_cms.admin.table.public')}"
+                end
+                result << tag.div
 
-      <div class='panel-options hidden'>
+                result << tag.label(style: 'display: block;') do
+                  tag.input(
+                    name: 'post[visibility]', class: 'radio', type: 'radio', value: 'private', checked: private_checked
+                  ) + " #{t('camaleon_cms.admin.table.private')}"
+                end
 
-        <label style='display: block;'><input type='radio' name='post[visibility]' claass='radio' value='public' #{if post.visibility.blank? || post.visibility == 'public'
-                                                                                                                     "checked=''"
-                                                                                                                   end}> #{t('camaleon_cms.admin.table.public')}</label>
-        <div></div>
+                result << tag.div(style: 'padding-left: 20px;') { groups_list(post) }
 
-        <label style='display: block;'><input type='radio' name='post[visibility]' claass='radio' value='private' #{if post.visibility == 'private'
-                                                                                                                      "checked=''"
-                                                                                                                    end}> #{t('camaleon_cms.admin.table.private')}</label>
-        <div style='padding-left: 20px;'>#{groups_list(post)}</div>
+                result << tag.label(style: 'display: block;') do
+                  tag.input(
+                    name: 'post[visibility]', class: 'radio', type: 'radio',
+                    value: 'password', checked: password_checked
+                  ) + " #{t('camaleon_cms.admin.table.password_protection')}"
+                end
 
-        <label style='display: block;'><input type='radio' name='post[visibility]' claass='radio' value='password' #{if post.visibility == 'password'
-                                                                                                                       "checked=''"
-                                                                                                                     end}> #{t('camaleon_cms.admin.table.password_protection')}</label>
-        <div><input type='text' class='form-control password_field_value' name='post[visibility_value]' value='#{if post.visibility == 'password'
-                                                                                                                   post.visibility_value
-                                                                                                                 end}'></div>
+                result << tag.div do
+                  tag.input(
+                    name: 'post[visibility_value]', class: 'form-control password_field_value', type: 'text',
+                    value: post.visibility == 'password' ? post.visibility_value : nil
+                  )
+                end
 
-        <p>
-          <a class='lnk_hide' href='#'>#{t('camaleon_cms.admin.table.hide')}</a>
-        </p>
-      </div>
-    </div>"
+                result << tag.p { tag.a(t('camaleon_cms.admin.table.hide'), class: 'lnk_hide', href: '#') }
+
+                safe_join(result)
+              end
+        end
+
+        safe_join(html)
       end
 
       def groups_list(post)
-        res = []
-        current_groups = []
-        current_groups = post.visibility_value.split(',') if post.visibility == 'private'
+        current_groups = (post.visibility == 'private' && post.visibility_value) ? post.visibility_value.split(',') : []
+        elements = []
         current_site.user_roles.each do |role|
-          res << "<label><input type='checkbox' name='post_private_groups[]' class='visibility_private_group_item' value='#{role.slug}' #{if current_groups.include?(role.slug.to_s)
-                                                                                                                                            "checked=''"
-                                                                                                                                          end}> #{role.name}</label><br>"
+          checked = current_groups.include?(role.slug.to_s)
+          input = tag.input(
+            type: 'checkbox',
+            name: 'post_private_groups[]',
+            class: 'visibility_private_group_item',
+            value: role.slug,
+            checked: checked
+          )
+          label = tag.label { safe_join([input, " #{role.name}"]) }
+          elements << label
+          elements << tag.br
         end
-        res.join('')
+        safe_join(elements)
       end
     end
   end

--- a/app/apps/plugins/visibility_post/visibility_post_helper.rb
+++ b/app/apps/plugins/visibility_post/visibility_post_helper.rb
@@ -117,52 +117,52 @@ module Plugins
             "#{t('camaleon_cms.admin.table.visibility')}: ".html_safe + tag.span(class: 'visibility_label')
           end << ' - ' <<
             tag.a(href: '#') { tag.span(t('camaleon_cms.admin.button.edit'), 'aria-hidden': 'true') } <<
-              tag.div(class: 'panel-options hidden') do
-                public_checked = post.visibility.blank? || post.visibility == 'public'
-                private_checked = post.visibility == 'private'
-                password_checked = post.visibility == 'password'
+            tag.div(class: 'panel-options hidden') do
+              public_checked = post.visibility.blank? || post.visibility == 'public'
+              private_checked = post.visibility == 'private'
+              password_checked = post.visibility == 'password'
 
-                result = []
-                result << tag.label(style: 'display: block;') do
-                  tag.input(
-                    name: 'post[visibility]', class: 'radio', type: 'radio', value: 'public', checked: public_checked
-                  ) + " #{t('camaleon_cms.admin.table.public')}"
-                end
-                result << tag.div
-
-                result << tag.label(style: 'display: block;') do
-                  tag.input(
-                    name: 'post[visibility]', class: 'radio', type: 'radio', value: 'private', checked: private_checked
-                  ) + " #{t('camaleon_cms.admin.table.private')}"
-                end
-
-                result << tag.div(style: 'padding-left: 20px;') { groups_list(post) }
-
-                result << tag.label(style: 'display: block;') do
-                  tag.input(
-                    name: 'post[visibility]', class: 'radio', type: 'radio',
-                    value: 'password', checked: password_checked
-                  ) + " #{t('camaleon_cms.admin.table.password_protection')}"
-                end
-
-                result << tag.div do
-                  tag.input(
-                    name: 'post[visibility_value]', class: 'form-control password_field_value', type: 'text',
-                    value: post.visibility == 'password' ? post.visibility_value : nil
-                  )
-                end
-
-                result << tag.p { tag.a(t('camaleon_cms.admin.table.hide'), class: 'lnk_hide', href: '#') }
-
-                safe_join(result)
+              result = []
+              result << tag.label(style: 'display: block;') do
+                tag.input(
+                  name: 'post[visibility]', class: 'radio', type: 'radio', value: 'public', checked: public_checked
+                ) + " #{t('camaleon_cms.admin.table.public')}"
               end
+              result << tag.div
+
+              result << tag.label(style: 'display: block;') do
+                tag.input(
+                  name: 'post[visibility]', class: 'radio', type: 'radio', value: 'private', checked: private_checked
+                ) + " #{t('camaleon_cms.admin.table.private')}"
+              end
+
+              result << tag.div(style: 'padding-left: 20px;') { groups_list(post) }
+
+              result << tag.label(style: 'display: block;') do
+                tag.input(
+                  name: 'post[visibility]', class: 'radio', type: 'radio',
+                  value: 'password', checked: password_checked
+                ) + " #{t('camaleon_cms.admin.table.password_protection')}"
+              end
+
+              result << tag.div do
+                tag.input(
+                  name: 'post[visibility_value]', class: 'form-control password_field_value', type: 'text',
+                  value: post.visibility == 'password' ? post.visibility_value : nil
+                )
+              end
+
+              result << tag.p { tag.a(t('camaleon_cms.admin.table.hide'), class: 'lnk_hide', href: '#') }
+
+              safe_join(result)
+            end
         end
 
         safe_join(html)
       end
 
       def groups_list(post)
-        current_groups = (post.visibility == 'private' && post.visibility_value) ? post.visibility_value.split(',') : []
+        current_groups = post.visibility == 'private' && post.visibility_value ? post.visibility_value.split(',') : []
         elements = []
         current_site.user_roles.each do |role|
           checked = current_groups.include?(role.slug.to_s)

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -42,29 +42,29 @@ module CamaleonCms
     # render search results
     # receive params[:q]
     # receive params[:kind]: define de type of the results type (content|category|tag) => default content
-    # if this is receive a param[:ajax], then will render only results view
+    # if this is receiving a param[:ajax], then will render only results view
     def search
       add_breadcrumb I18n.t('camaleon_cms.admin.button.search')
       params[:kind] = 'content' if params[:kind].blank?
       params[:q] = (params[:q] || '').downcase
-      @items = case params[:kind]
-               when 'post_type'
-                 current_site.post_types.where(
-                   "LOWER(#{Cama::PostType.table_name}.name) LIKE ? OR LOWER(#{Cama::PostType.table_name}.slug) LIKE ? OR LOWER(#{Cama::PostType.table_name}.description) LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
-                 )
-               when 'category'
-                 current_site.full_categories.where(
-                   "LOWER(#{Cama::Category.table_name}.name) LIKE ? OR LOWER(#{Cama::Category.table_name}.slug) LIKE ? OR LOWER(#{Cama::Category.table_name}.description) LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
-                 )
-               when 'tag'
-                 current_site.post_tags.where(
-                   "LOWER(#{Cama::PostTag.table_name}.name) LIKE ? OR LOWER(#{Cama::PostTag.table_name}.slug) LIKE ? OR LOWER(#{Cama::PostTag.table_name}.description) LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
-                 )
-               else
-                 current_site.posts.where(
-                   "LOWER(#{Cama::Post.table_name}.title) LIKE ? OR LOWER(#{Cama::Post.table_name}.slug) LIKE ? OR LOWER(#{Cama::Post.table_name}.content_filtered) LIKE ?", "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
-                 )
-               end
+      table_name = case params[:kind]
+        when 'post_type'
+          base_query = current_site.post_types
+          Cama::PostType.table_name
+        when 'category'
+          base_query = current_site.full_categories
+          Cama::Category.table_name
+        when 'tag'
+          base_query = current_site.post_tags
+          Cama::PostTag.table_name
+        else
+          base_query = current_site.posts
+          Cama::Post.table_name
+      end
+      @items = base_query.where(
+        items_sql_by_name(table_name), "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
+      )
+
       @items = @items.paginate(page: params[:page], per_page: current_site.admin_per_page)
     end
 
@@ -97,6 +97,15 @@ module CamaleonCms
 
     def admin_logged_actions
       admin_menus_add_commons if !request.xhr? || params[:cama_ajax_request].blank? # initialize admin sidebar menus
+    end
+
+    def items_sql_by_name(table_name)
+      lower_name = "LOWER(#{table_name}"
+      if table_name == Cama::Post.table_name
+        return "#{lower_name}.title) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.content_filtered) LIKE ?"
+      end
+
+      "#{lower_name}.name) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.description) LIKE ?"
     end
   end
 end

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -48,19 +48,19 @@ module CamaleonCms
       params[:kind] = 'content' if params[:kind].blank?
       params[:q] = (params[:q] || '').downcase
       table_name = case params[:kind]
-        when 'post_type'
-          base_query = current_site.post_types
-          Cama::PostType.table_name
-        when 'category'
-          base_query = current_site.full_categories
-          Cama::Category.table_name
-        when 'tag'
-          base_query = current_site.post_tags
-          Cama::PostTag.table_name
-        else
-          base_query = current_site.posts
-          Cama::Post.table_name
-      end
+                   when 'post_type'
+                     base_query = current_site.post_types
+                     Cama::PostType.table_name
+                   when 'category'
+                     base_query = current_site.full_categories
+                     Cama::Category.table_name
+                   when 'tag'
+                     base_query = current_site.post_tags
+                     Cama::PostTag.table_name
+                   else
+                     base_query = current_site.posts
+                     Cama::Post.table_name
+                   end
       @items = base_query.where(
         items_sql_by_name(table_name), "%#{params[:q]}%", "%#{params[:q]}%", "%#{params[:q]}%"
       )
@@ -101,9 +101,7 @@ module CamaleonCms
 
     def items_sql_by_name(table_name)
       lower_name = "LOWER(#{table_name}"
-      if table_name == Cama::Post.table_name
-        return "#{lower_name}.title) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.content_filtered) LIKE ?"
-      end
+      return "#{lower_name}.title) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.content_filtered) LIKE ?" if table_name == Cama::Post.table_name
 
       "#{lower_name}.name) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.description) LIKE ?"
     end

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -2,33 +2,32 @@ module CamaleonCms
   module Admin
     module MenusHelper
       include CamaleonCms::Admin::BreadcrumbHelper
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::OutputSafetyHelper
 
       def admin_menus_add_commons
-        admin_menu_add_menu('dashboard',
-                            { icon: 'dashboard', title: t('camaleon_cms.admin.sidebar.dashboard'),
-                              url: cama_admin_dashboard_path })
+        admin_menu_add_menu(
+          'dashboard',
+          { icon: 'dashboard', title: t('camaleon_cms.admin.sidebar.dashboard'), url: cama_admin_dashboard_path }
+        )
         items = []
 
         current_site.post_types.eager_load(:metas).visible_menu.find_each do |pt|
           pt = pt.decorate
           items_i = []
-          if can? :posts,
-                  pt
+          if can? :posts, pt
             items_i << { icon: 'list', title: t('camaleon_cms.admin.post_type.all').to_s,
                          url: cama_admin_post_type_posts_path(pt.id) }
           end
-          if can? :create_post,
-                  pt
+          if can? :create_post, pt
             items_i << { icon: 'plus', title: t('camaleon_cms.admin.post_type.add_new', type_title: pt.the_title).to_s,
                          url: new_cama_admin_post_type_post_path(pt.id) }
           end
-          if pt.manage_categories? && (can? :categories,
-                                            pt)
+          if pt.manage_categories? && (can? :categories, pt)
             items_i << { icon: 'folder-open', title: t('camaleon_cms.admin.post_type.categories'),
                          url: cama_admin_post_type_categories_path(pt.id) }
           end
-          if pt.manage_tags? && (can? :post_tags,
-                                      pt)
+          if pt.manage_tags? && (can? :post_tags, pt)
             items_i << { icon: 'tags', title: t('camaleon_cms.admin.post_type.tags'),
                          url: cama_admin_post_type_post_tags_path(pt.id) }
           end
@@ -37,57 +36,91 @@ module CamaleonCms
           end
         end
         if items.present?
-          admin_menu_add_menu('content',
-                              { icon: 'database', title: t('camaleon_cms.admin.sidebar.contents'), url: '', items: items,
-                                datas: "data-intro='#{t('camaleon_cms.admin.intro.content')}' data-position='right' data-wait='600'" })
+          admin_menu_add_menu(
+            'content',
+            {
+              icon: 'database', title: t('camaleon_cms.admin.sidebar.contents'), url: '', items: items,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.content')}' data-position='right' data-wait='600'"
+            }
+          )
         end
         # end
 
-        if can? :manage,
-                :media
-          admin_menu_add_menu('media',
-                              { icon: 'picture-o', title: t('camaleon_cms.admin.sidebar.media'), url: cama_admin_media_path,
-                                datas: "data-intro='#{t('camaleon_cms.admin.intro.media')}' data-position='right'" })
+        if can? :manage, :media
+          admin_menu_add_menu(
+            'media',
+            {
+              icon: 'picture-o', title: t('camaleon_cms.admin.sidebar.media'), url: cama_admin_media_path,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.media')}' data-position='right'"
+            }
+          )
         end
-        if can? :manage,
-                :comments
-          admin_menu_add_menu('comments',
-                              { icon: 'comments', title: t('camaleon_cms.admin.sidebar.comments'), url: cama_admin_comments_path,
-                                datas: "data-intro='#{t('camaleon_cms.admin.intro.comments')}' data-position='right'" })
+        if can? :manage, :comments
+          admin_menu_add_menu(
+            'comments',
+            {
+              icon: 'comments', title: t('camaleon_cms.admin.sidebar.comments'), url: cama_admin_comments_path,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.comments')}' data-position='right'"
+            }
+          )
         end
 
         items = []
-        if can? :manage,
-                :themes
-          items << { icon: 'desktop', title: t('camaleon_cms.admin.sidebar.themes'), url: cama_admin_appearances_themes_path,
-                     datas: "data-intro='#{t('camaleon_cms.admin.intro.themes')}' data-position='right'" }
+        if can? :manage, :themes
+          items << {
+            icon: 'desktop', title: t('camaleon_cms.admin.sidebar.themes'), url: cama_admin_appearances_themes_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.themes')}' data-position='right'"
+          }
         end
-        if can? :manage,
-                :widgets
-          items << { icon: 'archive', title: t('camaleon_cms.admin.sidebar.widgets'),
-                     url: cama_admin_appearances_widgets_main_index_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.widgets')}' data-position='right'" }
+        if can? :manage, :widgets
+          items << {
+            icon: 'archive', title: t('camaleon_cms.admin.sidebar.widgets'),
+            url: cama_admin_appearances_widgets_main_index_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.widgets')}' data-position='right'"
+          }
         end
-        if can? :manage,
-                :nav_menu
-          items << { icon: 'list', title: t('camaleon_cms.admin.sidebar.menus'), url: cama_admin_appearances_nav_menus_path,
-                     datas: "data-intro='#{t('camaleon_cms.admin.intro.menus', image: view_context.asset_path('camaleon_cms/admin/intro/menus.png'))}' data-position='right'" }
+        if can? :manage, :nav_menu
+          intro_menus_data =
+            t('camaleon_cms.admin.intro.menus', image: view_context.asset_path('camaleon_cms/admin/intro/menus.png'))
+          items << {
+            icon: 'list', title: t('camaleon_cms.admin.sidebar.menus'), url: cama_admin_appearances_nav_menus_path,
+            datas: "data-intro='#{intro_menus_data}' data-position='right'"
+          }
         end
-        if can? :manage,
-                :shortcodes
-          items << { icon: 'code', title: t('camaleon_cms.admin.sidebar.shortcodes', default: 'Shortcodes'),
-                     url: cama_admin_settings_shortcodes_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.shortcodes')}' data-position='right'" }
+        if can? :manage, :shortcodes
+          items << {
+            icon: 'code', title: t('camaleon_cms.admin.sidebar.shortcodes', default: 'Shortcodes'),
+            url: cama_admin_settings_shortcodes_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.shortcodes')}' data-position='right'"
+          }
         end
         if items.present?
-          admin_menu_add_menu('appearance',
-                              { icon: 'paint-brush', title: t('camaleon_cms.admin.sidebar.appearance'), url: '', items: items,
-                                datas: "data-intro='#{t('camaleon_cms.admin.intro.appearance')}' data-position='right' data-wait='500'" })
+          admin_menu_add_menu(
+            'appearance',
+            {
+              icon: 'paint-brush', title: t('camaleon_cms.admin.sidebar.appearance'), url: '', items: items,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.appearance')}' data-position='right' data-wait='500'"
+            }
+          )
         end
 
-        if can? :manage,
-                :plugins
-          admin_menu_add_menu('plugins', { icon: 'plug', title: "#{t('camaleon_cms.admin.sidebar.plugins')} <small class='label label-primary'>#{PluginRoutes.all_plugins.clone.delete_if do |plugin|
-                                                                                                                                                   plugin[:domain].present? && !plugin[:domain].split(',').include?(current_site.the_slug)
-                                                                                                                                                 end.size}</small>", url: cama_admin_plugins_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.plugins')}' data-position='right'" })
+        if can? :manage, :plugins
+          plugin_count = PluginRoutes.all_plugins.reject do |plugin|
+            plugin[:domain].present? && !plugin[:domain].split(',').include?(current_site.the_slug)
+          end.size
+          admin_menu_add_menu(
+            'plugins',
+            {
+              icon: 'plug',
+              title: safe_join([
+                t('camaleon_cms.admin.sidebar.plugins'),
+                ' ',
+                content_tag(:small, plugin_count, class: 'label label-primary')
+              ]),
+              url: cama_admin_plugins_path,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.plugins')}' data-position='right'"
+            }
+          )
         end
 
         if can? :manage, :users
@@ -95,37 +128,61 @@ module CamaleonCms
           items << { icon: 'list', title: t('camaleon_cms.admin.users.all_users'), url: cama_admin_users_path }
           items << { icon: 'plus', title: t('camaleon_cms.admin.users.add_user'), url: new_cama_admin_user_path }
           items << { icon: 'group', title: t('camaleon_cms.admin.users.user_roles'), url: cama_admin_user_roles_path }
-          admin_menu_add_menu('users',
-                              { icon: 'users', title: t('camaleon_cms.admin.sidebar.users'), url: '', items: items,
-                                datas: "data-intro='#{t('camaleon_cms.admin.intro.users')}' data-position='right' data-wait='500'" })
+          admin_menu_add_menu(
+            'users',
+            {
+              icon: 'users', title: t('camaleon_cms.admin.sidebar.users'), url: '', items: items,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.users')}' data-position='right' data-wait='500'"
+            }
+          )
         end
 
         items = []
         if can? :manage, :settings
-          items << { icon: 'desktop', title: t('camaleon_cms.admin.sidebar.general_site'),
-                     url: cama_admin_settings_site_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.gral_site')}' data-position='right'" }
+          items << {
+            icon: 'desktop', title: t('camaleon_cms.admin.sidebar.general_site'),
+            url: cama_admin_settings_site_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.gral_site')}' data-position='right'"
+          }
           if current_site.manage_sites?
-            items << { icon: 'cog', title: t('camaleon_cms.admin.sidebar.sites'), url: cama_admin_settings_sites_path,
-                       datas: "data-intro='#{t('camaleon_cms.admin.intro.sites')}' data-position='right'" }
+            items << {
+              icon: 'cog', title: t('camaleon_cms.admin.sidebar.sites'),
+              url: cama_admin_settings_sites_path,
+              datas: "data-intro='#{t('camaleon_cms.admin.intro.sites')}' data-position='right'"
+            }
           end
-          items << { icon: 'files-o', title: t('camaleon_cms.admin.sidebar.content_groups'),
-                     url: cama_admin_settings_post_types_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.post_type')}' data-position='right'" }
-          items << { icon: 'cog', title: t('camaleon_cms.admin.sidebar.custom_fields'),
-                     url: cama_admin_settings_custom_fields_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.custom_fields')}' data-position='right'" }
-          items << { icon: 'language', title: t('camaleon_cms.admin.sidebar.languages'),
-                     url: cama_admin_settings_languages_path, datas: "data-intro='#{t('camaleon_cms.admin.intro.languages')}' data-position='right'" }
+          items << {
+            icon: 'files-o', title: t('camaleon_cms.admin.sidebar.content_groups'),
+            url: cama_admin_settings_post_types_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.post_type')}' data-position='right'"
+          }
+          items << {
+            icon: 'cog', title: t('camaleon_cms.admin.sidebar.custom_fields'),
+            url: cama_admin_settings_custom_fields_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.custom_fields')}' data-position='right'"
+          }
+          items << {
+            icon: 'language', title: t('camaleon_cms.admin.sidebar.languages'),
+            url: cama_admin_settings_languages_path,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.languages')}' data-position='right'"
+          }
         end
 
-        if can? :manage,
-                :theme_settings
-          items << { icon: 'windows', title: t('camaleon_cms.admin.settings.theme_setting', default: 'Theme Settings'),
-                     url: cama_admin_settings_theme_path }
+        if can? :manage, :theme_settings
+          items << {
+            icon: 'windows', title: t('camaleon_cms.admin.settings.theme_setting', default: 'Theme Settings'),
+            url: cama_admin_settings_theme_path
+          }
         end
         return if items.blank?
 
-        admin_menu_add_menu('settings',
-                            { icon: 'cogs', title: t('camaleon_cms.admin.sidebar.settings'), url: '', items: items,
-                              datas: "data-intro='#{t('camaleon_cms.admin.intro.settings')}' data-position='right' data-wait='500'" })
+        admin_menu_add_menu(
+          'settings',
+          {
+            icon: 'cogs', title: t('camaleon_cms.admin.sidebar.settings'), url: '', items: items,
+            datas: "data-intro='#{t('camaleon_cms.admin.intro.settings')}' data-position='right' data-wait='500'"
+          }
+        )
       end
 
       # add menu item to admin menu at the the end
@@ -184,22 +241,28 @@ module CamaleonCms
 
       # draw admin menu as html
       def admin_menu_draw
-        res = []
         @_tmp_menu_parents = []
         menus = _get_url_current
-        menus.each do |menu|
-          res << "<li data-key='#{menu[:key]}' class='#{if menu.key?(:items)
-                                                          'treeview'
-                                                        end} #{if is_active_menu(menu[:key])
-                                                                 'active'
-                                                               end}' #{menu[:datas]}>
-        <a href='#{menu[:url]}'><i class='fa fa-#{menu[:icon]}'></i> <span class=''>#{menu[:title]}</span> #{if menu.key?(:items)
-                                                                                                               '<i class="fa fa-angle-left pull-right"></i>'
-                                                                                                             end}</a>
-        #{_admin_menu_draw(menu[:items]) if menu.key?(:items)}
-      </li>"
-        end
-        res.join
+        safe_join(menus.map do |menu|
+          css_class = +''
+          css_class << 'treeview ' if menu.key?(:items)
+          css_class << 'active' if is_active_menu(menu[:key])
+          css_class.strip!
+          data_attrs = parse_datas(menu[:datas])
+          content_tag(:li, class: css_class.presence, data: data_attrs.presence) do
+            safe_join([
+              content_tag(:a, href: menu[:url]) do
+                safe_join([
+                  content_tag(:i, nil, class: "fa fa-#{menu[:icon]}"),
+                  ' ',
+                  content_tag(:span, menu[:title]),
+                  (content_tag(:i, nil, class: 'fa fa-angle-left pull-right') if menu.key?(:items))
+                ].compact)
+              end,
+              (content_tag(:ul, class: 'treeview-menu') { _admin_menu_draw(menu[:items]) } if menu.key?(:items))
+            ].compact)
+          end
+        end)
       end
 
       private
@@ -235,7 +298,9 @@ module CamaleonCms
           bool = url_path.to_s == _url.to_s && url_path.present?
           # params compare
           if url_query.present?
-            bool &&= Rack::Utils.parse_nested_query(url_query.to_s) == Rack::Utils.parse_nested_query(URI(site_current_url).query.to_s)
+            menu_params = Rack::Utils.parse_nested_query(url_query.to_s)
+            current_params = Rack::Utils.parse_nested_query(URI(site_current_url).query.to_s)
+            bool &&= menu_params == current_params
           end
           if menu.key?(:items)
             resp = _search_in_menus(menu[:items], _url, parent_index + 1)
@@ -251,22 +316,38 @@ module CamaleonCms
       end
 
       def _admin_menu_draw(items)
-        res = []
-        res << "<ul class='treeview-menu'>"
-        items.each_with_index do |item, index|
-          res << "<li class='#{if item.key?(:items)
-                                 'xn-openable'
-                               end} item_#{index + 1} #{if is_active_menu(item[:key])
-                                                          'active'
-                                                        end}' #{item[:datas]}>
-                <a href='#{item[:url]}'><i class='fa fa-#{item[:icon]}'></i> #{item[:title]} #{if item.key?(:items)
-                                                                                                 '<i class="fa fa-angle-left pull-right"></i>'
-                                                                                               end}</a>
-                #{_admin_menu_draw(item[:items]) if item.key?(:items)}
-              </li>"
+        return ''.html_safe if items.blank?
+        content_tag(:ul, class: 'treeview-menu') do
+          safe_join(items.each_with_index.map do |item, index|
+            css_class = +"item_#{index + 1} "
+            css_class << 'xn-openable ' if item.key?(:items)
+            css_class << 'active ' if is_active_menu(item[:key])
+            css_class.strip!
+            data_attrs = parse_datas(item[:datas])
+            content_tag(:li, class: css_class.presence, data: data_attrs.presence) do
+              safe_join([
+                content_tag(:a, href: item[:url]) do
+                  safe_join([
+                    content_tag(:i, nil, class: "fa fa-#{item[:icon]}"),
+                    ' ',
+                    item[:title],
+                    (content_tag(:i, nil, class: 'fa fa-angle-left pull-right') if item.key?(:items))
+                  ].compact)
+                end,
+                (item.key?(:items) ? _admin_menu_draw(item[:items]) : nil)
+              ].compact)
+            end
+          end)
         end
-        res << '</ul>'
-        res.join
+      end
+
+      def parse_datas(datas_string)
+        return {} if datas_string.blank?
+        result = {}
+        datas_string.scan(/data-(\w+)=['"]([^'"]*)['"]/).each do |key, value|
+          result[key.to_sym] = value
+        end
+        result
       end
     end
   end

--- a/app/helpers/camaleon_cms/captcha_helper.rb
+++ b/app/helpers/camaleon_cms/captcha_helper.rb
@@ -27,20 +27,21 @@ module CamaleonCms
     # input_args: attributes for input field
     def cama_captcha_tag(len = 5, img_args = { alt: '' }, input_args = {}, bootstrap_group_mode = false)
       if input_args[:placeholder].blank?
-        input_args[:placeholder] =
-          I18n.t('camaleon_cms.captcha_placeholder',
-                 default: 'Please enter the text of the image')
+        default_text = I18n.t('camaleon_cms.captcha_placeholder', default: 'Please enter the text of the image')
+        input_args[:placeholder] = default_text
       end
-      img_args['onclick'] = "this.src = \"#{cama_captcha_url(len: len)}\"+\"&t=\"+(new Date().getTime());"
-      img = "<img style='cursor: pointer;' src='#{cama_captcha_url(len: len,
-                                                                   t: Time.current.to_i)}' #{img_args.collect do |k, v|
-                                                                                               "#{k}='#{v}'"
-                                                                                             end.join(' ')} />"
-      input = "<input type='text' name='captcha' #{input_args.collect { |k, v| "#{k}='#{v}'" }.join(' ')} />"
+
+      img_args[:onclick] = "this.src = \"#{cama_captcha_url(len: len)}\"+\"&t=\"+(new Date().getTime());"
+      img_args[:style] = 'cursor: pointer;'
+
+      img = image_tag(cama_captcha_url(len: len, t: Time.current.to_i), img_args)
+      input = tag(:input, type: 'text', name: 'captcha', **input_args)
+
       if bootstrap_group_mode
-        "<div class='input-group input-group-captcha'><span class='input-group-btn' style='vertical-align: top;'>#{img}</span>#{input}</div>"
+        span = content_tag(:span, img, class: 'input-group-btn', style: 'vertical-align: top;')
+        content_tag(:div, safe_join([span, input]), class: 'input-group input-group-captcha')
       else
-        "<div class='input-group-captcha'>#{img}#{input}</div>"
+        content_tag(:div, safe_join([img, input]), class: 'input-group-captcha')
       end
     end
 

--- a/app/helpers/camaleon_cms/captcha_helper.rb
+++ b/app/helpers/camaleon_cms/captcha_helper.rb
@@ -27,21 +27,21 @@ module CamaleonCms
     # input_args: attributes for input field
     def cama_captcha_tag(len = 5, img_args = { alt: '' }, input_args = {}, bootstrap_group_mode = false)
       if input_args[:placeholder].blank?
-        default_text = I18n.t('camaleon_cms.captcha_placeholder', default: 'Please enter the text of the image')
-        input_args[:placeholder] = default_text
+        input_args[:placeholder] =
+          I18n.t('camaleon_cms.captcha_placeholder', default: 'Please enter the text of the image')
       end
-
       img_args[:onclick] = "this.src = \"#{cama_captcha_url(len: len)}\"+\"&t=\"+(new Date().getTime());"
       img_args[:style] = 'cursor: pointer;'
 
-      img = image_tag(cama_captcha_url(len: len, t: Time.current.to_i), img_args)
-      input = tag(:input, type: 'text', name: 'captcha', **input_args)
+      helpers = ActionController::Base.helpers
+      img = helpers.image_tag(cama_captcha_url(len: len, t: Time.current.to_i), img_args)
+      input = helpers.tag(:input, type: 'text', name: 'captcha', **input_args)
 
       if bootstrap_group_mode
-        span = content_tag(:span, img, class: 'input-group-btn', style: 'vertical-align: top;')
-        content_tag(:div, safe_join([span, input]), class: 'input-group input-group-captcha')
+        span = helpers.content_tag(:span, img, class: 'input-group-btn', style: 'vertical-align: top;')
+        helpers.content_tag(:div, helpers.safe_join([span, input]), class: 'input-group input-group-captcha')
       else
-        content_tag(:div, safe_join([img, input]), class: 'input-group-captcha')
+        helpers.content_tag(:div, helpers.safe_join([img, input]), class: 'input-group-captcha')
       end
     end
 

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -2,7 +2,7 @@ module CamaleonCms
   module Frontend
     module NavMenuHelper
       # draw nav menu as html list
-      # key: slug for nav menu
+      # key: slug for a nav menu
       # to register this, go to admin -> appearance -> menus
       # (DEPRECATED)
       def get_nav_menu(key = 'main_menu', class_name = 'navigation')
@@ -24,18 +24,27 @@ module CamaleonCms
           sub_container: 'ul', # type of container for sub items
           sub_class: 'dropdown-menu', # class for sub container
           callback_item: ->(args) {},
-          # callback executed for each item (args = { menu_item, link, level, settings, has_children, link_attrs = "", index}).
+          # callback executed for each item:
+          #   (args = { menu_item, link, level, settings, has_children, link_attrs = "", index}).
           #     menu_item: (Object) Menu object
           #     link: (Hash) link data: {link: '', name: ''}
           #     level: (Integer) current level
           #     has_children: (boolean) if this item contain sub menus
           #     settings: (Hash) menu settings
           #     index: (Integer) Index Position of this menu
-          #     link_attrs: (String) Here you can add your custom attrs for current link, sample: id='my_id' data-title='#{args[:link][:name]}'
+          #     link_attrs: (String) Here you can add your custom attrs for current link,
+          #       sample: id='my_id' data-title='#{args[:link][:name]}'
           #     item_container_attrs: (String) Here you can add your custom attrs for link container.
-          # In settings, you can change the values for this item, like after, before, ..:
-          # sample: lambda{|args| args[:settings][:after] = "<span class='caret'></span>" if args[:has_children]; args[:link_attrs] = "id='#{menu_item.id}'";  }
-          # sample: lambda{|args| args[:settings][:before] = "<i class='fa fa-home'></i>" if args[:level] == 0 && args[:index] == 0;  }
+          # In settings, you can change the values for this item, like after, before,...:
+          # sample:
+          #   lambda do |args|
+          #     args[:settings][:after] = "<span class='caret'></span>" if args[:has_children]
+          #     args[:link_attrs] = "id='#{menu_item.id}'"
+          #   end
+          # sample:
+          #   lambda do |args|
+          #     args[:settings][:before] = "<i class='fa fa-home'></i>" if args[:level] == 0 && args[:index] == 0
+          #   end
           before: '', # content before link text
           after: '', # content after link text
           link_current: 'current-link', # class for current menu link
@@ -62,7 +71,7 @@ module CamaleonCms
 
       # draw menu items
       def cama_menu_draw_items(args, nav_menu, level = 0)
-        html = ''
+        items_html = []
         parent_current = false
         index = 0
         nav_menu.eager_load(:metas).find_each do |nav_menu_item|
@@ -70,10 +79,11 @@ module CamaleonCms
           data_nav_item = cama_parse_menu_item(nav_menu_item)
           next if data_nav_item == false
 
-          _is_current = data_nav_item[:current] || site_current_path == data_nav_item[:link] ||
+          _is_current = data_nav_item[:current] ||
+                        site_current_path == data_nav_item[:link] ||
                         site_current_path == data_nav_item[:link].sub('.html', '')
-          has_children = nav_menu_item.have_children? && (args[:levels] == -1 ||
-                         (args[:levels] != -1 && level <= args[:levels]))
+          has_children = nav_menu_item.have_children? &&
+                         (args[:levels] == -1 || (args[:levels] != -1 && level <= args[:levels]))
           r = {
             menu_item: nav_menu_item.decorate,
             link: data_nav_item,
@@ -88,42 +98,68 @@ module CamaleonCms
           _args = r[:settings]
 
           if has_children
-            html_children, current_children = cama_menu_draw_items(args, nav_menu_item.children.reorder(:term_order),
-                                                                   level + 1)
+            html_children, current_children = cama_menu_draw_items(
+              args, nav_menu_item.children.reorder(:term_order), level + 1
+            )
           else
             html_children = ''
             current_children = false
           end
-          parent_current = true if _is_current || current_children
+          parent_current ||= _is_current || current_children
 
-          html += "<#{_args[:item_container]} #{r[:item_container_attrs]} class='#{_args[:item_class]} #{if has_children
-                                                                                                           _args[:item_class_parent]
-                                                                                                         end} #{if _is_current
-                                                                                                                  _args[:item_current].to_s
-                                                                                                                end} #{if current_children
-                                                                                                                         'current-menu-ancestor'
-                                                                                                                       end}'>#{_args[:link_before]}
-                <a #{r[:link_attrs]} #{if nav_menu_item.target.present?
-                                         " target='#{nav_menu_item.target}'"
-                                       end} href='#{data_nav_item[:link]}' class='#{if _is_current
-                                                                                      args[:link_current]
-                                                                                    end} #{if has_children
-                                                                                             _args[:link_class_parent]
-                                                                                           end} #{_args[:link_class]}' #{if has_children
-                                                                                                                           "data-toggle='dropdown'"
-                                                                                                                         end} >#{_args[:before]}#{data_nav_item[:name]}#{_args[:after]}</a> #{_args[:link_after]}
-                #{html_children}
-              </#{_args[:item_container]}>"
+          item_classes = [_args[:item_class]]
+          item_classes << _args[:item_class_parent] if has_children
+          item_classes << _args[:item_current] if _is_current
+          item_classes << 'current-menu-ancestor' if current_children
+          item_class_str = item_classes.reject(&:blank?).join(' ')
+
+          item_attrs = []
+          item_attrs << r[:item_container_attrs] if r[:item_container_attrs].present?
+          item_attrs << "class='#{item_class_str}'" if item_class_str.present?
+          item_attrs_str = item_attrs.reject(&:blank?).join(' ')
+
+          item_open = "<#{_args[:item_container]}"
+          item_open << " #{item_attrs_str}" if item_attrs_str.present?
+          item_open << ">"
+
+          link_attr_parts = []
+          link_attr_parts << r[:link_attrs] if r[:link_attrs].present?
+          link_attr_parts << "target='#{nav_menu_item.target}'" if nav_menu_item.target.present?
+          link_attr_parts << "href='#{data_nav_item[:link]}'"
+          link_classes = []
+          link_classes << args[:link_current] if _is_current
+          link_classes << _args[:link_class_parent] if has_children
+          link_classes << _args[:link_class]
+          link_class_str = link_classes.reject(&:blank?).join(' ')
+          link_attr_parts << "class='#{link_class_str}'" if link_class_str.present?
+          link_attr_parts << "data-toggle='dropdown'" if has_children
+          link_attrs_str = link_attr_parts.reject(&:blank?).join(' ')
+
+          link_inner = [_args[:before], data_nav_item[:name], _args[:after]].reject(&:blank?).join('')
+          link_tag = "<a #{link_attrs_str}>#{link_inner}</a>"
+
+          item_inner = [
+            _args[:link_before],
+            link_tag,
+            _args[:link_after],
+            html_children
+          ].reject(&:blank?).join('')
+          item_html = "#{item_open}#{item_inner}</#{_args[:item_container]}>"
+          items_html << item_html
+
           index += 1
         end
 
         if level == 0
-          html
+          safe_join(items_html)
         else
-          html = "<#{args[:sub_container]} class='#{args[:sub_class]} #{if parent_current
-                                                                          "parent-#{args[:item_current]}"
-                                                                        end} level-#{level}'>#{html}</#{args[:sub_container]}>"
-          [html, parent_current]
+          sub_classes = [args[:sub_class]]
+          sub_classes << "parent-#{args[:item_current]}" if parent_current
+          sub_classes << "level-#{level}"
+          sub_container_class = sub_classes.reject(&:blank?).join(' ')
+          sub_html = "<#{args[:sub_container]} class='#{sub_container_class}'>" \
+                     "#{safe_join(items_html)}</#{args[:sub_container]}>"
+          [sub_html, parent_current]
         end
       end
 
@@ -139,9 +175,8 @@ module CamaleonCms
           data_nav_item = cama_parse_menu_item(nav_menu_item)
           next if data_nav_item == false
 
-          _is_current = data_nav_item[:current] || site_current_path == data_nav_item[:link] || site_current_path == data_nav_item[:link].sub(
-            '.html', ''
-          )
+          _is_current = data_nav_item[:current] || site_current_path == data_nav_item[:link] ||
+                        site_current_path == data_nav_item[:link].sub('.html', '')
           has_children = nav_menu_item.have_children?
           has_children = false if max_levels > 0 && max_levels == internal_level
           data_nav_item[:label] = data_nav_item[:name]
@@ -157,14 +192,15 @@ module CamaleonCms
           }.merge!(data_nav_item.except(:current, :name, :link))
 
           if has_children
-            r[:children], _is_current_parent, r[:levels] = cama_menu_parse_items(nav_menu_item.children, max_levels,
-                                                                                 internal_level + 1)
+            r[:children], _is_current_parent, r[:levels] =
+              cama_menu_parse_items(nav_menu_item.children, max_levels, internal_level + 1)
             if _is_current_parent
               is_current_parent = true
               r[:current_parent] = true
             end
             r[:levels] = r[:levels] + 1
           end
+
           is_current_parent = true if r[:current_item]
           levels << r[:levels]
           res << r
@@ -240,7 +276,11 @@ module CamaleonCms
             result = { link: nav_menu_item.url.to_s.translate, name: nav_menu_item.name.to_s.translate, current: false }
             # permit to customize or mark as current menu
             # _args: (HASH) {menu_item: Model Menu Item, parsed_menu: Parsed Menu }
-            #   Sample parsed_menu: {link: "url of the link", name: "Text of the menu", current: Boolean (true => is current menu, false => not current menu item)}
+            #   Sample parsed_menu:
+            # {
+            #   link: "url of the link", name: "Text of the menu",
+            #   current: Boolean (true => is current menu, false => not current menu item)
+            # }
             unless is_from_backend
               result[:link] = cama_root_path if result[:link] == 'root_url'
               result[:link] = site_current_path if site_current_path == "#{current_site.the_path}#{result[:link]}"
@@ -251,11 +291,15 @@ module CamaleonCms
             end
           else
             # permit to build custom menu items registered as Custom Menu by hook "nav_menu_custom"
-            # sample: def my_parse_custom_menu_item_listener(args);
+            # sample:
+            # def my_parse_custom_menu_item_listener(args)
             #   if args[:menu_item].kind == 'MyModelClass'
             #     my_model = MyModelClass.find(args[:menu_item].url)
-            #     res = {name: my_model.name, url_edit: my_model_edit_url(id: my_model.id), link: my_model_public_url(id: my_model.id)}
-            #     res[:current] = site_current_path == my_model_public_url(id: my_model.id) unless args[:is_from_backend]
+            #     res = {
+            #       name: my_model.name, url_edit: my_model_edit_url(id: my_model.id),
+            #       link: my_model_url(id: my_model.id)
+            #     }
+            #     res[:current] = site_current_path == my_model_url(id: my_model.id) unless args[:is_from_backend]
             #     args[:parsed_menu] = res
             #   end
             # end
@@ -264,17 +308,19 @@ module CamaleonCms
             result = hook_args[:parsed_menu]
           end
         rescue StandardError => e
-          Rails.logger.error "Camaleon CMS - Menu Item Not Found => Skipped menu for: #{e.message} (#{nav_menu_item.inspect})".cama_log_style(:red)
+          Rails.logger.error(
+            "Camaleon CMS - Menu Item Not Found => Skipped menu for: #{e.message} (#{nav_menu_item.inspect})"
+              .cama_log_style(:red)
+          )
         end
 
-        # permit to customize data, like: current, title, ... of parsed menu item or skip menu item by assigning false into :parsed_menu
-        if is_from_backend
-          result
-        else
-          _args = { menu_item: nav_menu_item, parsed_menu: result }
-          hooks_run('on_render_front_menu_item', _args)
-          _args[:parsed_menu]
-        end
+        # permit customizing data, like: current, title, ... of parsed menu item or
+        # skip menu item by assigning false into :parsed_menu
+        return result if is_from_backend
+
+        _args = { menu_item: nav_menu_item, parsed_menu: result }
+        hooks_run('on_render_front_menu_item', _args)
+        _args[:parsed_menu]
       end
     end
   end

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -120,7 +120,7 @@ module CamaleonCms
 
           item_open = "<#{_args[:item_container]}"
           item_open << " #{item_attrs_str}" if item_attrs_str.present?
-          item_open << ">"
+          item_open << '>'
 
           link_attr_parts = []
           link_attr_parts << r[:link_attrs] if r[:link_attrs].present?
@@ -145,7 +145,7 @@ module CamaleonCms
             html_children
           ].reject(&:blank?).join('')
           item_html = "#{item_open}#{item_inner}</#{_args[:item_container]}>"
-          items_html << item_html
+          items_html << item_html.html_safe
 
           index += 1
         end

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -29,9 +29,17 @@ module CamaleonCms
 
     alias add_asset_library cama_load_libraries
 
-    # add custom asset libraries (js, css or both) for the current request, also you can add extra css or js files for existent libraries
-    # sample: (add new library)
-    #   append_asset_libraries({"my_library_key"=> { js: [plugin_asset("js/my_js"), "plugins/myplugin/assets/js/my_js2"], css: [plugin_asset("css/my_css"), "plugins/myplugin/assets/css/my_css2"] }})
+    # add custom asset libraries (js, css or both) for the current request, also you can add extra css or js files for
+    # existent libraries
+    # sample: (add a new library)
+    #   append_asset_libraries(
+    #     {
+    #       "my_library_key"=> {
+    #         js: [plugin_asset("js/my_js"), "plugins/myplugin/assets/js/my_js2"],
+    #         css: [plugin_asset("css/my_css"), "plugins/myplugin/assets/css/my_css2"]
+    #       }
+    #     }
+    #   )
     # sample: (update existent library)
     #   append_asset_libraries({"colorpicker"=>{js: [plugin_asset("js/my_custom_js")] } })
     # return nil
@@ -90,11 +98,13 @@ module CamaleonCms
       "#{args[:css_html]}\n#{args[:js_html]}\n#{@_assets_content.join('').html_safe}"
     end
 
-    # create a html tooltip to include anywhere
+    # create an HTML tooltip to include anywhere
     # text: text of the tooltip
     # location: location of the tooltip (left | right | top |bottom)
     def cama_html_tooltip(text = 'Tooltip', location = 'left')
-      "<a href='javascript:;' title='#{text}' data-toggle='tooltip' data-placement='#{location}'><i class='fa fa-info-circle'></i></a>"
+      tag.a(href: 'javascript:;', title: text, data: { toggle: 'tooltip', placement: location }) do
+        tag.i(class: 'fa fa-info-circle')
+      end
     end
 
     private

--- a/app/helpers/camaleon_cms/short_code_helper.rb
+++ b/app/helpers/camaleon_cms/short_code_helper.rb
@@ -10,70 +10,74 @@ module CamaleonCms
                 Don't forget to create and copy the shortcode of your widgets in appearance -> widgets
                 Sample: [widget widget_key]")
 
-      shortcode_add('load_libraries',
-                    lambda { |attrs, args|
-                      return args[:shortcode] if attrs.blank?
+      shortcode_add(
+        'load_libraries',
+        lambda do |attrs, args|
+          return args[:shortcode] if attrs.blank?
 
-                      cama_load_libraries(*attrs['data'].to_s.split(','))
-                      ''
-                    },
-                    "Permit to load libraries on demand, sample: [load_libraries data='datepicker,tinymce']")
+          cama_load_libraries(*attrs['data'].to_s.split(','))
+          ''
+        end,
+        "Permit to load libraries on demand, sample: [load_libraries data='datepicker,tinymce']"
+      )
+      # rubocop:disable Layout/LineLength
+      shortcode_add(
+        'asset',
+        lambda do |attrs, args|
+          return args[:shortcode] if attrs.blank?
 
-      shortcode_add('asset',
-                    lambda { |attrs, args|
-                      return args[:shortcode] if attrs.blank?
+          url = ActionController::Base.helpers.asset_url(attrs['file'])
+          if attrs['image'].present?
+            ActionController::Base.helpers.image_tag(attrs['file'], class: attrs['class'], style: attrs['style'])
+          else
+            url
+          end
+        end,
+        "Permit to generate an asset url (
+        add file='' asset file path,
+        add as_path='true' to generate only the path and not the full url,
+        add class='my_class' to setup image class,
+        add style='height: 100px; width: 200px;...' to setup image style,
+        add image='true' to generate the image tag with this url),
+      sample: <img src=\"[asset as_path='true' file='themes/my_theme/assets/img/signature.png']\" /> or [asset image='true' file='themes/my_theme/assets/img/signature.png' style='height: 50px;']"
+      )
 
-                      url = ActionController::Base.helpers.asset_url(attrs['file'])
-                      if attrs['image'].present?
-                        ActionController::Base.helpers.image_tag(attrs['file'], class: attrs['class'],
-                                                                                style: attrs['style'])
-                      else
-                        url
-                      end
-                    },
-                    "Permit to generate an asset url (
-                    add file='' asset file path,
-                    add as_path='true' to generate only the path and not the full url,
-                    add class='my_class' to setup image class,
-                    add style='height: 100px; width: 200px;...' to setup image style,
-                    add image='true' to generate the image tag with this url),
-                  sample: <img src=\"[asset as_path='true' file='themes/my_theme/assets/img/signature.png']\" /> or [asset image='true' file='themes/my_theme/assets/img/signature.png' style='height: 50px;']")
-
-      shortcode_add('data',
-                    lambda { |attrs, args|
-                      attrs.present? ? cama_shortcode_data(attrs, args) : args[:shortcode]
-                    },
-                    "Permit to generate specific data of a post.
-                  Attributes:
-                    object: (String, defaut post) Model name: post | posttype | category | posttag | site | user |theme | navmenu
-                    id: (Integer) Post id
-                    key: (String) Post slug
-                    field: (String) Custom field key, you can add render_field='true' to render field as html element, also you can add index=2 to indicate the value in position 2 for multitple values
-                    attrs: (String) attribute name
-                            post: title | created_at | excerpt | url | link | thumb | updated_at | author_name | author_url | content
-                            posttype: title | created_at | excerpt | url | link | thumb | updated_at
-                            category: title | created_at | excerpt | url | link | thumb | updated_at
-                            posttag: title | created_at | excerpt | url | link | thumb | updated_at
-                            site: title | created_at | excerpt | url | link | thumb | updated_at
-                            user: title | created_at | excerpt | url | link | thumb | updated_at
-                            theme: title | created_at | excerpt | url | link | thumb | updated_at
-                            navmenu: title | created_at | excerpt | url | link | thumb | updated_at
-                    Note: If id and key is not present, then will be rendered for current model
-                  Sample:
-                    [data id='122' attr='title'] ==> return the title of post with id = 122
-                    [data key='contact' attr='url'] ==> return the url of post with slug = contact
-                    [data key='contact' attr='link'] ==> return the link with title as text of the link of post with slug = contact
-                    [data object='site' attr='url'] ==> return the url of currrent site
-                    [data key='page' object='posttype' attr='url'] ==> return the url of post_type with slug = page
-                    [data field=icon index=2] ==> return the second value (multiple values) for this custom field with key=icon of current object
-                    [data key='contact' field='sub_title'] ==> return the value of the custom_field with key=sub_title registered for post.slug = contact
-                    [data object='site' field='sub_title'] ==> return the value of the custom_field with key=sub_title registered for current_site")
+      shortcode_add(
+        'data',
+        lambda { |attrs, args| attrs.present? ? cama_shortcode_data(attrs, args) : args[:shortcode] },
+          "Permit to generate specific data of a post.
+        Attributes:
+          object: (String, defaut post) Model name: post | posttype | category | posttag | site | user |theme | navmenu
+          id: (Integer) Post id
+          key: (String) Post slug
+          field: (String) Custom field key, you can add render_field='true' to render field as html element, also you can add index=2 to indicate the value in position 2 for multitple values
+          attrs: (String) attribute name
+                  post: title | created_at | excerpt | url | link | thumb | updated_at | author_name | author_url | content
+                  posttype: title | created_at | excerpt | url | link | thumb | updated_at
+                  category: title | created_at | excerpt | url | link | thumb | updated_at
+                  posttag: title | created_at | excerpt | url | link | thumb | updated_at
+                  site: title | created_at | excerpt | url | link | thumb | updated_at
+                  user: title | created_at | excerpt | url | link | thumb | updated_at
+                  theme: title | created_at | excerpt | url | link | thumb | updated_at
+                  navmenu: title | created_at | excerpt | url | link | thumb | updated_at
+          Note: If id and key is not present, then will be rendered for current model
+        Sample:
+          [data id='122' attr='title'] ==> return the title of post with id = 122
+          [data key='contact' attr='url'] ==> return the url of post with slug = contact
+          [data key='contact' attr='link'] ==> return the link with title as text of the link of post with slug = contact
+          [data object='site' attr='url'] ==> return the url of currrent site
+          [data key='page' object='posttype' attr='url'] ==> return the url of post_type with slug = page
+          [data field=icon index=2] ==> return the second value (multiple values) for this custom field with key=icon of current object
+          [data key='contact' field='sub_title'] ==> return the value of the custom_field with key=sub_title registered for post.slug = contact
+          [data object='site' field='sub_title'] ==> return the value of the custom_field with key=sub_title registered for current_site"
+      )
     end
+    # rubocop:enable Layout/LineLength
 
     # add shortcode
     # key: shortcode key
-    # template: template to render, if nil will render "shortcode_templates/<key>"
-    # Also can be a function to execute that instead a render, sample: lambda{|attrs, args| return "my custom content"; }
+    # template: template to render, if nil renders "shortcode_templates/<key>"
+    # Also can be a function to execute that instead a render, sample: lambda{|attrs, args| return "my custom content" }
     # descr: description for shortcode
     def shortcode_add(key, template = nil, descr = '')
       @_shortcodes << key
@@ -88,7 +92,7 @@ module CamaleonCms
       @_shortcodes_template[key] = template
     end
 
-    # delete shortcode
+    # Delete the shortcode
     # key: chortcode key to delete
     def shortcode_delete(key)
       @_shortcodes.delete(key)
@@ -122,8 +126,11 @@ module CamaleonCms
     # text: text that contain the shortcode
     # key: shortcode key
     # template: template to render, if nil this will render default render file
-    # Also can be a function to execute that instead a render, sample: lambda{|attrs, args| return "my custom content"; }
-    # render_shortcode("asda dasdasdas[owen a='1'] [bbb] sdasdas dasd as das[owen a=213]", "owen", lambda{|attrs, args| puts attrs; return "my test"; })
+    # Also can be a function to execute that instead a render, sample: lambda{|attrs, args| return "my custom content" }
+    # render_shortcode(
+    #   "asda dasdasdas[owen a='1'] [bbb] sdasdas dasd as das[owen a=213]", "owen",
+    #   lambda { |attrs, args| puts attrs; return "my test"; }
+    # )
     def render_shortcode(text, key, template = nil)
       text.scan(/#{cama_reg_shortcode(key)}/).each do |item|
         text = _cama_replace_shortcode(text, item, {}, template)
@@ -154,7 +161,8 @@ module CamaleonCms
     # if empty, codes will be replaced with all registered shortcodes
     # Return: (String) reg expression string
     def cama_reg_shortcode(codes = nil)
-      # "(\\[(#{codes || (@_shortcodes || []).join("|")})(\s|\\]){0}(.*?)\\])" # doesn't support for similar names, like: [media] and [media_gallery]
+      # doesn't support for similar names, like: [media] and [media_gallery]
+      # "(\\[(#{codes || (@_shortcodes || []).join("|")})(\s|\\]){0}(.*?)\\])"
       "(\\[(#{codes || (@_shortcodes || []).join('|')})((\s)((?!\\]).)*|)\\])"
     end
 
@@ -174,12 +182,43 @@ module CamaleonCms
       res = {}
       return res if text.blank?
 
-      text.scan(/(\w+)\s*=\s*"([^"]*)"(?:\s|$)|(\w+)\s*=\s*'([^']*)'(?:\s|$)|(\w+)\s*=\s*([^\s'"]+)(?:\s|$)|"([^"]*)"(?:\s|$)|(\S+)(?:\s|$)/).each do |item|
-        item.each_with_index do |c, index|
-          if c.present?
-            res[c] = item[index + 1]
-            break
-          end
+      # StringScanner tokenizes the text by moving through it sequentially,
+      # matching patterns and advancing the scan pointer with each successful scan.
+      scanner = StringScanner.new(text)
+
+      # Continue parsing until we reach the end of the string.
+      until scanner.eos?
+        # Skip any leading whitespace before attempting to match a token.
+        scanner.skip(/\s+/)
+        break if scanner.eos?
+
+        # Attempt to match a key=value attribute (e.g., width="100", class='foo', height=200).
+        # Capture group 1 extracts the attribute name (word characters before =).
+        if scanner.scan(/(\w+)\s*=\s*/)
+          key = scanner[1]
+
+          # Determine the attribute value based on its quoting style:
+          # 1. Double-quoted string: "value" → extract content between quotes
+          # 2. Single-quoted string: 'value' → extract content between quotes
+          # 3. Unquoted value: any characters except whitespace or quotes
+          val = if scanner.scan(/"([^"]*)"/)
+                  scanner[1]
+                elsif scanner.scan(/'([^']*)'/)
+                  scanner[1]
+                elsif scanner.scan(/([^\s'"]+)/)
+                  scanner[1]
+                end
+
+          # Store the parsed key-value pair in the result hash.
+          res[key] = val
+
+        # If no key=value pattern matched, this is a standalone value (no assignment).
+        # Match either a double-quoted string or a bare unquoted token.
+        elsif scanner.scan(/"([^"]*)"|(\S+)/)
+          # Use the appropriate capture group: group 1 for quoted, group 2 for unquoted.
+          val = scanner[1] || scanner[2]
+          # Standalone values are stored with a nil key reference.
+          res[val] = nil
         end
       end
       res

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -250,7 +250,7 @@ module CamaleonCms
     # calculate a post order when it is empty
     def fix_post_order
       last_post = post_type.posts.where.not(id: nil).last
-      self.post_order = last_post.present? ? last_post.post_order + 1 : 1
+      self.post_order = last_post.present? ? (last_post.post_order || 0) + 1 : 1
     end
   end
 end

--- a/app/models/concerns/camaleon_cms/site_default_settings.rb
+++ b/app/models/concerns/camaleon_cms/site_default_settings.rb
@@ -4,10 +4,20 @@ module CamaleonCms
     # default structure for each new site
     def default_settings
       default_post_type = [
-        { name: 'Post', description: 'Posts',
-          options: { has_category: true, has_tags: true, not_deleted: true, has_summary: true, has_content: true, has_comments: true, has_picture: true, has_template: true } },
-        { name: 'Page', description: 'Pages',
-          options: { has_category: false, has_tags: false, not_deleted: true, has_summary: false, has_content: true, has_comments: false, has_picture: true, has_template: true, has_layout: true } }
+        {
+          name: 'Post', description: 'Posts',
+          options: {
+            has_category: true, has_tags: true, not_deleted: true, has_summary: true, has_content: true,
+            has_comments: true, has_picture: true, has_template: true
+          }
+        },
+        {
+          name: 'Page', description: 'Pages',
+          options: {
+            has_category: false, has_tags: false, not_deleted: true, has_summary: false, has_content: true,
+            has_comments: false, has_picture: true, has_template: true, has_layout: true
+          }
+        }
       ]
       default_post_type.each do |pt|
         post_types.create({ name: pt[:name], slug: pt[:name].to_s.parameterize, description: pt[:description],
@@ -21,11 +31,84 @@ module CamaleonCms
           if pt.slug == 'post'
             title = 'Sample Post'
             slug = 'sample-post'
-            content = '<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pharetra ut augue in posuere. Nulla non malesuada dui. Sed egestas tortor ut purus tempor sodales. Duis non sollicitudin nulla, quis mollis neque. Integer sit amet augue ac neque varius auctor. Vestibulum malesuada leo leo, at semper libero efficitur nec. Etiam semper nisi ac nisi ullamcorper, sed tincidunt purus elementum. Mauris ac congue nibh. Quisque pretium eget leo nec suscipit. </p> <p> Vestibulum ultrices orci ut congue interdum. Morbi dolor nunc, imperdiet vel risus semper, tempor dapibus urna. Phasellus luctus pharetra enim quis volutpat. Integer tristique urna nec malesuada ullamcorper. Curabitur dictum, lectus id ultrices rhoncus, ante neque auctor erat, ut sodales nisi odio sit amet lorem. In hac habitasse platea dictumst. Quisque orci orci, hendrerit at luctus tristique, lobortis in diam. Curabitur ligula enim, rhoncus ut vestibulum a, consequat sit amet nisi. Aliquam bibendum fringilla ultrices. Aliquam erat volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; In justo mi, congue in rhoncus lobortis, facilisis in est. Nam et rhoncus purus. </p> <p> Sed sagittis auctor lectus at rutrum. Morbi ultricies felis mi, ut scelerisque augue facilisis eu. In molestie quam ex. Quisque ut sapien sed odio tempus imperdiet. In id accumsan massa. Morbi quis nunc ullamcorper, interdum enim eu, finibus purus. Vestibulum ac fermentum augue, at tempus ante. Aliquam ultrices, purus ut porttitor gravida, dui augue dignissim massa, ac tempor ante dolor at arcu. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Suspendisse placerat risus est, eget varius mi ultricies in. Duis non odio ut felis dapibus eleifend. In fringilla enim lobortis placerat efficitur. </p> <p> Nulla sodales faucibus urna, quis viverra dolor facilisis sollicitudin. Aenean ac egestas nibh. Nam non tortor eget nibh scelerisque fermentum. Etiam ornare, nunc ut luctus mollis, ante dolor consectetur augue, non scelerisque odio est a nulla. Nullam cursus egestas nulla, nec commodo nibh suscipit ut. Mauris ut felis sem. Aenean at mi at nisi dictum blandit sit amet at erat. Etiam eget lobortis tellus. Curabitur in commodo arcu, at vehicula tortor. </p>'
+            content_parts = []
+            content_parts << helpers.content_tag(
+              :p, "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer pharetra ut augue in posuere. " \
+                  "Nulla non malesuada dui. Sed egestas tortor ut purus tempor sodales. " \
+                  "Duis non sollicitudin nulla, quis mollis neque. Integer sit amet augue ac neque varius auctor. " \
+                  "Vestibulum malesuada leo leo, at semper libero efficitur nec. " \
+                  "Etiam semper nisi ac nisi ullamcorper, sed tincidunt purus elementum. " \
+                  "Mauris ac congue nibh. Quisque pretium eget leo nec suscipit."
+            )
+            content_parts << helpers.content_tag(
+              :p, "Vestibulum ultrices orci ut congue interdum. " \
+                   "Morbi dolor nunc, imperdiet vel risus semper, tempor dapibus urna. " \
+                   "Phasellus luctus pharetra enim quis volutpat. Integer tristique urna nec malesuada ullamcorper. " \
+                   "Curabitur dictum, lectus id ultrices rhoncus, ante neque auctor erat, " \
+                   "ut sodales nisi odio sit amet lorem. In hac habitasse platea dictumst. " \
+                   "Quisque orci orci, hendrerit at luctus tristique, lobortis in diam. " \
+                   "Curabitur ligula enim, rhoncus ut vestibulum a, consequat sit amet nisi. " \
+                   "Aliquam bibendum fringilla ultrices. Aliquam erat volutpat. " \
+                   "Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; " \
+                   "In justo mi, congue in rhoncus lobortis, facilisis in est. Nam et rhoncus purus."
+            )
+            content_parts << helpers.content_tag(
+              :p, "Sed sagittis auctor lectus at rutrum. " \
+                  "Morbi ultricies felis mi, ut scelerisque augue facilisis eu. In molestie quam ex. " \
+                  "Quisque ut sapien sed odio tempus imperdiet. In id accumsan massa. " \
+                  "Morbi quis nunc ullamcorper, interdum enim eu, finibus purus. " \
+                  "Vestibulum ac fermentum augue, at tempus ante. " \
+                  "Aliquam ultrices, purus ut porttitor gravida, dui augue dignissim massa, " \
+                  "ac tempor ante dolor at arcu. " \
+                  "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. " \
+                  "Suspendisse placerat risus est, eget varius mi ultricies in. " \
+                  "Duis non odio ut felis dapibus eleifend. In fringilla enim lobortis placerat efficitur."
+            )
+            content_parts << helpers.content_tag(
+              :p, "Nulla sodales faucibus urna, quis viverra dolor facilisis sollicitudin. Aenean ac egestas nibh. " \
+                  "Nam non tortor eget nibh scelerisque fermentum. " \
+                  "Etiam ornare, nunc ut luctus mollis, ante dolor consectetur augue, " \
+                  "non scelerisque odio est a nulla. Nullam cursus egestas nulla, nec commodo nibh suscipit ut. " \
+                  "Mauris ut felis sem. Aenean at mi at nisi dictum blandit sit amet at erat. " \
+                  "Etiam eget lobortis tellus. Curabitur in commodo arcu, at vehicula tortor."
+            )
+            content = helpers.safe_join(content_parts)
           else
             title = 'Welcome'
             slug = 'welcome'
-            content = "<p style='text-align: center;'><img width='155' height='155' src='https://camaleon.website/media/132/logo2.png' alt='logo' /></p><p><strong>Camaleon CMS</strong>&nbsp;is a free and open-source tool and a fexible content management system (CMS) based on <a href='https://rubyonrails.org'>Ruby on Rails</a>.</p> <p>With Camaleon you can do the following:</p> <ul> <li>Create instantly a lot of sites&nbsp;in the same installation</li> <li>Manage your content information in several languages</li> <li>Extend current functionality by&nbsp;plugins (MVC structure and no more echo or prints anywhere)</li> <li>Create or install different themes for each site</li> <li>Create your own structure without coding anything (adapt Camaleon as you want&nbsp;and not you for Camaleon)</li> <li>Create your store and start to sell your products using our plugins</li> <li>Avoid web attacks</li> <li>Compare the speed and enjoy the speed of your new Camaleon site</li> <li>Customize or create your themes for mobile support</li> <li>Support&nbsp;more visitors at the same time</li> <li>Manage your information with a panel like wordpress&nbsp;</li> <li>All urls are oriented for SEO</li> <li>Multiples roles of users</li> </ul>"
+            welcome_parts = []
+            logo_img = helpers
+              .image_tag('https://camaleon.website/media/132/logo2.png', width: 155, height: 155, alt: 'logo')
+            welcome_parts << helpers.content_tag(:p, logo_img, style: 'text-align: center;')
+            cms_strong = helpers.content_tag(:strong, 'Camaleon CMS')
+            rails_link = helpers.link_to('Ruby on Rails', 'https://rubyonrails.org')
+            part2_text = helpers.safe_join(
+              [
+                cms_strong,
+                ' is a free and open-source tool and a fexible content management system (CMS) based on ',
+                rails_link
+              ]
+            )
+            welcome_parts << helpers.content_tag(:p, part2_text)
+            welcome_parts << helpers.content_tag(:p, 'With Camaleon you can do the following:')
+            li_texts = [
+              'Create instantly a lot of sites in the same installation',
+              'Manage your content information in several languages',
+              'Extend current functionality by plugins (MVC structure and no more echo or prints anywhere)',
+              'Create or install different themes for each site',
+              'Create your own structure without coding anything (adapt Camaleon as you want and not you for Camaleon)',
+              'Create your store and start to sell your products using our plugins',
+              'Avoid web attacks',
+              'Compare the speed and enjoy the speed of your new Camaleon site',
+              'Customize or create your themes for mobile support',
+              'Support more visitors at the same time',
+              'Manage your information with a panel like wordpress ',
+              'All urls are oriented for SEO',
+              'Multiples roles of users'
+            ]
+            li_tags = li_texts.map { |text| helpers.content_tag(:li, text) }
+            welcome_parts << helpers.content_tag(:ul, helpers.safe_join(li_tags))
+            content = helpers.safe_join(welcome_parts)
           end
           user = users.admin_scope.first
           if user.blank?
@@ -70,8 +153,8 @@ module CamaleonCms
         user_role.set_meta("_post_type_#{id}", d || {})
       end
 
-      user_role = user_roles.where({ slug: 'contributor' }).first_or_create({ name: 'Contributor',
-                                                                              description: 'Contributor Role' })
+      user_role = user_roles.where({ slug: 'contributor' })
+                            .first_or_create({ name: 'Contributor', description: 'Contributor Role' })
       if user_role.valid?
         d = {}
         if post_type.present?
@@ -89,13 +172,18 @@ module CamaleonCms
 
       return if post_type.present?
 
-      user_role = user_roles.where({ slug: 'client',
-                                     term_group: -1 }).first_or_create({ name: 'Client',
-                                                                         description: 'Default roles client' })
+      user_role = user_roles.where({ slug: 'client', term_group: -1 })
+                            .first_or_create({ name: 'Client', description: 'Default roles client' })
       return unless user_role.valid?
 
       user_role.set_meta("_post_type_#{id}", {})
       user_role.set_meta("_manager_#{id}", {})
+    end
+
+    private
+
+    def helpers
+      ActionController::Base.helpers
     end
   end
 end

--- a/spec/factories/nav_menu.rb
+++ b/spec/factories/nav_menu.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nav_menu, class: 'CamaleonCms::NavMenu' do
+    name { Faker::Name.unique.name }
+    slug { Faker::Internet.unique.slug }
+    taxonomy { :nav_menu }
+  end
+end

--- a/spec/factories/nav_menu_item.rb
+++ b/spec/factories/nav_menu_item.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :nav_menu_item, class: 'CamaleonCms::NavMenuItem' do
+    name { Faker::Name.name }
+    url { 'https://example.com' }
+    kind { 'external' }
+    target { '' }
+    taxonomy { :nav_menu_item }
+  end
+end

--- a/spec/helpers/camaleon_cms/captcha_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/captcha_helper_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe CamaleonCms::CaptchaHelper do
+  subject(:helper_instance) { plain_class.new }
+
+  # Test the helper when included in a plain object without view context.
+  # This mirrors how CamaleonController includes the module — the controller
+  # instance does NOT have direct access to view helpers like image_tag.
+  let(:plain_class) do
+    Class.new do
+      include CamaleonCms::CaptchaHelper
+
+      attr_accessor :session, :params
+
+      def initialize
+        @session = {}
+        @params = {}
+      end
+
+      def current_site
+        # Return a decorated site object required by cama_captcha_under_attack?
+        site = instance_double(Cama::Site)
+        allow(site).to receive(:get_option).and_return(5)
+        site
+      end
+
+      def cama_captcha_url(**args)
+        "http://test.host/captcha.png?len=#{args[:len]}&t=#{args[:t]}"
+      end
+    end
+  end
+
+  describe '#cama_captcha_tag' do
+    it 'generates valid HTML with image and input tags' do
+      result = helper_instance.cama_captcha_tag
+
+      expect(result).to be_a(String)
+      expect(result).to include('<img')
+      expect(result).to include('src="http://test.host/captcha.png?len=5')
+      expect(result).to include('<input')
+      expect(result).to include('type="text"')
+      expect(result).to include('name="captcha"')
+    end
+
+    it 'includes cursor-pointer style on the image' do
+      result = helper_instance.cama_captcha_tag
+
+      expect(result).to include(%(style="cursor: pointer;"))
+    end
+
+    it 'includes onclick handler that forces image reload with timestamp' do
+      result = helper_instance.cama_captcha_tag
+
+      expect(result).to include('onclick="this.src')
+      expect(result).to include('new Date().getTime()')
+    end
+
+    it 'uses I18n translation for placeholder when none is provided' do
+      I18n.backend.store_translations(:en, camaleon_cms: { captcha_placeholder: 'Type the code' })
+
+      result = helper_instance.cama_captcha_tag
+
+      expect(result).to include('placeholder="Type the code"')
+    end
+
+    it 'keeps an explicitly provided placeholder instead of the I18n default' do
+      I18n.backend.store_translations(:en, camaleon_cms: { captcha_placeholder: 'Default' })
+
+      result = helper_instance.cama_captcha_tag(5, { alt: '' }, { placeholder: 'My placeholder' })
+
+      expect(result).to include('placeholder="My placeholder"')
+      expect(result).not_to include('placeholder="Default"')
+    end
+
+    it 'falls back to I18n default when placeholder is an empty string' do
+      I18n.backend.store_translations(:en, camaleon_cms: { captcha_placeholder: 'Default' })
+
+      result = helper_instance.cama_captcha_tag(5, { alt: '' }, { placeholder: '' })
+
+      expect(result).to include('placeholder="Default"')
+    end
+
+    it 'passes custom img_args attributes through to the image tag' do
+      result = helper_instance.cama_captcha_tag(5, { alt: 'Verify', class: 'captcha-img' })
+
+      expect(result).to include('alt="Verify"')
+      expect(result).to include('class="captcha-img"')
+    end
+
+    it 'passes custom input_args attributes through to the input tag' do
+      result = helper_instance.cama_captcha_tag(5, { alt: '' }, { class: 'form-control', id: 'captcha' })
+
+      expect(result).to include('class="form-control"')
+      expect(result).to include('id="captcha"')
+    end
+
+    context 'with bootstrap_group_mode enabled' do
+      it 'wraps the image inside a span.input-group-btn' do
+        result = helper_instance.cama_captcha_tag(5, { alt: '' }, {}, true)
+
+        expect(result).to include('input-group input-group-captcha')
+        expect(result).to include(%(<span class="input-group-btn"))
+      end
+    end
+
+    context 'without bootstrap_group_mode' do
+      it 'uses plain div.input-group-captcha without a span wrapper' do
+        result = helper_instance.cama_captcha_tag
+
+        expect(result).to include('class="input-group-captcha"')
+        expect(result).not_to include('span')
+      end
+    end
+
+    it 'includes a timestamp parameter in the image src for cache busting' do
+      result = helper_instance.cama_captcha_tag
+
+      # image_tag HTML-escapes & to &amp; in attrs
+      expect(result).to match(%r{src="http://test\.host/captcha\.png\?len=5&amp;t=\d+"})
+    end
+  end
+end

--- a/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
@@ -1,0 +1,250 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Frontend::NavMenuHelper do
+  init_site
+
+  before do
+    @menu = create(:nav_menu, name: 'Main Menu', slug: 'main_menu', parent: @site)
+    allow(helper).to receive_messages(site_current_path: '/', cama_root_url: '/')
+  end
+
+  describe '#cama_menu_draw_items' do
+    let(:default_args) do
+      {
+        menu_slug: 'main_menu',
+        container: 'ul',
+        container_class: 'nav navbar-nav',
+        item_container: 'li',
+        item_class: 'menu-item',
+        item_class_parent: 'dropdown',
+        item_current: 'current-menu-item',
+        sub_container: 'ul',
+        sub_class: 'dropdown-menu',
+        link_class: 'menu_link',
+        link_class_parent: 'dropdown-toggle',
+        link_current: 'current-link',
+        levels: -1,
+        callback_item: ->(args) {},
+        before: '',
+        after: '',
+        link_before: '',
+        link_after: '',
+        container_prepend: '',
+        container_append: '',
+        container_id: ''
+      }
+    end
+
+    context 'with a single menu item' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'Home', url: '/home', kind: 'external', target: '', parent: @menu)
+      end
+
+      it 'renders the item as an li tag with an a tag inside' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include('<li')
+        expect(result).to include("class='menu-item'")
+        expect(result).to include('<a')
+        expect(result).to include("href='/home'")
+        expect(result).to include("class='menu_link'")
+        expect(result).to include('</li>')
+      end
+
+      it 'does not escape HTML entities in the output' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).not_to include('&lt;li&gt;')
+        expect(result).not_to include('&lt;a ')
+      end
+    end
+
+    context 'with current menu item' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'About', url: '/about', kind: 'external', target: '', parent: @menu)
+        allow(helper).to receive(:site_current_path).and_return('/about')
+      end
+
+      it 'adds the current item class to the li element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("class='menu-item current-menu-item'")
+      end
+
+      it 'adds the link current class to the a element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("class='current-link menu_link'")
+      end
+    end
+
+    context 'with menu item that has children' do
+      before do
+        @parent_item =
+          create(:nav_menu_item, name: 'Services', url: '/services', kind: 'external', target: '', parent: @menu)
+        @child_item = create(
+          :nav_menu_item, name: 'Design', url: '/design', kind: 'external', target: '', parent_item: @parent_item
+        )
+      end
+
+      it 'adds the parent class to the li element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("class='menu-item dropdown'")
+      end
+
+      it 'adds the dropdown-toggle class to the a element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("class='dropdown-toggle menu_link'")
+      end
+
+      it 'adds data-toggle attribute to the a element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("data-toggle='dropdown'")
+      end
+
+      it 'renders children inside a sub ul container' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("<ul class='dropdown-menu level-1'>")
+        expect(result).to include('Design')
+        expect(result).to include('</ul>')
+      end
+
+      context 'when child item is current' do
+        before { allow(helper).to receive(:site_current_path).and_return('/design') }
+
+        it 'adds current-menu-ancestor class to the parent li' do
+          result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+          expect(result).to include('current-menu-ancestor')
+        end
+
+        it 'adds parent-current class to the sub ul' do
+          result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+          expect(result).to include('parent-current-menu-item')
+        end
+      end
+    end
+
+    context 'with target attribute' do
+      before do
+        @menu_item = create(
+          :nav_menu_item,
+          name: 'External', url: 'https://example.com', kind: 'external', target: '_blank', parent: @menu
+        )
+      end
+
+      it 'renders the target attribute on the a tag' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("target='_blank'")
+      end
+    end
+
+    context 'with before/after content' do
+      before do
+        @menu_item =
+          create(:nav_menu_item, name: 'Contact', url: '/contact', kind: 'external', target: '', parent: @menu)
+
+        default_args[:before] = '<span class="icon">'
+        default_args[:after] = '</span>'
+      end
+
+      it 'includes before content inside the a tag' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include('<span class="icon">Contact</span>')
+      end
+    end
+
+    context 'with link_before/link_after wrapper' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'Blog', url: '/blog', kind: 'external', target: '', parent: @menu)
+
+        default_args[:link_before] = '<em>'
+        default_args[:link_after] = '</em>'
+      end
+
+      it 'wraps the link with link_before and link_after' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include('<em><a ')
+        expect(result).to include('</a></em>')
+      end
+    end
+
+    context 'with custom item_container_attrs from callback' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'Custom', url: '/custom', kind: 'external', target: '', parent: @menu)
+
+        default_args[:callback_item] = lambda { |args|
+          args[:item_container_attrs] = "id='custom-id' data-role='nav'"
+        }
+      end
+
+      it 'includes custom item container attributes' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("id='custom-id'")
+        expect(result).to include("data-role='nav'")
+      end
+    end
+
+    context 'with custom link_attrs from callback' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'Custom', url: '/custom', kind: 'external', target: '', parent: @menu)
+
+        default_args[:callback_item] = lambda { |args|
+          args[:link_attrs] = "id='custom-link' data-action='click'"
+        }
+      end
+
+      it 'includes custom link attributes' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include("id='custom-link'")
+        expect(result).to include("data-action='click'")
+      end
+    end
+
+    context 'when item is skipped via cama_parse_menu_item' do
+      before do
+        @menu_item = create(:nav_menu_item, name: 'Hidden', url: '/hidden', kind: 'external', target: '', parent: @menu)
+        allow(helper).to receive(:cama_parse_menu_item).and_return(false)
+      end
+
+      it 'does not render the item' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to be_blank
+      end
+    end
+
+    context 'with multiple items' do
+      before do
+        @item1 = create(:nav_menu_item, name: 'First', url: '/first', kind: 'external', target: '', parent: @menu)
+        @item2 = create(:nav_menu_item, name: 'Second', url: '/second', kind: 'external', target: '', parent: @menu)
+      end
+
+      it 'renders all items concatenated' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include('First')
+        expect(result).to include('Second')
+      end
+
+      it 'renders each item as a separate li element' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result.scan(/<li/).count).to eq(2)
+        expect(result.scan(%r{</li>}).count).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -51,4 +51,32 @@ RSpec.describe 'PostDecorator' do
     expect(post.has_thumb?).to be(true)
     expect(post.manage_comments?).to be(true)
   end
+
+  describe '#fix_post_order' do
+    it 'assigns post_order 1 when creating the first post with nil post_order' do
+      post_type = create(:post_type, site: @site)
+      post = build(:post, post_type: post_type, post_order: nil)
+      post.save
+      expect(post.post_order).to eq(1)
+    end
+
+    it 'does not fail when the last post has a nil post_order' do
+      post_type = create(:post_type, site: @site)
+      first_post = create(:post, post_type: post_type, post_order: 1)
+      first_post.update_column(:post_order, nil)
+
+      new_post = build(:post, post_type: post_type, post_order: nil)
+      expect { new_post.save }.not_to raise_error
+      expect(new_post.post_order).to eq(1)
+    end
+
+    it 'assigns post_order 2 when the last post has post_order 1' do
+      post_type = create(:post_type, site: @site)
+      create(:post, post_type: post_type, post_order: 1)
+
+      new_post = build(:post, post_type: post_type, post_order: nil)
+      new_post.save
+      expect(new_post.post_order).to eq(2)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Refactor HTML in Ruby code to Rails tags — replaces raw HTML string concatenation with idiomatic Rails helpers (content_tag, tag, image_tag, link_to, safe_join, StringScanner) across helpers, models, and controllers. Adds corresponding factory and spec coverage.

## Changes (15 files, +1057/-330 lines)

### Helpers
- **frontend/nav_menu_helper.rb**: Use safe_join instead of HTML string concatenation in cama_menu_draw_items; refactor sub-container class building and current-item detection for readability.
- **html_helper.rb**: Replace raw HTML string in cama_html_tooltip with Rails tag helper.
- **short_code_helper.rb**: Replace complex regex in _shortcode_parse_attr with StringScanner tokenizer; improve method documentation formatting.
- **captcha_helper.rb**: Use ActionController::Base.helpers proxy for image_tag/tag/content_tag/safe_join to fix undefined-method errors when included in controller context.
- **menus_helper.rb**: Refactor admin menu drawing methods to use Rails tag helpers.
- **admin_controller.rb**: Extract duplicate SQL-building code from search action into a private items_sql_by_name method.

### Plugins
- **authoring_post_helper.rb**: Refactor to use Rails helpers instead of raw HTML strings.
- **visibility_post_helper.rb**: Refactor form_html and groups_list to use Rails helpers.

### Models
- **post.rb**: Fix fix_post_order to handle nil post_order on the last existing post ((last_post.post_order || 0) + 1).
- **site_default_settings.rb**: Use ActionController::Base.helpers (content_tag, image_tag, link_to, safe_join) for default sample content instead of raw HTML strings.

### Tests (new)
- **spec/factories/nav_menu.rb** and **nav_menu_item.rb**: FactoryBot factories for menu testing.
- **spec/helpers/captcha_helper_spec.rb**: Full spec suite for cama_captcha_tag (markup, attributes, bootstrap mode, i18n placeholder, cache-busting).
- **spec/helpers/frontend/nav_menu_helper_spec.rb**: Specs for cama_menu_draw_items covering current items, nested children, target attributes, before/after content, link wrappers, and custom container attributes.
- **spec/models/post_spec.rb**: Specs for fix_post_order nil-handling scenarios.

### Motivation
Raw HTML strings in Ruby code are hard to maintain, prone to escaping bugs, and do not benefit from Rails tag helpers. This PR systematically replaces them with Rails idioms, improving readability, safety, and testability.
