### PR TITLE
Fix post-release 2.9.2 widget, navigation, and plugin regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Fix:** Restore legacy widget assignments, configured navigation order, and frontend plugin controller helper compatibility, [#1194](https://github.com/owen2345/camaleon-cms/pull/1194)
+
 - **Developer tooling:** Add OpenSpec planning workflow and agent guidance, [#1193](https://github.com/owen2345/camaleon-cms/pull/1193)
 
 - **Security bumps:** Bump json, puma to 8.0.2, rubocop to 1.88.1, zeitwerk to 2.8.2, and other gems on development and fix all new Rubocop offenses, [#1167](https://github.com/owen2345/camaleon-cms/pull/1186)

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -3,6 +3,7 @@ module CamaleonCms
     before_action :init_frontent
     include CamaleonCms::FrontendVisitedStateConcern
     include CamaleonCms::FrontendConcern
+    include CamaleonCms::Frontend::ApplicationHelper
     layout proc { |controller|
       args = {
         layout: (params[:cama_ajax_request].present? ? 'cama_ajax' : PluginRoutes.static_system_info['default_layout']),

--- a/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/nav_menu_helper.rb
@@ -70,11 +70,13 @@ module CamaleonCms
       end
 
       # draw menu items
+      # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       def cama_menu_draw_items(args, nav_menu, level = 0)
         items_html = []
         parent_current = false
         index = 0
-        nav_menu.eager_load(:metas).find_each do |nav_menu_item|
+        # rubocop:disable Rails/FindEach -- Rendering must preserve the relation's configured term_order.
+        nav_menu.eager_load(:metas).each do |nav_menu_item|
           _args = args.dup
           data_nav_item = cama_parse_menu_item(nav_menu_item)
           next if data_nav_item == false
@@ -154,6 +156,7 @@ module CamaleonCms
 
           index += 1
         end
+        # rubocop:enable Rails/FindEach
 
         if level == 0
           safe_join(items_html)
@@ -167,6 +170,7 @@ module CamaleonCms
           [sub_html, parent_current]
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
       # filter and parse all menu items visible for current user and adding the flag for current_parent or current_item
       # max_levels: max levels to iterate

--- a/app/models/camaleon_cms/widget/assigned.rb
+++ b/app/models/camaleon_cms/widget/assigned.rb
@@ -1,7 +1,12 @@
 module CamaleonCms
   module Widget
     class Assigned < CamaleonCms::PostDefault
-      # default_scope -> { where(post_class: name).order(:taxonomy_id) }
+      default_scope -> { order(:taxonomy_id) }
+
+      def self.type_condition(table = arel_table)
+        super.or(table[inheritance_column].eq(name))
+      end
+
       # post_parent: sidebar_id
       # visibility: widget_id
       # comment_count: item_order

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/design.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The changes merged after 2.9.2 introduced three regressions in otherwise independent areas:
+
+- Native STI now stores compact class names in `posts.post_class`, while existing widget assignments use
+  the former fully qualified discriminator.
+- The frontend menu renderer replaced ordered relation iteration with Active Record batch iteration.
+- The helper-concern refactor removed a helper module from `FrontendController`, changing the API inherited
+  by plugin frontend controllers.
+
+The fixes must preserve data and APIs for installations upgrading from releases that predate the affected
+changes. No new dependencies or schema changes are required.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Read legacy and current widget-assignment discriminators without mutating upgrade data.
+- Preserve configured menu ordering at every rendered menu level.
+- Restore the frontend controller helper methods previously available to plugin controllers.
+- Cover each regression with behavioral specs that would fail with the regressed implementation.
+
+**Non-Goals:**
+
+- Convert every historical STI discriminator or redesign the broader STI model hierarchy.
+- Optimize menu rendering for arbitrarily large menus at the expense of configured ordering.
+- Expand the frontend controller API beyond the two helper methods lost by the refactor.
+- Change the user-role form linked in the request; it is outside these regressions.
+
+## Decisions
+
+### Read both widget-assignment discriminator formats
+
+`Widget::Assigned` will recognize both the compact native-STI discriminator and the legacy
+`CamaleonCms::Widget::Assigned` discriminator when Rails builds its STI type condition. New records will
+continue to use the compact discriminator.
+
+This avoids a data migration that could be expensive, irreversible during a rollback, and incomplete for
+installations upgraded without running an optional task. A one-time data migration was considered but
+rejected because query compatibility is sufficient and safe for existing records.
+
+### Iterate rendered menu relations in their declared order
+
+The menu renderer will use normal relation iteration for ordered root and child relations instead of
+`find_each`. `find_each` deliberately replaces scoped ordering with primary-key batching, which violates
+the menu contract.
+
+An ordered cursor-based batch implementation was considered but rejected: menus are presentation data,
+their configured order is essential, and a simpler ordered iteration matches pre-regression behavior.
+
+### Restore the controller-safe frontend helper inclusion
+
+`FrontendController` will regain the frontend application helper inclusion so inheriting plugin controllers
+again receive `cama_url_to_fixed` and `verify_front_visibility`.
+
+Extracting only the two methods into a new concern was considered but rejected because it creates another
+runtime boundary without reducing risk. Restoring the established inclusion preserves the prior public
+controller API with the smallest compatibility change.
+
+## Risks / Trade-offs
+
+- [Legacy STI values remain in the database] -> The compatibility type condition supports them alongside
+  canonical values, so upgrades and rollbacks continue to read the same assignments.
+- [Ordered menu iteration loads a full menu level] -> Menu levels are rendered presentation collections;
+  correctness and existing behavior take priority over batch throughput.
+- [Helper inclusion exposes the existing helper surface] -> The module was already included by
+  `FrontendController` before the refactor, so this restores rather than expands a documented compatibility
+  surface.

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/proposal.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+The post-2.9.2 changes through `746a9fa9` introduced upgrade and rendering regressions that affect
+existing CMS installations and plugin controllers. Existing widget assignments can disappear, navigation
+menus can render in the wrong order, and controller-facing frontend helper APIs can fail at runtime.
+
+## What Changes
+
+- Preserve access to legacy namespaced widget-assignment records after the native STI migration.
+- Render frontend navigation items in their configured `term_order`, including nested items.
+- Restore the controller runtime surface for `cama_url_to_fixed` and `verify_front_visibility` used by
+  frontend plugin controllers.
+- Add focused regression coverage for each repaired behavior, including upgrade-compatible persisted data.
+
+## Capabilities
+
+### New Capabilities
+
+- `legacy-widget-assignment-compatibility`: Upgrade-compatible retrieval and rendering of pre-STI widget assignments.
+- `ordered-navigation-rendering`: Navigation rendering that honors configured item order at every menu level.
+- `frontend-controller-helper-compatibility`: Stable frontend controller access to legacy helper methods required by plugins.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Affected models: `CamaleonCms::PostDefault`, `CamaleonCms::Widget::Assigned`,
+  `CamaleonCms::Widget::Sidebar`, and `CamaleonCms::Widget::Main`.
+- Affected rendering: `CamaleonCms::Frontend::NavMenuHelper`.
+- Affected controller/plugin API: `CamaleonCms::FrontendController` and inheriting plugin frontend controllers.
+- Affected tests: model, helper, and controller compatibility specs.

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/frontend-controller-helper-compatibility/spec.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/frontend-controller-helper-compatibility/spec.md
@@ -1,0 +1,14 @@
+## ADDED Requirements
+
+### Requirement: Preserve frontend helper methods on frontend controllers
+The system SHALL expose `cama_url_to_fixed` and `verify_front_visibility` on `FrontendController` and on
+frontend controllers that inherit from it.
+
+#### Scenario: Calling a restored URL helper from a frontend controller
+- **WHEN** a frontend controller action calls `cama_url_to_fixed`
+- **THEN** the call SHALL execute without a `NoMethodError`
+
+#### Scenario: Calling a restored visibility helper from a plugin controller
+- **WHEN** a plugin frontend controller inheriting from `FrontendController` calls
+  `verify_front_visibility`
+- **THEN** the call SHALL execute without a `NoMethodError`

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/legacy-widget-assignment-compatibility/spec.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/legacy-widget-assignment-compatibility/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Preserve widget assignments across STI discriminator formats
+The system SHALL return widget assignments stored with either the legacy
+`CamaleonCms::Widget::Assigned` discriminator or the compact `Widget::Assigned` discriminator. New widget
+assignments SHALL continue to use the compact discriminator.
+
+#### Scenario: Loading a sidebar upgraded from a legacy release
+- **WHEN** a sidebar has an assignment row whose `post_class` is `CamaleonCms::Widget::Assigned`
+- **THEN** the sidebar SHALL return that assignment through its `assigned` association and the associated
+  widget SHALL remain available for rendering
+
+#### Scenario: Loading mixed legacy and current assignments
+- **WHEN** a sidebar has assignments stored with both supported discriminator formats
+- **THEN** the sidebar SHALL return all of those assignments in their configured item order
+
+#### Scenario: Creating an assignment after the compatibility fix
+- **WHEN** a widget is assigned to a sidebar after the fix is deployed
+- **THEN** the assignment SHALL be stored with the compact `Widget::Assigned` discriminator

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/ordered-navigation-rendering/spec.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/specs/ordered-navigation-rendering/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Render navigation items in configured order
+The system SHALL render frontend navigation items in ascending `term_order` at every menu level. Rendering
+SHALL preserve that order even when record identifiers differ from the configured order.
+
+#### Scenario: Rendering reordered root navigation items
+- **WHEN** root menu items have `term_order` values that differ from their creation order
+- **THEN** the rendered menu markup SHALL list the items in ascending `term_order`
+
+#### Scenario: Rendering reordered nested navigation items
+- **WHEN** a parent menu item has child items with `term_order` values that differ from their creation order
+- **THEN** the rendered nested markup SHALL list the child items in ascending `term_order`
+
+#### Scenario: Supplying callback indices for ordered items
+- **WHEN** a menu callback receives rendered root or nested items
+- **THEN** each callback index SHALL reflect the item's position in configured `term_order`

--- a/openspec/changes/archive/2026-07-11-fix-post-release-regressions/tasks.md
+++ b/openspec/changes/archive/2026-07-11-fix-post-release-regressions/tasks.md
@@ -1,0 +1,23 @@
+## 1. Restore widget assignment upgrade compatibility
+
+- [x] 1.1 Add model coverage for legacy and compact `Widget::Assigned` `post_class` values, mixed
+  sidebar assignments, and canonical writes for newly created assignments.
+- [x] 1.2 Extend `Widget::Assigned` STI type compatibility so its associations read both supported
+  discriminator formats without changing persisted legacy rows.
+
+## 2. Restore configured navigation ordering
+
+- [x] 2.1 Add helper coverage with root and nested items whose `term_order` differs from creation order,
+  including callback index assertions.
+- [x] 2.2 Replace unordered batch iteration in `cama_menu_draw_items` with ordered relation iteration.
+
+## 3. Restore frontend controller helper compatibility
+
+- [x] 3.1 Add controller compatibility coverage for `cama_url_to_fixed` and `verify_front_visibility` on
+  `FrontendController` and an inheriting plugin-style frontend controller.
+- [x] 3.2 Restore the frontend application helper to the frontend controller runtime surface.
+
+## 4. Verify the regression fixes
+
+- [x] 4.1 Run the targeted model, frontend helper, and controller specs covering the three regressions.
+- [x] 4.2 Run `(cd spec/dummy && bin/rails zeitwerk:check)`, `bin/rubocop`, and `bin/rspec`.

--- a/openspec/specs/frontend-controller-helper-compatibility/spec.md
+++ b/openspec/specs/frontend-controller-helper-compatibility/spec.md
@@ -1,0 +1,18 @@
+## Purpose
+
+Maintain the frontend controller helper API relied on by inheriting plugin controllers.
+
+## Requirements
+
+### Requirement: Preserve frontend helper methods on frontend controllers
+The system SHALL expose `cama_url_to_fixed` and `verify_front_visibility` on `FrontendController` and on
+frontend controllers that inherit from it.
+
+#### Scenario: Calling a restored URL helper from a frontend controller
+- **WHEN** a frontend controller action calls `cama_url_to_fixed`
+- **THEN** the call SHALL execute without a `NoMethodError`
+
+#### Scenario: Calling a restored visibility helper from a plugin controller
+- **WHEN** a plugin frontend controller inheriting from `FrontendController` calls
+  `verify_front_visibility`
+- **THEN** the call SHALL execute without a `NoMethodError`

--- a/openspec/specs/legacy-widget-assignment-compatibility/spec.md
+++ b/openspec/specs/legacy-widget-assignment-compatibility/spec.md
@@ -1,0 +1,23 @@
+## Purpose
+
+Preserve widget assignments for installations upgrading across the native STI migration.
+
+## Requirements
+
+### Requirement: Preserve widget assignments across STI discriminator formats
+The system SHALL return widget assignments stored with either the legacy
+`CamaleonCms::Widget::Assigned` discriminator or the compact `Widget::Assigned` discriminator. New widget
+assignments SHALL continue to use the compact discriminator.
+
+#### Scenario: Loading a sidebar upgraded from a legacy release
+- **WHEN** a sidebar has an assignment row whose `post_class` is `CamaleonCms::Widget::Assigned`
+- **THEN** the sidebar SHALL return that assignment through its `assigned` association and the associated
+  widget SHALL remain available for rendering
+
+#### Scenario: Loading mixed legacy and current assignments
+- **WHEN** a sidebar has assignments stored with both supported discriminator formats
+- **THEN** the sidebar SHALL return all of those assignments in their configured item order
+
+#### Scenario: Creating an assignment after the compatibility fix
+- **WHEN** a widget is assigned to a sidebar after the fix is deployed
+- **THEN** the assignment SHALL be stored with the compact `Widget::Assigned` discriminator

--- a/openspec/specs/ordered-navigation-rendering/spec.md
+++ b/openspec/specs/ordered-navigation-rendering/spec.md
@@ -1,0 +1,21 @@
+## Purpose
+
+Ensure frontend navigation rendering preserves the configured order of each menu level.
+
+## Requirements
+
+### Requirement: Render navigation items in configured order
+The system SHALL render frontend navigation items in ascending `term_order` at every menu level. Rendering
+SHALL preserve that order even when record identifiers differ from the configured order.
+
+#### Scenario: Rendering reordered root navigation items
+- **WHEN** root menu items have `term_order` values that differ from their creation order
+- **THEN** the rendered menu markup SHALL list the items in ascending `term_order`
+
+#### Scenario: Rendering reordered nested navigation items
+- **WHEN** a parent menu item has child items with `term_order` values that differ from their creation order
+- **THEN** the rendered nested markup SHALL list the child items in ascending `term_order`
+
+#### Scenario: Supplying callback indices for ordered items
+- **WHEN** a menu callback receives rendered root or nested items
+- **THEN** each callback index SHALL reflect the item's position in configured `term_order`

--- a/spec/controllers/camaleon_cms/frontend_controller_lookup_prefixes_spec.rb
+++ b/spec/controllers/camaleon_cms/frontend_controller_lookup_prefixes_spec.rb
@@ -3,6 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe CamaleonCms::FrontendController do
+  describe 'frontend application helper compatibility' do
+    let(:controller) { described_class.new }
+    let(:plugin_controller_class) { Class.new(described_class) }
+
+    it 'calls cama_url_to_fixed from the frontend controller' do
+      allow(controller).to receive_messages(current_site: nil, request: nil, cama_current_site_host_port: nil)
+      controller.define_singleton_method(:compatibility_path) { |_options = {}| '/compatibility' }
+
+      expect { controller.cama_url_to_fixed('compatibility_path') }.not_to raise_error
+      expect(controller.cama_url_to_fixed('compatibility_path')).to eq('/compatibility')
+    end
+
+    it 'calls verify_front_visibility from an inheriting plugin-style controller' do
+      plugin_controller = plugin_controller_class.new
+      relation = double(visible_frontend: :visible)
+      allow(plugin_controller).to receive(:hooks_run)
+
+      expect { plugin_controller.verify_front_visibility(relation) }.not_to raise_error
+      expect(plugin_controller.verify_front_visibility(relation)).to eq(:visible)
+    end
+  end
+
   describe 'frontend visited-state concern integration' do
     let(:controller) { described_class.new }
     let(:post) { instance_double(CamaleonCms::Post) }

--- a/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
@@ -276,6 +276,49 @@ RSpec.describe CamaleonCms::Frontend::NavMenuHelper do
         expect(result.scan(%r{</li>}).count).to eq(2)
       end
     end
+
+    context 'with reordered menu items' do
+      before do
+        @first = create(:nav_menu_item, name: 'First', url: '/first', kind: 'external', target: '', parent: @menu)
+        @second = create(:nav_menu_item, name: 'Second', url: '/second', kind: 'external', target: '', parent: @menu)
+        @first.update!(term_order: 2)
+        @second.update!(term_order: 1)
+
+        @child_first = create(
+          :nav_menu_item, name: 'Child First', url: '/child-first', kind: 'external', target: '', parent_item: @first
+        )
+        @child_second = create(
+          :nav_menu_item, name: 'Child Second', url: '/child-second', kind: 'external', target: '', parent_item: @first
+        )
+        @child_first.update!(term_order: 2)
+        @child_second.update!(term_order: 1)
+      end
+
+      it 'renders root and nested items in configured order' do
+        result = helper.cama_menu_draw_items(default_args, @menu.children.reorder(:term_order))
+
+        expect(result.index('Second')).to be < result.index('First')
+        expect(result.index('Child Second')).to be < result.index('Child First')
+      end
+
+      it 'supplies callback indexes in configured order at every level' do
+        yielded_items = []
+        args = default_args.merge(
+          callback_item: lambda do |item_args|
+            yielded_items << [item_args[:level], item_args[:index], item_args[:menu_item].name]
+          end
+        )
+
+        helper.cama_menu_draw_items(args, @menu.children.reorder(:term_order))
+
+        expect(yielded_items).to include(
+          [0, 0, 'Second'],
+          [0, 1, 'First'],
+          [1, 0, 'Child Second'],
+          [1, 1, 'Child First']
+        )
+      end
+    end
   end
 
   describe 'breadcrumbs' do

--- a/spec/models/widget/assigned_spec.rb
+++ b/spec/models/widget/assigned_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Widget::Assigned, type: :model do
+  let!(:site) { create(:site).decorate }
+  let!(:sidebar) do
+    CamaleonCms::Widget::Sidebar.create!(
+      taxonomy: CamaleonCms::Widget::Sidebar.sti_name,
+      name: 'Regression sidebar',
+      slug: "regression-sidebar-#{SecureRandom.hex(4)}",
+      parent_id: site.id
+    )
+  end
+  let!(:widget) do
+    CamaleonCms::Widget::Main.create!(
+      taxonomy: CamaleonCms::Widget::Main.sti_name,
+      name: 'Regression widget',
+      slug: "regression-widget-#{SecureRandom.hex(4)}",
+      parent_id: site.id
+    )
+  end
+
+  def create_assignment(name, item_order)
+    described_class.create!(
+      title: name,
+      slug: "#{name.parameterize}-#{SecureRandom.hex(4)}",
+      sidebar: sidebar,
+      widget: widget
+    ).tap { |assignment| assignment.update!(taxonomy_id: item_order) }
+  end
+
+  describe 'native STI compatibility' do
+    it 'returns legacy assignments through the sidebar association' do
+      legacy_assignment = create_assignment('Legacy assignment', 1)
+      legacy_assignment.update!(post_class: 'CamaleonCms::Widget::Assigned')
+
+      expect(sidebar.reload.assigned).to include(legacy_assignment)
+      expect(sidebar.assigned.find(legacy_assignment.id).widget).to eq(widget)
+    end
+
+    it 'orders mixed legacy and compact assignments by item order' do
+      compact_assignment = create_assignment('Compact assignment', 2)
+      legacy_assignment = create_assignment('Legacy assignment', 1)
+      legacy_assignment.update!(post_class: 'CamaleonCms::Widget::Assigned')
+
+      expect(sidebar.reload.assigned.pluck(:id)).to eq([legacy_assignment.id, compact_assignment.id])
+    end
+
+    it 'stores new assignments with the compact discriminator' do
+      assignment = create_assignment('New assignment', 1)
+
+      expect(assignment.post_class).to eq('Widget::Assigned')
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

Restores compatibility behaviors regressed after 2.9.2: legacy widget assignment records are readable alongside native-STI values, navigation rendering honors configured item order, and frontend plugin controllers regain their established helper API.

## User-Visible Impact

Upgraded sites retain sidebar widgets, menus render in the configured order, and plugins depending on frontend controller helper methods no longer fail at runtime.