### PR TITLE
Refactor helper state for Phase 1 CurrentRequest rollout

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -147,6 +147,22 @@ Naming/VariableNumber:
     - 'config/initializers/assets.rb'
     - 'spec/models/post_spec.rb'
 
+# Offense count: 160
+Rails/HelperInstanceVariable:
+  Exclude:
+    - 'app/helpers/camaleon_cms/admin/custom_fields_helper.rb'
+    - 'app/helpers/camaleon_cms/admin/menus_helper.rb'
+    - 'app/helpers/camaleon_cms/admin/post_type_helper.rb'
+    - 'app/helpers/camaleon_cms/camaleon_helper.rb'
+    - 'app/helpers/camaleon_cms/comment_helper.rb'
+    - 'app/helpers/camaleon_cms/frontend/content_select_helper.rb'
+    - 'app/helpers/camaleon_cms/frontend/nav_menu_helper.rb'
+    - 'app/helpers/camaleon_cms/frontend/seo_helper.rb'
+    - 'app/helpers/camaleon_cms/frontend/site_helper.rb'
+    - 'app/helpers/camaleon_cms/session_helper.rb'
+    - 'app/helpers/camaleon_cms/short_code_helper.rb'
+    - 'app/helpers/camaleon_cms/site_helper.rb'
+
 # Offense count: 2
 Security/Eval:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Refactor:** Replace Phase 1 helper instance-variable state with CurrentRequest-backed state, [#1176](https://github.com/owen2345/camaleon-cms/pull/1176)
+  - Refactors content, hooks, html, and theme helpers to use request-scoped CurrentRequest state
+  - Extends CurrentRequest with helper state attributes used by these helpers
+  - Adds helper specs for content/hooks/theme state lifecycle and html helper state behavior
+
 - **Fix:** Restore admin preview locale compatibility for decorators and plugin helpers, [#1175](https://github.com/owen2345/camaleon-cms/pull/1175)
   - Restores the admin-side frontend locale compatibility path removed by #1166
   - Preserves theme previews and other admin-rendered frontend flows that rely on frontend URLs or plugin helpers such as `camaleon-ecommerce`

--- a/app/helpers/camaleon_cms/content_helper.rb
+++ b/app/helpers/camaleon_cms/content_helper.rb
@@ -2,34 +2,41 @@ module CamaleonCms
   module ContentHelper
     # initialize content variables
     def cama_content_init
-      @_before_content = []
-      @_after_content = []
+      state = cama_content_state
+      state[:before_content] = []
+      state[:after_content] = []
     end
 
     # prepend content for admin or frontend (after <body>)
     # sample: cama_content_prepend(<div>my prepend content</div>)
     def cama_content_prepend(content)
-      @_before_content << content
+      cama_content_state[:before_content] << content
     end
 
     # append content for admin or frontend (before </body>)
     # sample: cama_content_prepend(<div>my after content</div>)
     def cama_content_append(content)
-      @_after_content << content
+      cama_content_state[:after_content] << content
     end
 
     # draw all before contents registered by cama_content_prepend
     def cama_content_before_draw
-      @_before_content.join('')
+      cama_content_state[:before_content].join('')
     rescue StandardError
       ''
     end
 
     # draw all after contents registered by cama_content_append
     def cama_content_after_draw
-      @_after_content.join('')
+      cama_content_state[:after_content].join('')
     rescue StandardError
       ''
+    end
+
+    private
+
+    def cama_content_state
+      CurrentRequest.content_helper_state ||= { before_content: [], after_content: [] }
     end
   end
 end

--- a/app/helpers/camaleon_cms/hooks_helper.rb
+++ b/app/helpers/camaleon_cms/hooks_helper.rb
@@ -28,7 +28,7 @@ module CamaleonCms
 
     # skip hook function with name: hook_function_name
     def hook_skip(hook_function_name)
-      @_hooks_skip << hook_function_name
+      hook_skip_list << hook_function_name
     end
 
     private
@@ -37,7 +37,7 @@ module CamaleonCms
       return if plugin.blank? || plugin['hooks'].blank? || plugin['hooks'][hook_key].blank?
 
       plugin['hooks'][hook_key].each do |hook|
-        next if @_hooks_skip.present? && @_hooks_skip.include?(hook)
+        next if hook_skip_list.include?(hook)
 
         begin
           if params.nil?
@@ -59,6 +59,18 @@ module CamaleonCms
           end
         end
       end
+    end
+
+    def hook_skip_list
+      state = camaleon_hooks_state
+      return state[:hooks_skip] if state[:hooks_skip]
+
+      existing_hooks_skip = instance_variable_get(:@_hooks_skip)
+      state[:hooks_skip] = existing_hooks_skip.is_a?(Array) ? existing_hooks_skip : []
+    end
+
+    def camaleon_hooks_state
+      CurrentRequest.hooks_helper_state ||= {}
     end
   end
 end

--- a/app/helpers/camaleon_cms/html_helper.rb
+++ b/app/helpers/camaleon_cms/html_helper.rb
@@ -1,9 +1,10 @@
 module CamaleonCms
   module HtmlHelper
     def cama_html_helpers_init
-      @_pre_assets_content = [] # Assets contents before the libraries import
-      @_assets_libraries = {}
-      @_assets_content = []
+      state = camaleon_html_helper_state
+      state[:pre_assets_content] = [] # Assets contents before the libraries import
+      state[:assets_libraries] = {}
+      state[:assets_content] = []
     end
 
     # register a new asset library to be included on demand calling by: cama_load_libraries(...)
@@ -12,18 +13,20 @@ module CamaleonCms
     def cama_assets_library_register(key, assets = {})
       key = key.to_sym
       cama_assets_libraries
-      @_cama_assets_libraries[key] = { css: [], js: [] } if @_cama_assets_libraries[key].blank?
-      @_cama_assets_libraries[key][:css] += assets[:css] if assets[:css].present?
-      @_cama_assets_libraries[key][:js] += assets[:js] if assets[:js].present?
+      state = camaleon_html_helper_state
+      state[:cama_assets_libraries][key] = { css: [], js: [] } if state[:cama_assets_libraries][key].blank?
+      state[:cama_assets_libraries][key][:css] += assets[:css] if assets[:css].present?
+      state[:cama_assets_libraries][key][:js] += assets[:js] if assets[:js].present?
     end
 
     # enable to load admin or registered libraries (colorpicker, datepicker, tinymce, form_ajax, cropper)
     # sample: add_asset_library("datepicker", "colorpicker")
     # This will add this assets library in the admin head or in a custom place by calling: cama_draw_custom_assets()
     def cama_load_libraries(*keys)
+      state = camaleon_html_helper_state
       keys.each do |key|
         library = cama_assets_libraries[key.to_sym]
-        @_assets_libraries[key.to_sym] = library if library.present?
+        state[:assets_libraries][key.to_sym] = library if library.present?
       end
     end
 
@@ -44,12 +47,13 @@ module CamaleonCms
     #   append_asset_libraries({"colorpicker"=>{js: [plugin_asset("js/my_custom_js")] } })
     # return nil
     def append_asset_libraries(libraries)
+      state = camaleon_html_helper_state
       libraries.each do |key, library|
-        @_assets_libraries[key.to_sym] = if @_assets_libraries.include?(key)
-                                           @_assets_libraries[key.to_sym].merge(library)
-                                         else
-                                           library
-                                         end
+        state[:assets_libraries][key.to_sym] = if state[:assets_libraries].include?(key)
+                                                 state[:assets_libraries][key.to_sym].merge(library)
+                                               else
+                                                 library
+                                               end
       end
     end
     alias cama_load_custom_assets append_asset_libraries
@@ -59,7 +63,7 @@ module CamaleonCms
     # content may be: <style>a{color: red;}</style>
     # this will be printed with <%raw cama_draw_custom_assets %>
     def append_asset_content(content)
-      @_assets_content << content
+      camaleon_html_helper_state[:assets_content] << content
     end
 
     # add pre asset content into custom assets
@@ -67,29 +71,30 @@ module CamaleonCms
     # content may be: <style>a{color: red;}</style>
     # this will be printed before assets_library with <%raw cama_draw_pre_asset_contents %>
     def append_pre_asset_content(content)
-      @_pre_assets_content << content
+      camaleon_html_helper_state[:pre_assets_content] << content
     end
 
     # return all scripts to be executed before import the js libraries(cama_draw_custom_assets)
     def cama_draw_pre_asset_contents
       # rubocop:disable Rails/OutputSafety -- Callers append trusted script/style fragments that must render as markup.
-      (@_pre_assets_content || []).join('').html_safe
+      camaleon_html_helper_state[:pre_assets_content].join('').html_safe
       # rubocop:enable Rails/OutputSafety
     end
 
     # return all js libraries added [aa.js, bb,js, ..]
     # def get_assets_js
     def cama_draw_custom_assets
-      cama_html_helpers_init if @_assets_libraries.blank?
+      state = camaleon_html_helper_state
+      cama_html_helpers_init if state[:assets_libraries].blank?
       libs = []
-      @_assets_libraries.each_value do |assets|
+      state[:assets_libraries].each_value do |assets|
         libs += assets[:css] if assets[:css].present?
       end
       stylesheets = libs.uniq
       css = stylesheet_link_tag(*stylesheets, media: 'all')
 
       libs = []
-      @_assets_libraries.each_value do |assets|
+      state[:assets_libraries].each_value do |assets|
         libs += assets[:js] if assets[:js].present?
       end
       javascripts = libs.uniq
@@ -98,7 +103,7 @@ module CamaleonCms
       args = { stylesheets: stylesheets, javascripts: javascripts, js_html: js, css_html: css }
       hooks_run('draw_custom_assets', args)
       # rubocop:disable Rails/OutputSafety -- Asset helper output and appended fragments are trusted framework/plugin markup.
-      trusted_fragments = [args[:css_html], args[:js_html], *@_assets_content].filter_map do |fragment|
+      trusted_fragments = [args[:css_html], args[:js_html], *state[:assets_content]].filter_map do |fragment|
         next if fragment.blank?
 
         fragment.is_a?(ActiveSupport::SafeBuffer) ? fragment : fragment.to_s.html_safe
@@ -120,7 +125,8 @@ module CamaleonCms
     private
 
     def cama_assets_libraries
-      return @_cama_assets_libraries if @_cama_assets_libraries.present?
+      state = camaleon_html_helper_state
+      return state[:cama_assets_libraries] if state[:cama_assets_libraries].present?
 
       libs = {}
       libs[:colorpicker] =
@@ -142,7 +148,15 @@ module CamaleonCms
           js: %w[camaleon_cms/admin/jquery.nestable camaleon_cms/admin/nav_menu] }
       libs[:admin_intro] =
         { js: ['camaleon_cms/admin/introjs/intro.min'], css: ['camaleon_cms/admin/introjs/introjs.min'] }
-      @_cama_assets_libraries = libs
+      state[:cama_assets_libraries] = libs
+    end
+
+    def camaleon_html_helper_state
+      state = CurrentRequest.html_helper_state ||= {}
+      state[:pre_assets_content] ||= []
+      state[:assets_libraries] ||= {}
+      state[:assets_content] ||= []
+      state
     end
 
     # execute translation for value if this value is like: t(admin.my_text) ==> My Text

--- a/app/helpers/camaleon_cms/theme_helper.rb
+++ b/app/helpers/camaleon_cms/theme_helper.rb
@@ -1,7 +1,9 @@
 module CamaleonCms
   module ThemeHelper
     def theme_init
-      @_front_breadcrumb = []
+      breadcrumb_items = []
+      camaleon_theme_state[:front_breadcrumb] = breadcrumb_items
+      instance_variable_set(:@_front_breadcrumb, breadcrumb_items)
     end
 
     # return theme full asset path
@@ -93,6 +95,12 @@ module CamaleonCms
       current_site.the_post(current_theme.get_field('home_page')) ||
         current_site.the_posts('page').first ||
         CamaleonCms::Post.new(title: 'Hello World!', content: 'Please add a page.', status: 'published')
+    end
+
+    private
+
+    def camaleon_theme_state
+      CurrentRequest.theme_helper_state ||= {}
     end
   end
 end

--- a/app/models/current_request.rb
+++ b/app/models/current_request.rb
@@ -12,5 +12,5 @@
 # Note: Rails automatically resets CurrentAttributes between requests, ensuring no leakage.
 # In specs, call CurrentRequest.reset in before/after hooks to avoid cross-test pollution.
 class CurrentRequest < ActiveSupport::CurrentAttributes
-  attribute :user, :site
+  attribute :user, :site, :content_helper_state, :hooks_helper_state, :html_helper_state, :theme_helper_state
 end

--- a/spec/helpers/camaleon_cms/content_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/content_helper_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::ContentHelper do
+  let(:content_helper) do
+    Class.new do
+      include CamaleonCms::ContentHelper
+    end.new
+  end
+
+  describe 'CurrentRequest-backed helper state' do
+    it 'stores content buffers in CurrentRequest' do
+      content_helper.cama_content_init
+      content_helper.cama_content_prepend('<div>before</div>')
+      content_helper.cama_content_append('<div>after</div>')
+
+      state = CurrentRequest.content_helper_state
+      expect(state[:before_content]).to eq(['<div>before</div>'])
+      expect(state[:after_content]).to eq(['<div>after</div>'])
+      expect(content_helper.cama_content_before_draw).to eq('<div>before</div>')
+      expect(content_helper.cama_content_after_draw).to eq('<div>after</div>')
+    end
+
+    it 'reinitializes buffers after CurrentRequest.reset' do
+      content_helper.cama_content_init
+      content_helper.cama_content_prepend('<div>before</div>')
+      CurrentRequest.reset
+
+      expect(content_helper.cama_content_before_draw).to eq('')
+      expect(content_helper.cama_content_after_draw).to eq('')
+    end
+  end
+end

--- a/spec/helpers/camaleon_cms/hooks_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/hooks_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::HooksHelper do
+  let(:hooks_helper) do
+    Class.new do
+      include CamaleonCms::HooksHelper
+    end.new
+  end
+
+  describe 'CurrentRequest-backed helper state' do
+    it 'stores the skip list in CurrentRequest' do
+      hooks_helper.hook_skip('skip_me')
+
+      expect(CurrentRequest.hooks_helper_state[:hooks_skip]).to eq(['skip_me'])
+    end
+
+    it 'starts with an empty skip list after CurrentRequest.reset' do
+      hooks_helper.hook_skip('skip_me')
+      CurrentRequest.reset
+
+      expect(hooks_helper.send(:hook_skip_list)).to eq([])
+    end
+  end
+end

--- a/spec/helpers/camaleon_cms/theme_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/theme_helper_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::ThemeHelper do
+  let(:theme_helper) do
+    Class.new do
+      include CamaleonCms::ThemeHelper
+    end.new
+  end
+
+  describe '#theme_init' do
+    it 'stores breadcrumb state in CurrentRequest' do
+      theme_helper.theme_init
+
+      state = CurrentRequest.theme_helper_state
+      expect(state[:front_breadcrumb]).to eq([])
+    end
+
+    it 'keeps nav menu helper compatibility via @_front_breadcrumb' do
+      theme_helper.theme_init
+
+      expect(theme_helper.instance_variable_get(:@_front_breadcrumb)).to eq([])
+    end
+  end
+end

--- a/spec/helpers/html_helper_spec.rb
+++ b/spec/helpers/html_helper_spec.rb
@@ -28,4 +28,15 @@ describe CamaleonCms::HtmlHelper do
       expect(output).not_to include('&lt;link')
     end
   end
+
+  describe 'CurrentRequest-backed helper state' do
+    it 'stores html helper state in CurrentRequest' do
+      helper.cama_html_helpers_init
+      helper.cama_load_libraries('nav_menu')
+
+      state = CurrentRequest.html_helper_state
+      expect(state).to be_present
+      expect(state[:assets_libraries]).to include(:nav_menu)
+    end
+  end
 end


### PR DESCRIPTION
## What and Why
This PR ships Phase 1 of the Rails/HelperInstanceVariable cleanup by moving mutable helper request state from helper instance variables and thread-local fallback storage into CurrentRequest (ActiveSupport::CurrentAttributes).

It refactors content_helper, hooks_helper, html_helper, and theme_helper to use explicit CurrentRequest-backed state, extends CurrentRequest with helper state attributes, and adds focused helper specs for content/hooks/theme state behavior plus HTML helper coverage.

## User-Visible Impact
None. This is an internal state-management refactor intended to preserve existing behavior while removing helper instance-variable usage.