### PR TITLE
docs: add canonical Phase 6 helper/concern architecture plan

### DIFF
--- a/docs/ai/plans/helper-concern-architecture-refactor.md
+++ b/docs/ai/plans/helper-concern-architecture-refactor.md
@@ -1,0 +1,102 @@
+# Helper/Concern Architecture Refactor (Post-Phase-5)
+
+See also:
+- `docs/ai/plans/helper-ivar-refactor-master-plan.md`
+- `docs/ai/plans/helper-ivar-refactor-phases.md`
+
+## Problem
+The helper-ivar cleanup stream reduced RuboCop offenses, but the runtime architecture still mixes controller behavior into helpers and uses compatibility bridges (`instance_variable_set` / `instance_variable_get`) that keep helpers coupled to controller internals.
+
+## Goal
+Move to idiomatic Rails boundaries:
+1. Helpers are view-facing only (presentation/formatting/read-only context usage).
+2. Controller behavior lives in controllers and controller concerns.
+3. Controllers include concerns, not broad helper modules for runtime flow.
+4. Remove helper-side ivar writes/reads and implicit helper↔controller state coupling.
+
+## Scope
+- `CamaleonController`, `FrontendController`, `AdminController`
+- Shared runtime modules currently implemented as helpers (`SessionHelper`, `SiteHelper`, `ThemeHelper`, `HooksHelper`, selected frontend/admin helpers)
+- Plugin compatibility surfaces (`PluginRoutes.all_helpers`, hook/load paths)
+
+## Phase A output: ownership inventory
+
+### Current controller/runtime includes (to unwind)
+- `CamaleonController` currently includes many `CamaleonCms::*Helper` modules directly for runtime behavior.
+- `FrontendController` includes `CamaleonCms::Frontend::ApplicationHelper`.
+- `AdminController` includes `CamaleonCms::Admin::ApplicationHelper`.
+- Plugin helpers are dynamically included through `PluginRoutes.all_helpers`.
+
+### Mixed-module ownership map
+
+| Module | Current mixed responsibilities | Target owner |
+|---|---|---|
+| `CamaleonCms::SessionHelper` | auth/session cookies, redirects, login/logout, current user resolution, controller `@user` bridging | **Controller concern** for runtime/auth flows; helper surface only for view-safe predicates |
+| `CamaleonCms::SiteHelper` | current site/theme resolution, request host resolution, site install/uninstall runtime tasks, helper-side `@current_site` bridging | **Controller concern** for request lifecycle + site/theme context; helper readers for view only |
+| `CamaleonCms::ThemeHelper` | theme state init + breadcrumb state wiring + asset/view path helpers | split: **controller concern** for lifecycle state init; **helper** for asset/view path methods |
+| `CamaleonCms::HooksHelper` | lifecycle hook orchestration + skip-list state with legacy ivar fallback | **Controller concern** for hook orchestration and skip-list state |
+| `CamaleonCms::Frontend::SiteHelper` | visited-state checks with legacy ivar fallbacks | **Helper** with `CurrentRequest` readers only (remove ivar fallback) |
+| `CamaleonCms::Frontend::SeoHelper` | SEO rendering plus visited/user fallback via ivars | **Helper** with explicit/current-request context only |
+| `CamaleonCms::Frontend::ContentSelectHelper` | content selection DSL with `@object` fallback | **Helper** with explicit block context + `CurrentRequest` only |
+| `CamaleonCms::Frontend::NavMenuHelper` | rendering/parser helper with visited-state legacy fallback | **Helper** with explicit/current-request context only |
+| `CamaleonCms::CommentHelper` | recursive rendering with controller ivar fallback for post | **Helper** with explicit `post_id` only |
+| `CamaleonCms::Admin::PostTypeHelper` | helper fallback to controller `@post_type` | **Helper** with explicit `post_type` argument only |
+| `CamaleonCms::CamaleonHelper` | view helpers + helper-side ivar cache helper | split: keep view helpers; move cache strategy to request store/helper-local pattern without dynamic ivars |
+
+### Compatibility constraints discovered
+- Frontend themes still rely on controller-assigned ivars in templates (`@post`, `@category`, etc.); these ivars belong in controllers, not helper bridges.
+- Decorators/plugins depend on admin preview locale compatibility (`cama_get_i18n_frontend` / `cama_is_admin_request?` path).
+- Hook/plugin ecosystem depends on helper availability and dynamic plugin helper loading (`PluginRoutes.all_helpers`), so concern extraction must preserve callable surfaces used by hooks.
+
+### Phase A boundary rules (to enforce in implementation)
+1. No helper should call `instance_variable_set` / `instance_variable_get` for controller state bridging.
+2. Helpers may read request-scoped state from `CurrentRequest` and explicit method arguments.
+3. Runtime flow (redirects, cookies/session mutation, hook lifecycle dispatch) must be concern/controller-owned.
+4. Controller ivars required for template compatibility are assigned in controllers only.
+
+## Phased plan
+
+### Phase A — Architecture inventory + ownership map
+- Classify methods into:
+  - controller concern responsibilities
+  - view helper responsibilities
+- Produce ownership map for mixed modules.
+- Identify compatibility constraints (themes/plugins/decorators).
+
+### Phase B — Extract controller concerns (foundation)
+- Create concerns for:
+  - request/site/theme context lifecycle
+  - auth/session control flow
+  - hook orchestration for controller lifecycle
+  - frontend visited-state mutation
+- Wire concerns into base/admin/frontend controllers.
+
+### Phase C — Slim helpers to presentation APIs
+- Remove helper ivar mutation/access bridges.
+- Convert helper state access to explicit args and read-only `CurrentRequest`.
+- Keep public helper API stable where feasible.
+
+### Phase D — Controller include cleanup
+- Remove runtime `include CamaleonCms::*Helper` usage from controllers.
+- Keep helper exposure view-focused via helper contracts.
+- Ensure redirects/session side effects are concern-driven.
+
+### Phase E — Frontend/admin hotspots
+- Frontend: remove remaining nav/seo/content-select legacy ivar fallbacks.
+- Admin: replace helper fallback reads from controller ivars with explicit params/context APIs.
+
+### Phase F — Compatibility + deprecation
+- Add narrow adapters only where ecosystem compatibility requires it.
+- Document retained compatibility contracts and deprecation path.
+
+### Phase G — Verification + documentation
+- `(cd spec/dummy && bin/rails zeitwerk:check)`
+- `bin/rubocop -A`
+- `bin/rspec`
+- Update plan/changelog/docs with final architecture contract.
+
+## Constraints
+- No feature expansion; architecture-only refactor.
+- Follow Step-0 cleanup rule for files >300 LOC before structural edits.
+- Execute in small phases; each phase should remain independently reviewable.
+- Prefer explicit state flow over implicit ivar/module coupling.

--- a/docs/ai/plans/helper-ivar-refactor-phases.md
+++ b/docs/ai/plans/helper-ivar-refactor-phases.md
@@ -14,7 +14,8 @@ Progressive removal of `Rails/HelperInstanceVariable` helper state patterns, wit
 - Phase 2: merged
 - Phase 3: merged
 - Phase 4: merged
-- Phase 5: planned/in progress
+- Phase 5: merged
+- Phase 6 (architecture boundary refactor): in progress
 
 ## Phase 4 plan
 
@@ -115,10 +116,23 @@ Progressive removal of `Rails/HelperInstanceVariable` helper state patterns, wit
 - `phase5-rubocop-todo-cleanup`
 - `phase5-verification-and-pr`
 
-## Future follow-ups (non-blocking)
-- Deterministic `Metas#get_meta` for duplicate-key rows (stable row ordering before selecting one).
-- Legacy polymorphic owner compatibility hardening for demodulized `object_class` values under strict host-app defaults.
-- Host app note (`camaleon_website`): harden e_shop header partial against missing nav menu slugs.
+## Phase 6 queue (canonical)
+- Canonical plan: `docs/ai/plans/helper-concern-architecture-refactor.md`
+- Objective: move controller/runtime responsibilities out of helpers into controller concerns and keep helpers view-facing only.
+- Scope highlights:
+  - remove helper-side ivar bridging (`instance_variable_set` / `instance_variable_get`)
+  - replace runtime controller includes of helpers with concern includes
+  - keep plugin/theme compatibility through explicit adapters where necessary
+
+### Phase 6 progress update
+- Branch: `fix/phase-6-helper-concern-architecture`
+- Phase A (inventory/boundaries): completed
+  - added ownership map of mixed modules (runtime concern vs view helper targets)
+  - documented compatibility constraints for themes/plugins/decorators
+  - defined enforceable boundary rules for implementation phases
+
+## Future follow-ups
+- Resolved during Phase 5 and no longer pending.
 
 ## Persistence policy
 This file is the durable source of truth for this refactor stream.


### PR DESCRIPTION
## What and Why
This PR establishes the canonical Phase 6 architecture plan for the helper/concern boundary refactor and aligns the phase tracker with the current state after Phase 5.

It adds a dedicated plan document for the controller-concern vs view-helper split and updates the phase tracker to mark Phase 5 as merged, Phase 6 as in progress, record Phase 6 inventory progress, and mark prior non-blocking follow-ups as resolved.

## User-Visible Impact
None. This is documentation-only and does not change runtime behavior.
