### PR TITLE
Restore admin locale compatibility removed by #1166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Fix:** Restore admin preview locale compatibility for decorators and plugin helpers, [#1175](https://github.com/owen2345/camaleon-cms/pull/1175)
+  - Restores the admin-side frontend locale compatibility path removed by #1166
+  - Preserves theme previews and other admin-rendered frontend flows that rely on frontend URLs or plugin helpers such as `camaleon-ecommerce`
+
 - **Security fix:** Fix Rails OutputSafety sinks while preserving menu and asset rendering, [#1174](https://github.com/owen2345/camaleon-cms/pull/1174)
   - Escapes untrusted HTML in attack responses, media crop output, edit-link labels, hierarchy titles, and select option generation
   - Keeps trusted cached markup replay and asset injection paths explicit and narrowly suppressed

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -16,6 +16,7 @@ module CamaleonCms
              params[:cama_ajax_request].present? ? 'camaleon_cms/admin/_ajax' : 'camaleon_cms/admin'
            }
     add_breadcrumb I18n.t('camaleon_cms.admin.sidebar.dashboard', default: 'Dashboard'), :cama_admin_path
+    helper_method :cama_get_i18n_frontend
 
     # render admin dashboard
     def index
@@ -68,6 +69,12 @@ module CamaleonCms
       @items = @items.paginate(page: params[:page], per_page: current_site.admin_per_page)
     end
 
+    # Decorators use this helper while rendering admin pages to keep public URLs in
+    # the site's frontend language instead of the admin interface language.
+    def cama_get_i18n_frontend
+      @cama_i18n_frontend
+    end
+
     private
 
     # initialize all vars and methods for admin panel
@@ -76,6 +83,9 @@ module CamaleonCms
       @_admin_menus = {}
       @_admin_breadcrumb = []
       @_extra_models_for_fields = []
+      # Cache the site's frontend language for decorators and plugins that still
+      # need to distinguish admin requests from frontend visitor requests.
+      @cama_i18n_frontend = current_site.get_languages.first
     end
 
     # trigger hooks for admin panel before admin load

--- a/app/decorators/camaleon_cms/application_decorator.rb
+++ b/app/decorators/camaleon_cms/application_decorator.rb
@@ -50,14 +50,25 @@ module CamaleonCms
       @_deco_locale = locale.to_sym
     end
 
-    # get the locale for current decorator
+    # Admin requests can render frontend URLs from the dashboard, so prefer the
+    # cached frontend locale before falling back to the current I18n locale.
     def get_locale(locale = nil)
-      locale || @_deco_locale || I18n.locale
+      frontend_locale = begin
+        h.cama_get_i18n_frontend
+      rescue NoMethodError
+        nil
+      end
+      locale || @_deco_locale || frontend_locale || I18n.locale
     end
 
     # return the current locale prefixed to add in frontend routes
     def _calc_locale(_l)
-      _l = (_l || @_deco_locale || I18n.locale).to_s
+      frontend_locale = begin
+        h.cama_get_i18n_frontend
+      rescue NoMethodError
+        nil
+      end
+      _l = (_l || @_deco_locale || frontend_locale || I18n.locale).to_s
       "_#{_l}"
     end
   end

--- a/app/helpers/camaleon_cms/camaleon_helper.rb
+++ b/app/helpers/camaleon_cms/camaleon_helper.rb
@@ -48,6 +48,15 @@ module CamaleonCms
       I18n.translate("camaleon_cms.common.#{key}", **args)
     end
 
+    # Public compatibility API for plugins such as camaleon-ecommerce, which use
+    # this predicate to switch from visitor pricing/locale behavior to admin mode.
+    # This still matters while previewing frontend content from admin, for example
+    # a theme preview that renders ecommerce helpers before the request reaches the
+    # public frontend controller stack.
+    def cama_is_admin_request?
+      respond_to?(:cama_get_i18n_frontend) && cama_get_i18n_frontend.present?
+    end
+
     # generate loop categories html sitemap links
     # this is a helper for sitemap generator to print categories, sub categories and post contents in html list format
     def cama_sitemap_cats_generator(cats)

--- a/docs/ai/rails-conventions.md
+++ b/docs/ai/rails-conventions.md
@@ -41,6 +41,9 @@ module CamaleonCms
 end
 ```
 
+- Admin pages can render frontend decorators and plugin helpers during preview flows.
+- Preserve the `cama_get_i18n_frontend` / `cama_is_admin_request?` compatibility path when changing locale behavior around admin previews, especially for theme previews that render plugins such as `camaleon-ecommerce`.
+
 ### Association Options
 
 Always specify class_name and foreign_key explicitly

--- a/docs/ai/reference.md
+++ b/docs/ai/reference.md
@@ -62,6 +62,9 @@ Plugins live in `app/apps/plugins/` and can:
 - Hook into lifecycle events
 - Add migrations
 
+Compatibility note:
+- `CamaleonHelper#cama_is_admin_request?` is still a public plugin API. Keep it available for admin-rendered frontend flows such as theme preview pages that call plugin helpers like `camaleon-ecommerce`, where the plugin must detect admin preview mode instead of visitor/frontend mode.
+
 ## Authorization
 
 - Roles and permissions managed via `CamaleonCms::UserRole` and CanaCanCan's `Ability` class

--- a/spec/decorators/locale_resolution_spec.rb
+++ b/spec/decorators/locale_resolution_spec.rb
@@ -2,136 +2,77 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Decorator i18n locale resolution', type: :feature do
-  let!(:site) { create(:site) }
-  let!(:post) { create(:post, site: site) }
+RSpec.describe CamaleonCms::ApplicationDecorator do
+  init_site
 
-  describe 'ApplicationDecorator#get_locale priority chain' do
-    let(:decorated_post) { post.decorate }
+  let(:decorated_post) { @post }
+  let(:helper_context_class) do
+    Class.new do
+      def initialize(frontend_locale)
+        @frontend_locale = frontend_locale
+      end
 
-    it 'uses explicit locale when provided' do
+      def cama_get_i18n_frontend
+        @frontend_locale
+      end
+    end
+  end
+  let(:helper_context) { helper_context_class.new(:es) }
+
+  around do |example|
+    original_locale = I18n.locale
+    example.run
+    I18n.locale = original_locale
+  end
+
+  before do
+    allow(decorated_post).to receive(:h).and_return(helper_context)
+  end
+
+  describe '#get_locale' do
+    it 'uses an explicit locale when provided' do
       expect(decorated_post.get_locale(:es)).to eq(:es)
     end
 
-    it 'uses set_decoration_locale when explicit not provided' do
+    it 'uses the decoration locale before helper or I18n fallbacks' do
       decorated_post.set_decoration_locale(:fr)
+      I18n.locale = :en
+
       expect(decorated_post.get_locale).to eq(:fr)
     end
 
-    it 'falls back to I18n.locale as last resort' do
-      expect(decorated_post.get_locale).to eq(I18n.locale)
+    it 'uses the admin request frontend locale before I18n.locale' do
+      I18n.locale = :en
+
+      expect(decorated_post.get_locale).to eq(:es)
+    end
+
+    it 'falls back to I18n.locale when no frontend locale helper is exposed' do
+      allow(decorated_post).to receive(:h).and_return(Object.new)
+      I18n.locale = :en
+
+      expect(decorated_post.get_locale).to eq(:en)
     end
   end
 
-  describe 'decorator locale usage: admin vs frontend contexts' do
-    describe 'in frontend context' do
-      it 'renders correct frontend language in page output (via I18n.locale)' do
-        # Set site frontend language to 'es'
-        site.set_meta('languages_site', ['es'])
-        # Refresh cache to pick up new language
-        site.instance_variable_set(:@_languages, nil)
+  describe '#_calc_locale' do
+    it 'uses the admin request frontend locale when building route prefixes' do
+      I18n.locale = :en
 
-        # Set I18n.locale to different value 'en' initially
-        original_locale = I18n.locale
-        begin
-          I18n.locale = :en
-
-          # Visit frontend - init_frontent will set I18n.locale to site's frontend language (:es)
-          visit '/'
-          expect(page.status_code).to eq(200)
-
-          # Verify the page head renders correct locale (via the_head method)
-          # This confirms I18n.locale was set to site's frontend language, not :en
-          expect(page.html).to include('var LANGUAGE = "es";'),
-                               "Expected page head to render LANGUAGE='es' (site's frontend language)"
-        ensure
-          I18n.locale = original_locale
-        end
-      end
+      expect(decorated_post.send(:_calc_locale, nil)).to eq('_es')
     end
   end
 
-  describe 'POST decorator URL generation' do
-    it 'generates a valid URL without raising an error' do
-      decorated_post = post.decorate
-      url = decorated_post.the_url
+  describe CamaleonCms::AdminController do
+    let(:controller_instance) { described_class.new }
+    let(:site) { instance_double(CamaleonCms::Site, get_admin_language: :en, get_languages: %i[es en]) }
 
-      expect(url).to be_a(String)
-      expect(url).not_to be_empty
-    end
+    it 'caches the frontend locale for admin helpers and decorators' do
+      allow(controller_instance).to receive(:current_site).and_return(site)
 
-    context 'with site having specific frontend language' do
-      it 'generates URL using available site languages' do
-        site.get_languages
+      controller_instance.send(:admin_init_actions)
 
-        decorated = post.decorate
-        url = decorated.the_url
-
-        # URL should be generated successfully
-        expect(url).to be_a(String)
-        # URL should exist
-        expect(url.length).to be > 0
-      end
-    end
-  end
-
-  describe 'decorator locale resolution: verified via rendered output' do
-    it 'renders correct I18n.locale in frontend page head (set to site frontend language)' do
-      # Set the existing site to have English and Spanish as frontend languages
-      site.set_meta('languages_site', [I18n.default_locale, :es])
-
-      original_locale = I18n.locale
-      begin
-        # Set I18n.locale to English (site's first language)
-        I18n.locale = :en
-
-        # Visit the frontend home page - this triggers the controller's `before_action :init_frontent`,
-        # which, if no params[:locale] || session[:cama_current_language] are present, initializes I18n.locale to the
-        # site's first language (:en in this case)
-        visit '/'
-
-        # Verify page loaded successfully
-        expect(page.status_code).to eq(200)
-
-        # Verify the rendered output: the_head method renders var LANGUAGE = 'I18n.locale' in JavaScript
-        # See: app/helpers/camaleon_cms/frontend/site_helper.rb line 63
-        # This proves I18n.locale is set correctly to site's frontend language
-        expected_language = site.get_languages.first.to_s
-        expect(page.html).to include("var LANGUAGE = \"#{expected_language}\";"),
-                             "Expected page head to render LANGUAGE='#{expected_language}' (site's frontend language)"
-
-        # Additional verification: direct decorator test
-        frontend_language = site.get_languages.first
-        decorated = site.post_types.first&.posts&.first&.decorate
-        if decorated.present?
-          actual_locale = decorated.get_locale
-          expect(actual_locale)
-            .to eq(frontend_language),
-                "Expected decorator to use site's frontend language (#{frontend_language}), but got #{actual_locale}"
-        end
-      ensure
-        I18n.locale = original_locale
-      end
-    end
-
-    it 'renders correct I18n.locale when user explicitly switches language' do
-      site.set_meta('languages_site', [I18n.default_locale, :es])
-
-      original_locale = I18n.locale
-      begin
-        # User clicks language switcher to switch to Spanish
-        visit '/?cama_set_language=es'
-
-        # Verify page loaded
-        expect(page.status_code).to eq(200)
-
-        # Verify the rendered head shows Spanish locale
-        # This proves I18n.locale was set to user's chosen language
-        expect(page.html).to include('var LANGUAGE = "es";'),
-                             "Expected page head to render LANGUAGE='es' after user switched to Spanish"
-      ensure
-        I18n.locale = original_locale
-      end
+      expect(controller_instance.cama_get_i18n_frontend).to eq(:es)
     end
   end
 end

--- a/spec/helpers/camaleon_cms/camaleon_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/camaleon_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::CamaleonHelper, type: :helper do
+  describe '#cama_is_admin_request?' do
+    it 'returns true when the admin compatibility helper exposes a frontend locale' do
+      helper.define_singleton_method(:cama_get_i18n_frontend) { :es }
+
+      expect(helper.cama_is_admin_request?).to be(true)
+    end
+
+    it 'returns false when the helper is running outside the admin compatibility context' do
+      expect(helper.cama_is_admin_request?).to be(false)
+    end
+  end
+end


### PR DESCRIPTION
## What and Why
Restore the admin/frontend locale compatibility path removed in #1166 so admin-rendered frontend URLs and plugin helpers can still distinguish preview/admin mode. This reintroduces the frontend-locale helper path, restores `cama_is_admin_request?`, adds focused regression coverage, and documents the theme-preview ecommerce use case for future work.

## User-Visible Impact
Theme previews and other admin-rendered frontend content keep using the site's frontend locale, and plugins such as `camaleon-ecommerce` continue switching to admin behavior while previewing.