### PR TITLE
Implement native Rails STI for TermTaxonomy and PostDefault models, and introduce Meta's polymorphic owner for easing the associations setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Refactor:** Implement native Rails STI for term taxonomies and posts, and add polymorphic meta ownership, [#1173](https://github.com/owen2345/camaleon-cms/pull/1173)
+  - Moves `TermTaxonomy` and `PostDefault` onto native STI so subclasses resolve through Rails instead of custom taxonomy plumbing
+  - Introduces polymorphic `owner` associations for metas and custom-field records to simplify shared association setup
+  - Updates related models and specs to match the new inheritance and ownership behavior
+
 - **Style & tooling:** Add RuboCop plugin gems and fix all offenses, [#1167](https://github.com/owen2345/camaleon-cms/pull/1167)
   - Added `rubocop-performance`, `rubocop-rails`, `rubocop-capybara`, `rubocop-factory_bot`, `rubocop-rake`, `rubocop-rspec_rails` to development dependencies
   - Fixed hundreds of Layout, Style, Performance, and Rails offenses across 92 files

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -101,7 +101,9 @@ module CamaleonCms
 
     def items_sql_by_name(table_name)
       lower_name = "LOWER(#{table_name}"
-      return "#{lower_name}.title) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.content_filtered) LIKE ?" if table_name == Cama::Post.table_name
+      if table_name == Cama::Post.table_name
+        return "#{lower_name}.title) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.content_filtered) LIKE ?"
+      end
 
       "#{lower_name}.name) LIKE ? OR #{lower_name}.slug) LIKE ? OR #{lower_name}.description) LIKE ?"
     end

--- a/app/models/camaleon_cms/category.rb
+++ b/app/models/camaleon_cms/category.rb
@@ -5,13 +5,13 @@ module CamaleonCms
     alias_attribute :site_id, :term_group
     alias_attribute :post_type_id, :status
 
-    default_scope { where(taxonomy: :category) }
     scope :no_empty, -> { where('count > 0') } # return all categories that contains at least one post
     scope :empty, -> { where(count: [0, nil]) } # return all categories that does not contain any post
     # scope :parents, -> { where("term_taxonomy.parent_id IS NULL") }
 
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
-    has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy
+    has_many :children, class_name: 'CamaleonCms::Category', foreign_key: :parent_id, dependent: :destroy,
+                        inverse_of: :parent
     belongs_to :parent, class_name: 'CamaleonCms::Category', optional: true
     belongs_to :post_type_parent, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id,
                                   inverse_of: :categories, optional: true

--- a/app/models/camaleon_cms/custom_field.rb
+++ b/app/models/camaleon_cms/custom_field.rb
@@ -14,10 +14,13 @@ module CamaleonCms
     # status: nil -> visible on list group fields
     # attr_accessible :object_class, :objectid, :description, :parent_id, :count, :name, :slug,
     # :field_order, :status, :is_repeat
-    has_many :metas, -> { where(object_class: 'CustomField') }, foreign_key: :objectid, dependent: :destroy
+
+    has_many :metas, foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
     has_many :values, class_name: 'CamaleonCms::CustomFieldsRelationship', dependent: :destroy
-    belongs_to :custom_field_group, optional: true
+
+    belongs_to :custom_field_group, foreign_key: :objectid, optional: true, inverse_of: :fields
     belongs_to :parent, class_name: 'CamaleonCms::CustomField', optional: true
+    belongs_to :owner, polymorphic: true, foreign_key: :objectid, foreign_type: :object_class
 
     validates :name, :object_class, presence: true
     validates :slug, uniqueness: { scope: %i[parent_id object_class],

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -8,10 +8,13 @@ module CamaleonCms
       where("object_class != '_fields'").reorder("#{CamaleonCms::CustomField.table_name}.field_order ASC")
     end
 
-    has_many :metas, -> { where(object_class: 'CustomFieldGroup') }, foreign_key: :objectid, dependent: :destroy
+    has_many :metas, foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
+
     has_many :fields, -> { where(object_class: '_fields') }, class_name: 'CamaleonCms::CustomField',
-                                                             foreign_key: :parent_id, dependent: :destroy
-    belongs_to :site, foreign_key: :parent_id, optional: true
+                                                             foreign_key: :parent_id, dependent: :destroy,
+                                                             inverse_of: :custom_field_group
+    belongs_to :site, foreign_key: :parent_id, optional: true, inverse_of: :custom_field_groups
+    belongs_to :owner, polymorphic: true, foreign_key: :objectid, foreign_type: :object_class
 
     validates :slug, uniqueness: { scope: %i[object_class objectid parent_id] }
 

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -8,6 +8,7 @@ module CamaleonCms
 
     # relations
     belongs_to :custom_field, class_name: 'CamaleonCms::CustomField', optional: true
+    belongs_to :owner, polymorphic: true, foreign_key: :objectid, foreign_type: :object_class
 
     # validates :objectid, :custom_field_id, presence: true
     validates :custom_field_id, presence: true # error on clone model

--- a/app/models/camaleon_cms/meta.rb
+++ b/app/models/camaleon_cms/meta.rb
@@ -3,6 +3,8 @@ module CamaleonCms
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}metas"
     # attr_accessible :objectid, :key, :value, :object_class
 
+    belongs_to :owner, polymorphic: true, foreign_key: :objectid, foreign_type: :object_class
+
     extend CamaleonCms::NormalizeAttrs
 
     normalize_attrs(:value)

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -2,7 +2,6 @@ module CamaleonCms
   class NavMenu < CamaleonCms::TermTaxonomy
     normalize_attrs(:name, :description)
 
-    default_scope { where(taxonomy: :nav_menu).order(id: :asc) }
     alias_attribute :site_id, :parent_id
 
     has_many :children, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id, dependent: :destroy,

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -7,9 +7,8 @@ module CamaleonCms
     alias_attribute :url, :description
     alias_attribute :kind, :slug
     alias_attribute :target, :status
+
     # attr_accessible :label, :url, :kind
-    #
-    default_scope { where(taxonomy: :nav_menu_item).order(id: :asc) }
 
     belongs_to :parent, class_name: 'CamaleonCms::NavMenu', inverse_of: :children, optional: true
     belongs_to :parent_item, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id, inverse_of: :children,

--- a/app/models/camaleon_cms/plugin.rb
+++ b/app/models/camaleon_cms/plugin.rb
@@ -9,9 +9,8 @@ module CamaleonCms
 
     attr_accessor :error
 
-    belongs_to :site, foreign_key: :parent_id, optional: true
+    belongs_to :site, foreign_key: :parent_id, optional: true, inverse_of: :plugins
 
-    default_scope { where(taxonomy: :plugin) }
     scope :active, -> { where(term_group: 1) }
 
     before_validation :set_default

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -15,11 +15,10 @@ module CamaleonCms
     has_many :categories, class_name: 'CamaleonCms::Category', through: :term_relationships, source: :term_taxonomy
     has_many :post_tags, class_name: 'CamaleonCms::PostTag', through: :term_relationships, source: :term_taxonomy
     has_many :comments, class_name: 'CamaleonCms::PostComment', dependent: :destroy
-    has_many :drafts, lambda {
-                        where(status: 'draft_child')
-                      }, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy
+    has_many :drafts, -> { where(status: 'draft_child') }, class_name: 'CamaleonCms::Post', inverse_of: :owner,
+                                                           foreign_key: :post_parent, dependent: :destroy
     has_many :children, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy,
-                        primary_key: :id
+                        primary_key: :id, inverse_of: :parent
 
     belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, optional: true
     belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, optional: true

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -20,8 +20,10 @@ module CamaleonCms
     has_many :children, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy,
                         primary_key: :id, inverse_of: :parent
 
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, optional: true
-    belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, optional: true
+    belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
+                       inverse_of: :all_posts
+    belongs_to :parent, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, optional: true,
+                        inverse_of: :children
     belongs_to :post_type, foreign_key: :taxonomy_id, inverse_of: :posts, optional: true
 
     scope :visible_frontend, -> { where(status: 'published') }

--- a/app/models/camaleon_cms/post_comment.rb
+++ b/app/models/camaleon_cms/post_comment.rb
@@ -13,10 +13,13 @@ module CamaleonCms
     # default_scope order('comments.created_at ASC')
     # approved: approved | pending | spam
 
-    has_many :children, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, dependent: :destroy
+    has_many :children, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, dependent: :destroy,
+                        inverse_of: :parent
+
     belongs_to :post, optional: true
-    belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, optional: true
-    belongs_to :user, class_name: CamaManager.get_user_class_name, optional: true
+    belongs_to :parent, class_name: 'CamaleonCms::PostComment', foreign_key: :comment_parent, optional: true,
+                        inverse_of: :children
+    belongs_to :user, class_name: CamaManager.get_user_class_name.to_s, optional: true
 
     default_scope { order("#{CamaleonCms::PostComment.table_name}.created_at DESC") }
 

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -68,11 +68,6 @@ module CamaleonCms
       res.take
     end
 
-    # return the parent of a post (support for sub contents or tree of posts)
-    # def parent
-    #   CamaleonCms::Post.where(id: post_parent).first
-    # end
-
     # return the author of this Content
     def author
       CamaleonCms::User.find(user_id)

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -11,6 +11,26 @@ module CamaleonCms
       end
     end
 
+    # Point Rails to use the post_class column for Native STI
+    self.inheritance_column = :post_class
+
+    # Controls Writing: Strip 'CamaleonCms::' when saving to DB
+    # "CamaleonCms::Widget::Assigned" -> "Widget::Assigned"
+    # "CamaleonCms::Post" -> "Post"
+    def self.sti_name
+      name.sub(/^CamaleonCms::/, '')
+    end
+
+    # Controls Reading: Prepend 'CamaleonCms::' when pulling from DB
+    # "Widget::Assigned" -> "CamaleonCms::Widget::Assigned"
+    # "Post" -> "CamaleonCms::Post"
+    def self.find_sti_class(type_name)
+      full_class_name = type_name.start_with?('CamaleonCms::') ? type_name : "CamaleonCms::#{type_name}"
+      full_class_name.constantize
+    rescue NameError
+      super
+    end
+
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}posts"
 
     # attr_accessible :user_id, :title, :slug, :content, :content_filtered, :status,  :visibility, :visibility_value,
@@ -63,7 +83,7 @@ module CamaleonCms
       CamaleonCms::NavMenuItem.where(url: id, kind: 'post')
     end
 
-    # Set the meta, field values and the post keywords here
+    # Set the meta-field values and the post keywords here
     def set_params(meta, custom_fields, options)
       set_metas(meta)
       set_field_values(custom_fields)

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -42,9 +42,11 @@ module CamaleonCms
     cattr_accessor :current_user
     cattr_accessor :current_site
 
-    has_many :term_relationships, foreign_key: :objectid, dependent: :destroy, primary_key: :id
     has_many :children, -> { where(post_class: 'PostDefault') },
-             class_name: 'CamaleonCms::PostDefault', foreign_key: :post_parent, dependent: :destroy, primary_key: :id
+             class_name: 'CamaleonCms::PostDefault', foreign_key: :post_parent, dependent: :destroy, inverse_of: :parent
+
+    belongs_to :parent, class_name: 'CamaleonCms::PostDefault', foreign_key: :post_parent, optional: true,
+                        inverse_of: :children
 
     scope :featured, -> { where(is_feature: true) }
 
@@ -67,9 +69,9 @@ module CamaleonCms
     end
 
     # return the parent of a post (support for sub contents or tree of posts)
-    def parent
-      CamaleonCms::Post.where(id: post_parent).first
-    end
+    # def parent
+    #   CamaleonCms::Post.where(id: post_parent).first
+    # end
 
     # return the author of this Content
     def author

--- a/app/models/camaleon_cms/post_tag.rb
+++ b/app/models/camaleon_cms/post_tag.rb
@@ -2,10 +2,9 @@ module CamaleonCms
   class PostTag < CamaleonCms::TermTaxonomy
     normalize_attrs(:name, :description)
 
-    default_scope { where(taxonomy: :post_tag) }
-
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     belongs_to :post_type, foreign_key: :parent_id, inverse_of: :post_tags, optional: true
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, optional: true
+    belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
+                       inverse_of: :post_tags
   end
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -3,7 +3,6 @@ module CamaleonCms
     normalize_attrs(:name, :description)
 
     alias_attribute :site_id, :parent_id
-    default_scope { where(taxonomy: :post_type) }
 
     has_many :categories, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type_parent
     has_many :post_tags, foreign_key: :parent_id, dependent: :destroy, inverse_of: :post_type
@@ -13,10 +12,11 @@ module CamaleonCms
     has_many :posts_draft, class_name: 'CamaleonCms::Post', foreign_key: :taxonomy_id, dependent: :destroy,
                            inverse_of: :post_type
     has_many :field_group_taxonomy, -> { where('object_class LIKE ?', 'PostType_%') },
-             class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy
+             class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
 
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, optional: true
-    belongs_to :site, foreign_key: :parent_id, optional: true
+    belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
+                       inverse_of: :post_type_owners
+    belongs_to :site, foreign_key: :parent_id, optional: true, inverse_of: :post_types
 
     scope :visible_menu, -> { where(term_group: nil) }
     scope :hidden_menu, -> { where(term_group: -1) }

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -7,26 +7,33 @@ module CamaleonCms
     # attrs: [name, description, slug]
     attr_accessor :site_domain
 
-    default_scope { where(taxonomy: :site).reorder(term_group: :desc) }
+    # default_scope { where(taxonomy: :site).reorder(term_group: :desc) }
 
-    has_many :post_types, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, dependent: :destroy
+    has_many :post_types, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, dependent: :destroy,
+                          inverse_of: :site
     has_many :nav_menus, class_name: 'CamaleonCms::NavMenu', foreign_key: :parent_id, dependent: :destroy,
                          inverse_of: :site
-    has_many :nav_menu_items, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :term_group
-    has_many :widgets, class_name: 'CamaleonCms::Widget::Main', foreign_key: :parent_id, dependent: :destroy
-    has_many :sidebars, class_name: 'CamaleonCms::Widget::Sidebar', foreign_key: :parent_id, dependent: :destroy
-    has_many :user_roles_rel, class_name: 'CamaleonCms::UserRole', foreign_key: :parent_id, dependent: :destroy
+    has_many :nav_menu_items, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :term_group, inverse_of: :parent,
+                              dependent: :destroy
+    has_many :widgets, class_name: 'CamaleonCms::Widget::Main', foreign_key: :parent_id, dependent: :destroy,
+                       inverse_of: :site
+    has_many :sidebars, class_name: 'CamaleonCms::Widget::Sidebar', foreign_key: :parent_id, dependent: :destroy,
+                        inverse_of: :site
+    has_many :user_roles_rel, class_name: 'CamaleonCms::UserRole', foreign_key: :parent_id, dependent: :destroy,
+                              inverse_of: :site
     has_many :custom_field_groups, class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :parent_id,
-                                   dependent: :destroy
-    has_many :term_taxonomies, class_name: 'CamaleonCms::TermTaxonomy', foreign_key: :parent_id
+                                   dependent: :destroy, inverse_of: :parent
+    has_many :term_taxonomies, class_name: 'CamaleonCms::TermTaxonomy', foreign_key: :parent_id, inverse_of: :parent,
+                               dependent: :destroy
 
     has_many :posts, through: :post_types, source: :posts
-    has_many :plugins, class_name: 'CamaleonCms::Plugin', foreign_key: :parent_id, dependent: :destroy
-    has_many :themes, class_name: 'CamaleonCms::Theme', foreign_key: :parent_id, dependent: :destroy
-    has_many :public_media, -> { where(is_public: true) },
-             class_name: 'CamaleonCms::Media', foreign_key: :site_id, dependent: :destroy
-    has_many :private_media, -> { where(is_public: false) },
-             class_name: 'CamaleonCms::Media', foreign_key: :site_id, dependent: :destroy
+    has_many :plugins, class_name: 'CamaleonCms::Plugin', foreign_key: :parent_id, dependent: :destroy,
+                       inverse_of: :site
+    has_many :themes, class_name: 'CamaleonCms::Theme', foreign_key: :parent_id, dependent: :destroy, inverse_of: :site
+    has_many :public_media, -> { where(is_public: true) }, class_name: 'CamaleonCms::Media', foreign_key: :site_id,
+                                                           dependent: :destroy, inverse_of: :site
+    has_many :private_media, -> { where(is_public: false) }, class_name: 'CamaleonCms::Media', foreign_key: :site_id,
+                                                             dependent: :destroy, inverse_of: :site
 
     after_create :default_settings
     after_create :set_default_user_roles

--- a/app/models/camaleon_cms/term_relationship.rb
+++ b/app/models/camaleon_cms/term_relationship.rb
@@ -6,7 +6,8 @@ module CamaleonCms
 
     belongs_to :term_taxonomy, inverse_of: :term_relationships, optional: true
     belongs_to :object, -> { order("#{CamaleonCms::Post.table_name}.id DESC") },
-               class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :term_relationships, optional: true
+               class_name: 'CamaleonCms::Post', foreign_key: :objectid, inverse_of: :term_relationships,
+               optional: true
 
     after_create :update_count
     before_destroy :update_count

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -19,6 +19,38 @@ module CamaleonCms
     # attr_accessible :data_options
     # attr_accessible :data_metas
 
+    self.inheritance_column = :taxonomy
+
+    def self.sti_name
+      name.demodulize.underscore
+    end
+
+    def self.polymorphic_name
+      name.demodulize
+    end
+
+    def self.find_sti_class(type_name)
+      # Handle explicit exceptions where database string doesn't match namespacing layout
+      case type_name.to_s
+      when 'widget'
+        return CamaleonCms::Widget::Main
+      when 'sidebar'
+        return CamaleonCms::Widget::Sidebar
+      end
+
+      # Standard conversion for "site" -> "CamaleonCms::Site"
+      # or "nav_menu_item" -> "CamaleonCms::NavMenuItem"
+      full_class_name = "CamaleonCms::#{type_name.camelize}"
+      full_class_name.constantize
+    rescue NameError
+      # Universal safety net: runtime scan across loaded taxonomy memory models
+      found_subclass = CamaleonCms::TermTaxonomy.descendants.find do |klass|
+        klass.sti_name == type_name.to_s
+      end
+
+      found_subclass || super
+    end
+
     # callbacks
     before_validation :before_validating
     before_destroy :destroy_dependencies
@@ -32,7 +64,8 @@ module CamaleonCms
                                   dependent: :destroy
     # has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
     belongs_to :parent, class_name: 'CamaleonCms::TermTaxonomy', optional: true
-    belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id, optional: true
+    belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
+                       inverse_of: :term_taxonomies
 
     # return all children taxonomy
     # sample: sub categories of a category

--- a/app/models/camaleon_cms/theme.rb
+++ b/app/models/camaleon_cms/theme.rb
@@ -4,9 +4,7 @@ module CamaleonCms
 
     # attrs:
     #   slug => plugin key
-    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, optional: true
-
-    default_scope { where(taxonomy: :theme) }
+    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, optional: true, inverse_of: :themes
 
     before_validation :fix_name
     before_destroy :destroy_custom_fields

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -8,6 +8,9 @@ if PluginRoutes.static_system_info['user_model'].blank?
 
       default_scope { order(role: :asc) }
 
+      has_many :widgets, class_name: 'CamaleonCms::Widget::Main', foreign_key: :parent_id, dependent: :destroy,
+                         inverse_of: :owner
+
       validates :username, presence: true
       # The following might be continued wit: , :unless => Proc.new { |a| a.auth_social.present? }
       validates :email, presence: true, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -8,7 +8,7 @@ if PluginRoutes.static_system_info['user_model'].blank?
 
       default_scope { order(role: :asc) }
 
-      has_many :widgets, class_name: 'CamaleonCms::Widget::Main', foreign_key: :parent_id, dependent: :destroy,
+      has_many :widgets, class_name: 'CamaleonCms::Widget::Main', dependent: :destroy,
                          inverse_of: :owner
 
       validates :username, presence: true

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -4,9 +4,8 @@ module CamaleonCms
 
     after_destroy :set_users_as_cilent
 
-    default_scope { where(taxonomy: :user_roles) }
-
-    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, optional: true
+    belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, optional: true,
+                      inverse_of: :user_roles_rel
 
     def roles_post_type
       get_meta('_post_type')

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -2,6 +2,10 @@ module CamaleonCms
   class UserRole < CamaleonCms::TermTaxonomy
     normalize_attrs(:name, :description)
 
+    def self.sti_name
+      'user_roles'
+    end
+
     after_destroy :set_users_as_cilent
 
     belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, optional: true,

--- a/app/models/camaleon_cms/widget/assigned.rb
+++ b/app/models/camaleon_cms/widget/assigned.rb
@@ -1,7 +1,7 @@
 module CamaleonCms
   module Widget
     class Assigned < CamaleonCms::PostDefault
-      default_scope -> { where(post_class: name).order(:taxonomy_id) }
+      # default_scope -> { where(post_class: name).order(:taxonomy_id) }
       # post_parent: sidebar_id
       # visibility: widget_id
       # comment_count: item_order
@@ -12,11 +12,9 @@ module CamaleonCms
 
       # attr_accessible :widget_id, :sidebar_id, :item_order
 
-      has_many :metas, lambda {
-                         where(object_class: 'Widget::Assigned')
-                       }, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
-      belongs_to :sidebar, class_name: 'CamaleonCms::Widget::Sidebar', foreign_key: :post_parent
-      belongs_to :widget, class_name: 'CamaleonCms::Widget::Main', foreign_key: :visibility
+      belongs_to :sidebar, class_name: 'CamaleonCms::Widget::Sidebar', foreign_key: :post_parent, inverse_of: :assigned
+      belongs_to :widget, class_name: 'CamaleonCms::Widget::Main', foreign_key: :visibility, inverse_of: :assigned
+
       after_initialize :fix_slug2
       before_create :set_order
 

--- a/app/models/camaleon_cms/widget/main.rb
+++ b/app/models/camaleon_cms/widget/main.rb
@@ -3,7 +3,6 @@ module CamaleonCms
     class Main < CamaleonCms::TermTaxonomy
       normalize_attrs(:name)
 
-      default_scope { where(taxonomy: :widget) }
       # attr_accessible :excerpt, :renderer
       # name: "title"
       # description: "content for this"
@@ -12,14 +11,14 @@ module CamaleonCms
       # excerpt: string for message
       # renderer: string (path to the template for render this widget)
 
-      has_many :metas, lambda {
-                         where(object_class: 'Widget::Main')
-                       }, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
-      belongs_to :owner, class_name: CamaManager.get_user_class_name, foreign_key: :user_id
-      belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+      belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, inverse_of: :widgets
+      belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, inverse_of: :widgets
 
-      has_many :assigned, class_name: 'CamaleonCms::Widget::Assigned', foreign_key: :visibility, dependent: :destroy
+      has_many :assigned, class_name: 'CamaleonCms::Widget::Assigned', foreign_key: :visibility, dependent: :destroy,
+                          inverse_of: :widget
+
       before_save :check_excerpt
+
       def is_simple?
         status == 'simple'
       end

--- a/app/models/camaleon_cms/widget/main.rb
+++ b/app/models/camaleon_cms/widget/main.rb
@@ -3,6 +3,10 @@ module CamaleonCms
     class Main < CamaleonCms::TermTaxonomy
       normalize_attrs(:name)
 
+      def self.sti_name
+        'widget'
+      end
+
       # attr_accessible :excerpt, :renderer
       # name: "title"
       # description: "content for this"

--- a/app/models/camaleon_cms/widget/sidebar.rb
+++ b/app/models/camaleon_cms/widget/sidebar.rb
@@ -3,13 +3,8 @@ module CamaleonCms
     class Sidebar < CamaleonCms::TermTaxonomy
       normalize_attrs(:name, :description)
 
-      default_scope { where(taxonomy: :sidebar) }
-
-      has_many :metas, lambda {
-                         where(object_class: 'Widget::Sidebar')
-                       }, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
-      has_many :assigned, foreign_key: :post_parent, dependent: :destroy
-      belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id
+      has_many :assigned, foreign_key: :post_parent, dependent: :destroy, inverse_of: :sidebar
+      belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, inverse_of: :sidebars
 
       # scopes
       scope :default_sidebar, -> { where(slug: 'default-sidebar') }

--- a/app/models/camaleon_record.rb
+++ b/app/models/camaleon_record.rb
@@ -7,8 +7,6 @@ class CamaleonRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRec
   TRANSLATION_TAG_RESTORE_REGEX =
     Regexp.new(TRANSLATION_TAG_RESTORE_MAP.keys.map { |x| Regexp.escape(x) }.join('|')).freeze
 
-  include ActiveRecordExtras::Relation
-
   self.abstract_class = true
 
   # save cache value for this key

--- a/app/models/concerns/camaleon_cms/common_relationships.rb
+++ b/app/models/concerns/camaleon_cms/common_relationships.rb
@@ -3,20 +3,24 @@
 module CamaleonCms
   module CommonRelationships
     extend ActiveSupport::Concern
+    # rubocop:disable Rails/InverseOf
 
     included do
-      has_many :metas, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
+      object_class_name = name.to_s.delete_prefix('CamaleonCms::')
+      has_many :metas, -> { where(object_class: object_class_name) },
+               class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
 
-      has_many :custom_field_values, class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid,
-                                     dependent: :delete_all, inverse_of: :owner
+      has_many :custom_field_values, -> { where(object_class: object_class_name) },
+               class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
 
-      has_many :custom_fields, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, inverse_of: :owner,
-                               dependent: :delete_all
+      has_many :custom_fields, -> { where(object_class: object_class_name) },
+               class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :delete_all
 
       # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
       # children groups
-      has_many :custom_field_groups, class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid,
-                                     inverse_of: :owner, dependent: :delete_all
+      has_many :custom_field_groups, -> { where(object_class: object_class_name) },
+               class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid, dependent: :delete_all
     end
+    # rubocop:enable Rails/InverseOf
   end
 end

--- a/app/models/concerns/camaleon_cms/common_relationships.rb
+++ b/app/models/concerns/camaleon_cms/common_relationships.rb
@@ -5,20 +5,18 @@ module CamaleonCms
     extend ActiveSupport::Concern
 
     included do
-      class_name = name.demodulize
-      has_many :metas, -> { where(object_class: class_name) },
-               class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
+      has_many :metas, class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
 
-      has_many :custom_field_values, -> { where(object_class: class_name) },
-               class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
+      has_many :custom_field_values, class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid,
+                                     dependent: :delete_all, inverse_of: :owner
 
-      has_many :custom_fields, -> { where(object_class: class_name) },
-               class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
+      has_many :custom_fields, class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, inverse_of: :owner,
+                               dependent: :delete_all
 
       # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
       # children groups
-      has_many :custom_field_groups, -> { where(object_class: class_name) },
-               class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
+      has_many :custom_field_groups, class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid,
+                                     inverse_of: :owner, dependent: :delete_all
     end
   end
 end

--- a/app/models/concerns/camaleon_cms/metas.rb
+++ b/app/models/concerns/camaleon_cms/metas.rb
@@ -14,7 +14,25 @@ module CamaleonCms
     # Add meta with value or Update meta with key: key
     # return true or false
     def set_meta(key, value)
-      metas.where(key: key).update_or_create({ value: fix_meta_value(value) })
+      fixed_value = fix_meta_value(value)
+
+      # Check if the parent object has been saved to the database yet
+      if persisted?
+        # Safe to use database-driven lookups and updates
+        meta_record = metas.find_or_create_by(key: key.to_s)
+        meta_record.update(value: fixed_value)
+      else
+        # In-Memory Fallback: Find an existing unsaved item in the array collection,
+        # or build a brand new unsaved record on the association.
+        meta_record = metas.find { |m| m.key == key.to_s }
+
+        if meta_record
+          meta_record.value = fixed_value
+        else
+          metas.build(key: key.to_s, value: fixed_value)
+        end
+      end
+
       cama_set_cache("meta_#{key}", value)
     end
 

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -34,8 +34,10 @@ module CamaleonCms
       before_update { generate_token :auth_token if will_save_change_to_password_digest? }
 
       # relations
-      has_many :all_posts, class_name: 'CamaleonCms::Post', foreign_key: :user_id
-      has_many :all_comments, class_name: 'CamaleonCms::PostComment'
+      has_many :all_posts, class_name: 'CamaleonCms::Post', foreign_key: :user_id, inverse_of: :owner,
+                           dependent: :nullify
+      has_many :all_comments, class_name: 'CamaleonCms::PostComment', dependent: :nullify
+
       belongs_to :site, class_name: 'CamaleonCms::Site', optional: true
 
       # scopes

--- a/config/initializers/active_record_extension.rb
+++ b/config/initializers/active_record_extension.rb
@@ -1,25 +1,3 @@
-module ActiveRecordExtras
-  module Relation
-    extend ActiveSupport::Concern
-
-    module ClassMethods
-      def update_or_create(attributes = {})
-        assign_or_new(attributes).save
-      end
-
-      def update_or_create!(attributes = {})
-        assign_or_new(attributes).save!
-      end
-
-      def assign_or_new(attributes)
-        obj = first || new
-        obj.assign_attributes(attributes)
-        obj
-      end
-    end
-  end
-end
-
 ActiveRecord::Associations::CollectionProxy.class_eval do
   # order a collection by custom fields
   # Arguments:

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe CamaleonCms::Site, type: :model do
     end
 
     it 'does not leak metas from other object classes sharing the same object id' do
+      # This guards against associations that only scope by objectid and ignore object_class.
       CamaleonCms::Meta.create!(
         objectid: site.id,
         object_class: 'UserRole',

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -14,5 +14,16 @@ RSpec.describe CamaleonCms::Site, type: :model do
 
       expect(front_cache_elements.object_class).to eql('Site')
     end
+
+    it 'does not leak metas from other object classes sharing the same object id' do
+      CamaleonCms::Meta.create!(
+        objectid: site.id,
+        object_class: 'UserRole',
+        key: "leak-check-#{SecureRandom.hex(4)}",
+        value: 'x'
+      )
+
+      expect(site.metas.where(object_class: 'UserRole')).to be_empty
+    end
   end
 end

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -5,4 +5,16 @@ require 'shared_specs/sanitize_attrs'
 
 RSpec.describe CamaleonCms::UserRole, type: :model do
   it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]
+
+  describe 'native STI compatibility' do
+    it 'uses legacy user_roles taxonomy as sti_name' do
+      expect(described_class.sti_name).to eq('user_roles')
+    end
+
+    it 'can read default roles created for a site' do
+      site = create(:site).decorate
+
+      expect(described_class.where(parent_id: site.id)).not_to be_empty
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -12,4 +12,20 @@ RSpec.describe CamaleonCms::User, type: :model do
       expect(user.email).to eql('foo@bar.com')
     end
   end
+
+  describe 'widgets association' do
+    it 'fetches widgets by user_id' do
+      user = create(:user)
+      other_site = create(:site, slug: "other-site-#{SecureRandom.hex(3)}").decorate
+      widget = CamaleonCms::Widget::Main.create!(
+        taxonomy: CamaleonCms::Widget::Main.sti_name,
+        name: 'User Widget',
+        slug: "user-widget-#{SecureRandom.hex(4)}",
+        parent_id: other_site.id,
+        user_id: user.id
+      )
+
+      expect(user.widgets).to include(widget)
+    end
+  end
 end

--- a/spec/models/widget/widget_main_spec.rb
+++ b/spec/models/widget/widget_main_spec.rb
@@ -5,4 +5,10 @@ require 'shared_specs/sanitize_attrs'
 
 RSpec.describe CamaleonCms::Widget::Main, type: :model do
   it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name]
+
+  describe 'native STI compatibility' do
+    it 'uses legacy widget taxonomy as sti_name' do
+      expect(described_class.sti_name).to eq('widget')
+    end
+  end
 end


### PR DESCRIPTION
## User-Visible Impact
None. This is an internal model/association refactor that preserves existing behavior while removing custom STI/association plumbing.

## What and Why
This branch moves `TermTaxonomy` and `PostDefault` onto native Rails STI so the framework can resolve taxonomy/post subclasses directly, while keeping the legacy taxonomy strings mapped to the existing Camaleon models. It also introduces polymorphic `owner` associations for metas and custom-field records, then updates the surrounding models (`Site`, `Post`, widgets, menus, plugins, themes, comments, user roles, and users) to use cleaner inverse associations and the new ownership model.

The result is simpler association setup, less custom ActiveRecord extension code, and more reliable loading/ownership behavior across the CMS data model.