### PR TITLE
Fix SVG XSS bypass via missing animation event handlers (onbegin/onend/onrepeat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Security fix:** Prevent SVG XSS bypass via missing animation event handlers (\`onbegin\`/\`onend\`/\`onrepeat\`) in file upload content filter. DRY duplicated \`UNSAFE_EVENT_PATTERNS\` into shared \`CamaleonCms::ContentSecurity\` module, [#1195](https://github.com/owen2345/camaleon-cms/pull/1195)
+
 - **Fix:** Restore legacy widget assignments, configured navigation order, and frontend plugin controller helper compatibility, [#1194](https://github.com/owen2345/camaleon-cms/pull/1194)
 
 - **Developer tooling:** Add OpenSpec planning workflow and agent guidance, [#1193](https://github.com/owen2345/camaleon-cms/pull/1193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Security fix:** Prevent SVG XSS bypass via missing animation event handlers (\`onbegin\`/\`onend\`/\`onrepeat\`) in file upload content filter. DRY duplicated \`UNSAFE_EVENT_PATTERNS\` into shared \`CamaleonCms::ContentSecurity\` module, [#1195](https://github.com/owen2345/camaleon-cms/pull/1195)
+- **Security fix:** Prevent SVG XSS bypass via missing animation event handlers (\`onbegin\`/\`onend\`/\`onrepeat\`) in file upload content filter. DRY duplicated \`UNSAFE_EVENT_PATTERNS\` into shared \`CamaleonCms::ContentSecurity\` module, [#1195](https://github.com/owen2345/camaleon-cms/pull/1195) — thanks, Mohamed Almuhaya, for reporting this.
 
 - **Fix:** Restore legacy widget assignments, configured navigation order, and frontend plugin controller helper compatibility, [#1194](https://github.com/owen2345/camaleon-cms/pull/1194)
 
@@ -10,7 +10,7 @@
 
 - **Security bumps:** Bump json, puma to 8.0.2, rubocop to 1.88.1, zeitwerk to 2.8.2, and other gems on development and fix all new Rubocop offenses, [#1167](https://github.com/owen2345/camaleon-cms/pull/1186)
 
-- **Security fix:** Prevent account takeover in `Admin::UsersController#updated_ajax` by unifying target-user lookup and authorization. [#1185](https://github.com/owen2345/camaleon-cms/pull/1185) — thanks, Lukman Azri.
+- **Security fix:** Prevent account takeover in `Admin::UsersController#updated_ajax` by unifying target-user lookup and authorization. [#1185](https://github.com/owen2345/camaleon-cms/pull/1185) — thanks, Lukman Azri, for reporting this.
 
 - **Fix:** Restore TinyMCE editor icons in development, [#1183](https://github.com/owen2345/camaleon-cms/pull/1183)
   - sprockets-rails >= 3.5 registers `Sprockets::Rails::AssetUrlProcessor`, a `text/css` post-processor that rewrites every relative `url(...)` reference to a digested asset path. TinyMCE's bundled skin (`tinymce/skins/lightgray/skin.min.css`) references its icon font with relative urls such as `url("fonts/tinymce.woff")`, whose real logical path is `tinymce/skins/lightgray/fonts/...`. The processor cannot resolve them and rewrites them to an invalid root path (`/fonts/tinymce.woff`) that 404s, leaving the editor toolbar without icons.

--- a/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
@@ -6,23 +6,7 @@ module CamaleonCms
   module RuntimeUploaderConcern
     extend ActiveSupport::Concern
 
-    UNSAFE_EVENT_PATTERNS = %w[
-      onabort onafter onbefore onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick
-      ondrag ondrop ondurationchange onended onerror onfocus onhashchange oninvalid oninput onkey onload onmessage
-      onmouse ononline onoffline onpagehide onpageshow onpage onpaste onpause onplay onpopstate onprogress
-      onpropertychange onratechange onreadystatechange onreset onresize onscroll onsearch onseek onselect onshow
-      onstalled onstorage onsuspend ontimeupdate ontoggle onunloadonsubmit onvolumechange onwaiting onwheel
-    ].map { |pattern| /#{pattern}\w*\s*=/i }.freeze
-
-    SUSPICIOUS_PATTERNS = (UNSAFE_EVENT_PATTERNS + [
-      /<script[\s>]/i,
-      /javascript:/i,
-      /<iframe[\s>]/i,
-      /<object[\s>]/i,
-      /<embed[\s>]/i,
-      /<base[\s>]/i,
-      /data:/i
-    ]).freeze
+    include ContentSecurity
 
     def upload_file(uploaded_io, settings = {})
       cached_name = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.original_filename : nil

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -5,23 +5,7 @@ require 'tempfile'
 
 module CamaleonCms
   module UploaderHelper
-    UNSAFE_EVENT_PATTERNS = %w[
-      onabort onafter onbefore onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut ondblclick
-      ondrag ondrop ondurationchange onended onerror onfocus onhashchange oninvalid oninput onkey onload onmessage
-      onmouse ononline onoffline onpagehide onpageshow onpage onpaste onpause onplay onpopstate onprogress
-      onpropertychange onratechange onreadystatechange onreset onresize onscroll onsearch onseek onselect onshow
-      onstalled onstorage onsuspend ontimeupdate ontoggle onunloadonsubmit onvolumechange onwaiting onwheel
-    ].map { |pattern| /#{pattern}\w*\s*=/i }.freeze
-
-    SUSPICIOUS_PATTERNS = (UNSAFE_EVENT_PATTERNS + [
-      /<script[\s>]/i,  # Script tags
-      /javascript:/i,   # JavaScript in href/src attributes
-      /<iframe[\s>]/i,  # Iframes
-      /<object[\s>]/i,  # Object tags
-      /<embed[\s>]/i,   # Embed tags
-      /<base[\s>]/i,    # Base tags (can be used to manipulate URLs)
-      /data:/i          # data: URLs (which can include scripts)
-    ]).freeze
+    include ContentSecurity
 
     include ActionView::Helpers::NumberHelper
     include CamaleonCms::CamaleonHelper

--- a/lib/camaleon_cms.rb
+++ b/lib/camaleon_cms.rb
@@ -1,5 +1,6 @@
 require 'camaleon_cms/engine'
 require 'camaleon_cms/version'
+require 'camaleon_cms/content_security'
 
 module CamaleonCms
 end

--- a/lib/camaleon_cms/content_security.rb
+++ b/lib/camaleon_cms/content_security.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  module ContentSecurity
+    UNSAFE_EVENT_PATTERNS = %w[
+      onabort onafter onbefore onbegin onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut
+      ondblclick ondrag ondrop ondurationchange onend onended onerror onfocus onhashchange oninvalid oninput onkey
+      onload onmessage onmouse ononline onoffline onpagehide onpageshow onpage onpaste onpause onplay onpopstate
+      onprogress onpropertychange onratechange onreadystatechange onrepeat onreset onresize onscroll onsearch onseek
+      onselect onshow onstalled onstorage onsuspend ontimeupdate ontoggle onunloadonsubmit onvolumechange onwaiting
+      onwheel
+    ].map { |pattern| /#{pattern}\w*\s*=/i }.freeze
+
+    SUSPICIOUS_PATTERNS = (UNSAFE_EVENT_PATTERNS + [
+      /<script[\s>]/i,
+      /javascript:/i,
+      /<iframe[\s>]/i,
+      /<object[\s>]/i,
+      /<embed[\s>]/i,
+      /<base[\s>]/i,
+      /data:/i
+    ]).freeze
+  end
+end

--- a/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/design.md
+++ b/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/design.md
@@ -1,0 +1,52 @@
+## Context
+
+`UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` are currently defined identically in two files:
+
+- `app/helpers/camaleon_cms/uploader_helper.rb` (lines 8–14 and 16–24)
+- `app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb` (lines 9–15 and 17–25)
+
+Both lists are missing `onbegin`, `onend`, and `onrepeat` — SVG animation event handlers that execute JavaScript. An SVG using `<animate onbegin="alert(1)"/>` bypasses the filter because none of the existing regexes match those attribute names.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Block `onbegin`, `onend`, `onrepeat` in uploaded SVG files before storage.
+- Eliminate the code duplication so future additions touch one place.
+- Add test coverage for SVG animation event handlers.
+
+**Non-Goals:**
+- No changes to the thumbnail/resize pipeline or the uploader storage layer.
+- No changes to existing event handler patterns (they're already correct).
+- No changes to how `file_content_unsafe?` reads or rewinds files.
+
+## Decisions
+
+**Decision 1: Extract shared patterns into `CamaleonCms::ContentSecurity` module.**
+
+| Alternative | Verdict |
+|---|---|
+| Extract to `lib/camaleon_cms/content_security.rb` | **Chosen** — clear namespace, auto-loaded by Rails, no existing home is a better fit |
+| Keep inline, add note to update both files | Rejected — proven failure mode (this PR is the evidence) |
+| Extract to one of the existing files, include from the other | Rejected — neither `helper` nor `controller/concern` is the right namespace for a pure data module |
+
+The module will define both `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` as frozen constants, identical in content to the current lists plus the three additions.
+
+**Decision 2: Add `onbegin`, `onend`, `onrepeat` inline with `onblur`/`oncanplay` ordering.**
+
+Alphabetical insertion keeps the list navigable. The resulting section:
+
+```
+onbegin onblur oncanplay ...
+onend onerror ...
+onrepeat onresize ...
+```
+
+**Decision 3: No regex refactoring.**
+
+The existing regex builder — `/#{pattern}\w*\s*=/i` — is kept unchanged. The `\w*` allows for vendor-prefixed variants (e.g., `onbeginSomething=`) and `\s*=` catches the attribute-value separator. This matches the existing approach.
+
+## Risks / Trade-offs
+
+- **[False positive risk]** Adding three tokens to a blocklist has negligible risk — `onbegin`, `onend`, and `onrepeat` are not legitimate content attributes in any CMS workflow.
+- **[Missing future handlers]** A blocklist approach is inherently incomplete. A future SVG spec addition or browser extension could introduce new executable attributes. Mitigation: the centralized module makes it easier to audit and update.
+- **[URL-served SVGs]** The filter only applies to uploaded content. SVGs served from external URLs that the CMS links to (but doesn't store) are out of scope.

--- a/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/proposal.md
+++ b/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The SVG content security filter introduced in v2.8.2 (GHSA-r9cr-qmfw-pmrc) is missing three SVG animation event handlers — `onbegin`, `onend`, and `onrepeat` — from its blocklist, allowing an attacker to upload a crafted SVG that executes JavaScript when viewed. The event handler blocklist is also duplicated across two files, creating a maintenance hazard where future additions must be made in two places.
+
+## What Changes
+
+- Add `onbegin`, `onend`, and `onrepeat` to the `UNSAFE_EVENT_PATTERNS` array in both locations where it is defined.
+- Extract the shared `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` into a single module to eliminate the duplication.
+- Add a test fixture SVG using `onbegin` and a corresponding test case.
+- Verify all existing tests still pass.
+
+## Capabilities
+
+### New Capabilities
+
+- `upload-content-security`: Safe file uploads — the system MUST reject files containing executable content patterns (event handler attributes, script tags, javascript: URIs, etc.) before storing them. This replaces the ad-hoc inline filter with a testable specification.
+
+### Modified Capabilities
+
+- (none)
+
+## Impact
+
+- `app/helpers/camaleon_cms/uploader_helper.rb` — remove inline `UNSAFE_EVENT_PATTERNS` / `SUSPICIOUS_PATTERNS`, include shared module
+- `app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb` — remove inline `UNSAFE_EVENT_PATTERNS` / `SUSPICIOUS_PATTERNS`, include shared module
+- New shared module file (e.g., `lib/camaleon_cms/content_security_scanner.rb` or similar)
+- `spec/support/fixtures/` — add test SVG with `onbegin` payload
+- `spec/helpers/uploader_helper_spec.rb` — add test case for animation event handlers

--- a/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/specs/upload-content-security/spec.md
+++ b/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/specs/upload-content-security/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Reject uploaded files with event handler attributes
+
+The system SHALL reject file uploads whose content contains known executable event handler attributes before storing or persisting the file.
+
+#### Scenario: File with `onclick` is rejected
+- **WHEN** a user uploads a file whose content includes an `onclick` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onload` is rejected
+- **WHEN** a user uploads a file whose content includes an `onload` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onbegin` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onbegin="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onend` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onend="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onrepeat` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onrepeat="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: Safe SVG without event handlers is accepted
+- **WHEN** a user uploads an SVG file with no executable content patterns
+- **THEN** the system accepts and persists the file successfully
+
+### Requirement: Reject uploaded files with `<script>` tags
+
+The system SHALL reject file uploads whose content contains `<script>` elements.
+
+#### Scenario: SVG with `<script>` is rejected
+- **WHEN** a user uploads an SVG file containing a `<script>` tag
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Reject uploaded files with `javascript:` URIs
+
+The system SHALL reject file uploads whose content contains `javascript:` URIs in attributes.
+
+#### Scenario: File with `javascript:` in href is rejected
+- **WHEN** a user uploads a file containing `javascript:` in an href or src attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Safe file scanning does not consume the IO stream
+
+After scanning for malicious content, the file pointer SHALL be rewound so subsequent consumers can read the full content.
+
+#### Scenario: Tempfile is readable after scan
+- **WHEN** the system scans a Tempfile for unsafe content and the scan passes
+- **THEN** the Tempfile pointer is at the beginning and the full content can be read again

--- a/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/tasks.md
+++ b/openspec/changes/archive/2026-07-11-fix-svg-xss-bypass-missing-event-handlers/tasks.md
@@ -1,0 +1,18 @@
+## 1. Extract shared security patterns
+
+- [x] 1.1 Create `lib/camaleon_cms/content_security.rb` with `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` constants, adding `onbegin`, `onend`, and `onrepeat`
+- [x] 1.2 Replace inline constants in `app/helpers/camaleon_cms/uploader_helper.rb` with `include` / reference to the new module
+- [x] 1.3 Replace inline constants in `app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb` with `include` / reference to the new module
+
+## 2. Add test coverage
+
+- [x] 2.1 Create a test SVG fixture with `onbegin` event handler at `spec/support/fixtures/unsafe-svg-onbegin.svg`
+- [x] 2.2 Add RSpec test cases in `spec/helpers/uploader_helper_spec.rb` that verify `onbegin`, `onend`, and `onrepeat` are detected and the upload is rejected
+- [x] 2.3 Run the full test suite with `bin/rspec` and confirm all tests pass
+
+## 3. Final verification
+
+- [x] 3.1 Run `bin/rubocop -A` (lint)
+- [x] 3.2 Run `bin/brakeman --no-pager` (security)
+- [x] 3.3 Run `(cd spec/dummy && bin/rails zeitwerk:check)` (load verification)
+- [x] 3.4 Run `bin/rspec` (full test suite)

--- a/openspec/specs/upload-content-security/spec.md
+++ b/openspec/specs/upload-content-security/spec.md
@@ -1,0 +1,57 @@
+## Purpose
+
+Define the security requirements for content scanning of uploaded files. Uploaded files MUST be scanned for executable content patterns before being persisted, to prevent stored XSS attacks via uploaded SVGs and other file types.
+
+## Requirements
+
+### Requirement: Reject uploaded files with event handler attributes
+
+The system SHALL reject file uploads whose content contains known executable event handler attributes before storing or persisting the file.
+
+#### Scenario: File with `onclick` is rejected
+- **WHEN** a user uploads a file whose content includes an `onclick` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onload` is rejected
+- **WHEN** a user uploads a file whose content includes an `onload` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onbegin` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onbegin="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onend` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onend="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: File with `onrepeat` is rejected
+- **WHEN** a user uploads an SVG whose content includes `<animate onrepeat="...">`
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: Safe SVG without event handlers is accepted
+- **WHEN** a user uploads an SVG file with no executable content patterns
+- **THEN** the system accepts and persists the file successfully
+
+### Requirement: Reject uploaded files with `<script>` tags
+
+The system SHALL reject file uploads whose content contains `<script>` elements.
+
+#### Scenario: SVG with `<script>` is rejected
+- **WHEN** a user uploads an SVG file containing a `<script>` tag
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Reject uploaded files with `javascript:` URIs
+
+The system SHALL reject file uploads whose content contains `javascript:` URIs in attributes.
+
+#### Scenario: File with `javascript:` in href is rejected
+- **WHEN** a user uploads a file containing `javascript:` in an href or src attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Safe file scanning does not consume the IO stream
+
+After scanning for malicious content, the file pointer SHALL be rewound so subsequent consumers can read the full content.
+
+#### Scenario: Tempfile is readable after scan
+- **WHEN** the system scans a Tempfile for unsafe content and the scan passes
+- **THEN** the Tempfile pointer is at the beginning and the full content can be read again

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -91,9 +91,15 @@ describe CamaleonCms::UploaderHelper do
 
   describe 'file upload with unsafe content' do
     let(:unsafe_file_path) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/unsafe-test-xss.svg" }
+    let(:unsafe_svg_animation_path) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/unsafe-svg-onbegin.svg" }
 
     it "doesn't allow the file upload, returning an error" do
       expect(upload_file(File.open(unsafe_file_path), { folder: '/' })[:error])
+        .to eql('Potentially malicious content found!')
+    end
+
+    it "doesn't allow an SVG with animation event handlers (onbegin/onend/onrepeat)" do
+      expect(upload_file(File.open(unsafe_svg_animation_path), { folder: '/' })[:error])
         .to eql('Potentially malicious content found!')
     end
 

--- a/spec/support/fixtures/unsafe-svg-onbegin.svg
+++ b/spec/support/fixtures/unsafe-svg-onbegin.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 150">
+  <rect width="300" height="150" fill="#f0f0f0"/>
+  <text x="30" y="80" font-size="20" fill="#333">Totally normal image</text>
+  <animate attributeName="opacity" values="1;1" dur="1s"
+    onbegin="alert('XSS via onbegin')"
+    onend="alert('XSS via onend')"
+    onrepeat="alert('XSS via onrepeat')" />
+</svg>


### PR DESCRIPTION
## Summary

Fixes an SVG XSS bypass in the file upload content filter. Three SVG animation event handlers — `onbegin`, `onend`, and `onrepeat` — were missing from `UNSAFE_EVENT_PATTERNS`, allowing crafted SVGs to execute JavaScript when viewed.

## Changes

- **Security fix:** Added `onbegin`, `onend`, `onrepeat` to the event handler blocklist
- **Refactor:** Extracted duplicated `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` into shared `CamaleonCms::ContentSecurity` module (`lib/camaleon_cms/content_security.rb`)
- **Test coverage:** Added SVG fixture with all three animation event handlers and a spec verifying rejection