### PR TITLE
Fix output safety rendering and keep menu HTML working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Security fix:** Fix Rails OutputSafety sinks while preserving menu and asset rendering, [#1174](https://github.com/owen2345/camaleon-cms/pull/1174)
+  - Escapes untrusted HTML in attack responses, media crop output, edit-link labels, hierarchy titles, and select option generation
+  - Keeps trusted cached markup replay and asset injection paths explicit and narrowly suppressed
+  - Restores trusted frontend/admin menu HTML and renderable asset tags after the output-safety cleanup
+
 - **Refactor:** Implement native Rails STI for term taxonomies and posts, and add polymorphic meta ownership, [#1173](https://github.com/owen2345/camaleon-cms/pull/1173)
   - Moves `TermTaxonomy` and `PostDefault` onto native STI so subclasses resolve through Rails instead of custom taxonomy plumbing
   - Introduces polymorphic `owner` associations for metas and custom-field records to simplify shared association setup

--- a/app/apps/plugins/attack/attack_helper.rb
+++ b/app/apps/plugins/attack/attack_helper.rb
@@ -38,7 +38,7 @@ module Plugins
       def attack_app_before_load
         cache_ban = Rails.cache.read(cama_get_session_id)
         if cache_ban.present? # render banned message if it was banned
-          render html: cache_ban.html_safe, layout: false
+          render html: cache_ban.to_s, layout: false
           return
         end
 
@@ -72,7 +72,7 @@ module Plugins
           if r.count > config[:post][:max].to_i
             Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
             # Email administrator with request info (ip, browser, if logged, then send user info
-            render html: config[:msg].html_safe
+            render html: config[:msg].to_s
             return
           end
 
@@ -81,7 +81,7 @@ module Plugins
           r = query.where(created_at: config[:get][:sec].to_i.seconds.ago..Time.zone.now)
           if r.count > config[:get][:max].to_i
             Rails.cache.write(cama_get_session_id, config[:msg], expires_in: config[:ban].to_i.minutes)
-            render html: config[:msg].html_safe
+            render html: config[:msg].to_s
             return
           end
         end

--- a/app/apps/plugins/front_cache/front_cache_helper.rb
+++ b/app/apps/plugins/front_cache/front_cache_helper.rb
@@ -18,7 +18,9 @@ module Plugins
           response.headers['PLUGIN_FRONT_CACHE'] = 'TRUE'
           args = { data: front_cache_get(cache_key).gsub('{{form_authenticity_token}}', form_authenticity_token) }
           hooks_run('front_cache_reading_cache', args)
+          # rubocop:disable Rails/OutputSafety -- This replays a trusted cached page body that was already rendered by Rails.
           render html: args[:data].html_safe
+          # rubocop:enable Rails/OutputSafety
           return
         end
 

--- a/app/apps/themes/camaleon_first/main_helper.rb
+++ b/app/apps/themes/camaleon_first/main_helper.rb
@@ -11,9 +11,7 @@ module Themes
 
       # return a list of options for "Recent items from " on site settings -> theme settings
       def camaleon_first_list_select
-        res = []
-        current_site.the_post_types.decorate.each { |p| res << "<option value='#{p.the_slug}'>#{p.the_title}</option>" }
-        res.join('').html_safe
+        safe_join(current_site.the_post_types.decorate.map { |p| content_tag(:option, p.the_title, value: p.the_slug) })
       end
 
       def camaleon_first_on_install_theme(theme)

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -21,7 +21,7 @@ module CamaleonCms
         crop_path = cama_crop_image(path_image, params[:ic_w], params[:ic_h], params[:ic_x], params[:ic_y])
         res = upload_file(crop_path, { remove_source: true })
         CamaleonCms::User.find(params[:saved_avatar]).set_meta('avatar', res['url']) if params[:saved_avatar].present?
-        render html: res['url'].html_safe
+        render plain: res['url'].to_s
       end
 
       # download private files

--- a/app/decorators/camaleon_cms/post_decorator.rb
+++ b/app/decorators/camaleon_cms/post_decorator.rb
@@ -148,7 +148,7 @@ module CamaleonCms
       return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge!(attrs)
-      h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_edit_url, attrs)
+      h.link_to(h.safe_join(['→ ', title || h.ct('edit', default: 'Edit')]), the_edit_url, attrs)
     end
 
     # show thumbnail image as html
@@ -262,10 +262,9 @@ module CamaleonCms
     def the_hierarchy_title
       return the_title if object.post_parent.blank?
 
-      res = '&#8212;' * object.parents.count
-      res << " #{the_title}"
-      res << " | #{object.parent.decorate.the_title}" if object.show_title_with_parent
-      res.html_safe
+      parts = [h.raw('&#8212;' * object.parents.count), h.sanitize(" #{the_title}")]
+      parts << h.sanitize(" | #{object.parent.decorate.the_title}") if object.show_title_with_parent
+      h.safe_join(parts)
     end
 
     # return all related posts of the current post

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -195,21 +195,25 @@ module CamaleonCms
       lan = object.get_languages
       return if lan.size < 2
 
-      res = ["<ul class='#{list_class}'>"]
-      lan.each do |lang|
-        path = "#{lang}.png"
-        label = (if block
-                   h.capture(lang, I18n.locale.to_s == lang.to_s,
-                             &block)
-                 else
-                   "<img src='#{h.asset_path("camaleon_cms/language/#{path}")}'/>"
-                 end)
-        res << "<li class='#{current_class if I18n.locale.to_s == lang.to_s}'> <a href='#{h.cama_url_to_fixed(
-          current_page ? 'url_for' : 'cama_root_url', { locale: lang, cama_set_language: lang }
-        )}'>#{label}</a> </li>"
+      h.content_tag(:ul, class: list_class) do
+        h.safe_join(lan.map do |lang|
+          label = if block
+                    h.capture(lang, I18n.locale.to_s == lang.to_s, &block)
+                  else
+                    h.tag.img(src: h.asset_path("camaleon_cms/language/#{lang}.png"))
+                  end
+
+          h.content_tag(:li, class: (current_class if I18n.locale.to_s == lang.to_s)) do
+            h.link_to(
+              label,
+              h.cama_url_to_fixed(
+                current_page ? 'url_for' : 'cama_root_url',
+                { locale: lang, cama_set_language: lang }
+              )
+            )
+          end
+        end)
       end
-      res << '</ul>'
-      res.join('').html_safe
     end
 
     # return Array of frontend languages configured for this site

--- a/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
+++ b/app/decorators/camaleon_cms/term_taxonomy_decorator.rb
@@ -97,7 +97,7 @@ module CamaleonCms
       return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
-      h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_edit_url, attrs)
+      h.link_to(h.safe_join(['→ ', title || h.ct('edit', default: 'Edit')]), the_edit_url, attrs)
     end
 
     # return the user owner of this item

--- a/app/decorators/camaleon_cms/theme_decorator.rb
+++ b/app/decorators/camaleon_cms/theme_decorator.rb
@@ -11,11 +11,11 @@ module CamaleonCms
       h.cama_admin_settings_theme_url(args)
     end
 
-    def the_settings_link
+    def the_settings_link(title = nil, attrs = {})
       return '' if h.cama_current_user.blank?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
-      h.link_to("&rarr; #{title || h.ct('edit', default: 'Edit')}".html_safe, the_settings_url, attrs)
+      h.link_to(h.safe_join(['→ ', title || h.ct('edit', default: 'Edit')]), the_settings_url, attrs)
     end
   end
 end

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -16,13 +16,13 @@ module CamaleonCms
 
       # taxonomies ->  (categories || post_tags)
       def post_type_list_taxonomy(taxonomies, color = 'primary')
-        taxonomies.decorate.map do |f|
+        safe_join(taxonomies.decorate.map do |f|
           link_to(
             cama_admin_post_type_taxonomy_posts_path(@post_type.id, f.taxonomy, f.id), class: 'cama_ajax_request'
           ) do
             content_tag(:span, f.the_title, class: "label label-#{color} label-form")
           end
-        end.join(' ').html_safe
+        end, ' ')
       end
 
       # sort array of posts to build post's tree
@@ -59,7 +59,7 @@ module CamaleonCms
         end
 
         content_tag(:ul, class: class_cat) do
-          categories.decorate.map do |f|
+          items = categories.decorate.map do |f|
             content_tag(:li) do
               is_checked = Array(values).map(&:to_s).include?(f.id.to_s)
               input_options = {
@@ -71,12 +71,13 @@ module CamaleonCms
                             check_box_tag("#{name}[]", f.id, is_checked, input_options)
                           end
               res = content_tag(:label, class: 'class_slug', data: { post_link_edit: f.the_edit_url }) do
-                "#{input_tag} #{f.the_title} ".html_safe
+                safe_join([input_tag, ' ', f.the_title.to_s, ' '])
               end
               res << post_type_html_inputs(f, 'children', name, type, values, 'children') if f.children.present?
               res
             end
-          end.join.html_safe
+          end
+          safe_join(items)
         end + content_tag(:div, '', id: "validation_error_list_#{name}")
       end
     end

--- a/app/helpers/camaleon_cms/camaleon_helper.rb
+++ b/app/helpers/camaleon_cms/camaleon_helper.rb
@@ -8,7 +8,11 @@ module CamaleonCms
       return '' unless cama_current_user.admin?
 
       attrs = { target: '_blank', style: 'font-size:11px !important;cursor:pointer;' }.merge(attrs)
-      ActionController::Base.helpers.link_to("&rarr; #{title || ct('edit', default: 'Edit')}".html_safe, url, attrs)
+      link_to(
+        safe_join(['→ ', title || ct('edit', default: 'Edit')]),
+        url,
+        attrs
+      )
     end
 
     # execute controller action and return response

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -115,7 +115,7 @@ module CamaleonCms
 
           item_attrs = []
           item_attrs << r[:item_container_attrs] if r[:item_container_attrs].present?
-          item_attrs << "class='#{item_class_str}'" if item_class_str.present?
+          item_attrs << "class='#{ERB::Util.html_escape(item_class_str)}'" if item_class_str.present?
           item_attrs_str = item_attrs.reject(&:blank?).join(' ')
 
           item_open = "<#{_args[:item_container]}"
@@ -124,18 +124,21 @@ module CamaleonCms
 
           link_attr_parts = []
           link_attr_parts << r[:link_attrs] if r[:link_attrs].present?
-          link_attr_parts << "target='#{nav_menu_item.target}'" if nav_menu_item.target.present?
-          link_attr_parts << "href='#{data_nav_item[:link]}'"
+          if nav_menu_item.target.present?
+            link_attr_parts << "target='#{ERB::Util.html_escape(nav_menu_item.target.to_s)}'"
+          end
+          link_attr_parts << "href='#{ERB::Util.html_escape(data_nav_item[:link].to_s)}'"
           link_classes = []
           link_classes << args[:link_current] if _is_current
           link_classes << _args[:link_class_parent] if has_children
           link_classes << _args[:link_class]
           link_class_str = link_classes.reject(&:blank?).join(' ')
-          link_attr_parts << "class='#{link_class_str}'" if link_class_str.present?
+          link_attr_parts << "class='#{ERB::Util.html_escape(link_class_str)}'" if link_class_str.present?
           link_attr_parts << "data-toggle='dropdown'" if has_children
           link_attrs_str = link_attr_parts.reject(&:blank?).join(' ')
 
-          link_inner = [_args[:before], data_nav_item[:name], _args[:after]].reject(&:blank?).join('')
+          # Menu labels intentionally support trusted HTML snippets (icons, buttons, embeds) configured by site admins.
+          link_inner = [_args[:before], data_nav_item[:name].to_s, _args[:after]].reject(&:blank?).join('')
           link_tag = "<a #{link_attrs_str}>#{link_inner}</a>"
 
           item_inner = [
@@ -145,7 +148,9 @@ module CamaleonCms
             html_children
           ].reject(&:blank?).join('')
           item_html = "#{item_open}#{item_inner}</#{_args[:item_container]}>"
+          # rubocop:disable Rails/OutputSafety -- User-controlled fields are escaped before this trusted menu markup is marked safe.
           items_html << item_html.html_safe
+          # rubocop:enable Rails/OutputSafety
 
           index += 1
         end

--- a/app/helpers/camaleon_cms/frontend/site_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/site_helper.rb
@@ -60,9 +60,17 @@ module CamaleonCms
       # seo_attrs: Custom attributes for seo in Hash format
       # show_seo: (Boolean) control to append or not the seo attributes
       def the_head(seo_attrs = {}, _show_seo = true)
-        js = "<script>var ROOT_URL = '#{cama_root_url}'; var LANGUAGE = '#{I18n.locale}'; </script>".html_safe
-        js += cama_draw_pre_asset_contents
-        "#{csrf_meta_tag || ''}\n#{display_meta_tags(cama_the_seo(seo_attrs))}\n#{js}\n#{cama_draw_custom_assets}"
+        js = javascript_tag("var ROOT_URL = #{cama_root_url.to_json}; var LANGUAGE = #{I18n.locale.to_s.to_json};")
+        safe_join(
+          [
+            csrf_meta_tag.presence,
+            display_meta_tags(cama_the_seo(seo_attrs)).presence,
+            js,
+            cama_draw_pre_asset_contents.presence,
+            cama_draw_custom_assets.presence
+          ].compact,
+          "\n"
+        )
       end
     end
   end

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -72,7 +72,9 @@ module CamaleonCms
 
     # return all scripts to be executed before import the js libraries(cama_draw_custom_assets)
     def cama_draw_pre_asset_contents
+      # rubocop:disable Rails/OutputSafety -- Callers append trusted script/style fragments that must render as markup.
       (@_pre_assets_content || []).join('').html_safe
+      # rubocop:enable Rails/OutputSafety
     end
 
     # return all js libraries added [aa.js, bb,js, ..]
@@ -95,7 +97,15 @@ module CamaleonCms
 
       args = { stylesheets: stylesheets, javascripts: javascripts, js_html: js, css_html: css }
       hooks_run('draw_custom_assets', args)
-      "#{args[:css_html]}\n#{args[:js_html]}\n#{@_assets_content.join('').html_safe}"
+      # rubocop:disable Rails/OutputSafety -- Asset helper output and appended fragments are trusted framework/plugin markup.
+      trusted_fragments = [args[:css_html], args[:js_html], *@_assets_content].filter_map do |fragment|
+        next if fragment.blank?
+
+        fragment.is_a?(ActiveSupport::SafeBuffer) ? fragment : fragment.to_s.html_safe
+      end
+      # rubocop:enable Rails/OutputSafety
+
+      safe_join(trusted_fragments, "\n")
     end
 
     # create an HTML tooltip to include anywhere

--- a/spec/controllers/plugins/attack/attack_helper_spec.rb
+++ b/spec/controllers/plugins/attack/attack_helper_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Plugins::Attack::AttackHelper, type: :controller do
+  controller(ActionController::Base) do
+    # rubocop:disable RSpec/DescribedClass
+    include Plugins::Attack::AttackHelper
+    # rubocop:enable RSpec/DescribedClass
+
+    def index
+      attack_app_before_load
+    end
+
+    def current_site
+      nil
+    end
+
+    def attack_check_request; end
+
+    def cama_get_session_id
+      'attack-helper-session'
+    end
+  end
+
+  before do
+    routes.draw { get 'index' => 'anonymous#index' }
+  end
+
+  after do
+    Rails.cache.delete('attack-helper-session')
+  end
+
+  it 'escapes cached ban messages before rendering them' do
+    Rails.cache.write('attack-helper-session', '<script>alert(1)</script>')
+
+    get :index
+
+    expect(response.body).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+    expect(response.body).not_to include('<script>')
+  end
+end

--- a/spec/decorators/locale_resolution_spec.rb
+++ b/spec/decorators/locale_resolution_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe 'Decorator i18n locale resolution', type: :feature do
 
           # Verify the page head renders correct locale (via the_head method)
           # This confirms I18n.locale was set to site's frontend language, not :en
-          expect(page.html).to include("var LANGUAGE = 'es';"),
+          expect(page.html).to include('var LANGUAGE = "es";'),
                                "Expected page head to render LANGUAGE='es' (site's frontend language)"
         ensure
           I18n.locale = original_locale
@@ -97,7 +97,7 @@ RSpec.describe 'Decorator i18n locale resolution', type: :feature do
         # See: app/helpers/camaleon_cms/frontend/site_helper.rb line 63
         # This proves I18n.locale is set correctly to site's frontend language
         expected_language = site.get_languages.first.to_s
-        expect(page.html).to include("var LANGUAGE = '#{expected_language}';"),
+        expect(page.html).to include("var LANGUAGE = \"#{expected_language}\";"),
                              "Expected page head to render LANGUAGE='#{expected_language}' (site's frontend language)"
 
         # Additional verification: direct decorator test
@@ -127,7 +127,7 @@ RSpec.describe 'Decorator i18n locale resolution', type: :feature do
 
         # Verify the rendered head shows Spanish locale
         # This proves I18n.locale was set to user's chosen language
-        expect(page.html).to include("var LANGUAGE = 'es';"),
+        expect(page.html).to include('var LANGUAGE = "es";'),
                              "Expected page head to render LANGUAGE='es' after user switched to Spanish"
       ensure
         I18n.locale = original_locale

--- a/spec/decorators/post_decorator_spec.rb
+++ b/spec/decorators/post_decorator_spec.rb
@@ -25,4 +25,35 @@ RSpec.describe CamaleonCms::PostDecorator do
       expect(decorator.the_title).to include('&lt;script&gt;')
     end
   end
+
+  describe '#the_edit_link' do
+    let(:title) { 'Editable Post' }
+
+    it 'escapes the link label' do
+      allow(decorator.h).to receive(:cama_current_user).and_return(instance_double(CamaleonCms::User))
+      allow(decorator).to receive(:the_edit_url).and_return('/admin/posts/1/edit')
+
+      output = decorator.the_edit_link('<script>alert(1)</script>')
+
+      expect(output).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(output).not_to include('<script>')
+    end
+  end
+
+  describe '#the_hierarchy_title' do
+    let(:title) { '<img src=x onerror=alert(1)>' }
+    let(:parent_post) { create(:post, site: post.post_type.site, title: '<script>alert(1)</script>') }
+
+    it 'escapes both child and parent titles' do
+      post.update!(post_parent: parent_post.id)
+      post.show_title_with_parent = true
+
+      output = decorator.the_hierarchy_title
+
+      expect(output).to include('&lt;img')
+      expect(output).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(output).not_to include('<img')
+      expect(output).not_to include('<script>')
+    end
+  end
 end

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::SiteDecorator do
+  let(:site) { create(:site) }
+  let(:decorator) { site.decorate }
+
+  before do
+    allow(site).to receive(:get_languages).and_return(%w[en es])
+    allow(decorator.h).to receive(:asset_path).and_return('/assets/en.png')
+    allow(decorator.h).to receive(:cama_url_to_fixed) do |_helper_name, options|
+      "/?locale=#{options[:locale]}"
+    end
+  end
+
+  describe '#draw_languages' do
+    it 'escapes labels returned by the block' do
+      output = decorator.draw_languages('langs', true) { |_lang, _current| '<script>alert(1)</script>' }
+
+      expect(output).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(output).not_to include('<script>')
+    end
+  end
+end

--- a/spec/dummy/app/apps/themes/camaleon_first/main_helper.rb
+++ b/spec/dummy/app/apps/themes/camaleon_first/main_helper.rb
@@ -11,9 +11,7 @@ module Themes
 
       # return a list of options for "Recent items from " on site settings -> theme settings
       def camaleon_first_list_select
-        res = []
-        current_site.the_post_types.decorate.each { |p| res << "<option value='#{p.the_slug}'>#{p.the_title}</option>" }
-        res.join('').html_safe
+        safe_join(current_site.the_post_types.decorate.map { |p| content_tag(:option, p.the_title, value: p.the_slug) })
       end
 
       def camaleon_first_on_install_theme(theme)

--- a/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
@@ -147,6 +147,32 @@ RSpec.describe CamaleonCms::Frontend::NavMenuHelper do
       end
     end
 
+    context 'with unsafe menu values' do
+      before do
+        @menu_item = create(
+          :nav_menu_item,
+          name: 'Embedded',
+          url: "/search?q=' onclick='alert(1)",
+          kind: 'external',
+          target: "_blank' rel='bad",
+          parent: @menu
+        )
+        allow(helper).to receive(:cama_parse_menu_item).and_return(
+          link: "/search?q=' onclick='alert(1)",
+          name: '<iframe src="https://example.test/embed"></iframe>',
+          current: false
+        )
+      end
+
+      it 'keeps trusted HTML labels while escaping attribute values' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result).to include('<iframe src="https://example.test/embed"></iframe>')
+        expect(result).to include("href='/search?q=&#39; onclick=&#39;alert(1)'")
+        expect(result).to include("target='_blank&#39; rel=&#39;bad'")
+      end
+    end
+
     context 'with before/after content' do
       before do
         @menu_item =

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -13,4 +13,19 @@ describe CamaleonCms::HtmlHelper do
 
     it_behaves_like 'i18n value translation safety'
   end
+
+  describe '#cama_draw_custom_assets' do
+    it 'returns asset tags as renderable markup' do
+      helper.cama_html_helpers_init
+      allow(helper).to receive(:hooks_run)
+
+      helper.cama_load_libraries('nav_menu')
+      output = helper.cama_draw_custom_assets
+
+      expect(output).to include('<script')
+      expect(output).to include('<link')
+      expect(output).not_to include('&lt;script')
+      expect(output).not_to include('&lt;link')
+    end
+  end
 end

--- a/spec/helpers/themes/camaleon_first/main_helper_spec.rb
+++ b/spec/helpers/themes/camaleon_first/main_helper_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('app/apps/themes/camaleon_first/main_helper')
+
+RSpec.describe Themes::CamaleonFirst::MainHelper, type: :helper do
+  before do
+    helper.singleton_class.include(described_class)
+  end
+
+  describe '#camaleon_first_list_select' do
+    it 'escapes option labels and values' do
+      post_type = double(the_slug: 'bad"slug', the_title: '<script>alert(1)</script>')
+      allow(helper).to receive(:current_site).and_return(double(the_post_types: double(decorate: [post_type])))
+
+      output = helper.camaleon_first_list_select
+
+      expect(output).to include('&lt;script&gt;alert(1)&lt;/script&gt;')
+      expect(output).to include('value="bad&quot;slug"')
+      expect(output).not_to include('<script>')
+    end
+  end
+end

--- a/spec/requests/admin/media_controller/crop_spec.rb
+++ b/spec/requests/admin/media_controller/crop_spec.rb
@@ -23,6 +23,21 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#crop', type: :request do
 
       expect(response.status).not_to eq(403)
     end
+
+    it 'returns the cropped url as plain text' do
+      allow_any_instance_of(described_class).to receive(:verify_media_authorization).and_return(true)
+      allow_any_instance_of(described_class).to receive(:cama_tmp_upload).and_return(file_path: '/tmp/test.jpg')
+      allow_any_instance_of(described_class).to receive(:cama_crop_image).and_return('/tmp/cropped.jpg')
+      allow_any_instance_of(described_class).to receive(:upload_file).and_return(
+        'url' => '/uploads/<script>alert(1)</script>.jpg'
+      )
+      sign_in_as(admin_user, site: current_site)
+
+      get '/admin/media/crop'
+
+      expect(response.media_type).to eq('text/plain')
+      expect(response.body).to eq('/uploads/<script>alert(1)</script>.jpg')
+    end
   end
 
   context 'when user does NOT have media management permission' do


### PR DESCRIPTION
## What and Why
This updates the remaining Rails/OutputSafety call sites by fixing the places that could render untrusted HTML and by narrowing suppressions to trusted markup replay paths only. It also preserves intended frontend and admin behavior by restoring trusted menu-label HTML and renderable asset tags where the initial cleanup had become too aggressive.

## User-Visible Impact
Frontend menus, admin menus, edit links, cached pages, and related HTML rendering continue to display correctly while unsafe HTML sinks are no longer rendered as trusted output.