### PR TITLE
Security: Fix profile IDOR allowing any authenticated user to view arbitrary user profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Security fix:** Fix profile IDOR in \`Admin::UsersController#profile\` — add inline \`authorize!\` check when viewing another user, so low-privilege users can no longer enumerate arbitrary user accounts. [#1197](https://github.com/owen2345/camaleon-cms/pull/1197) — thanks, Neo Andrew, for reporting this.
+
 - **Security fix:** Fix improper authorization in draft autosave endpoint — scope draft lookups to post type, add \`authorize!\` checks before draft mutations, and validate \`post_parent\` against a real post, [#1196](https://github.com/owen2345/camaleon-cms/pull/1196) — thanks, Óscar Uribe, for reporting this.
 
 - **Security fix:** Prevent SVG XSS bypass via missing animation event handlers (\`onbegin\`/\`onend\`/\`onrepeat\`) in file upload content filter. DRY duplicated \`UNSAFE_EVENT_PATTERNS\` into shared \`CamaleonCms::ContentSecurity\` module, [#1195](https://github.com/owen2345/camaleon-cms/pull/1195) — thanks, Mohamed Almuhaya, for reporting this.

--- a/app/controllers/camaleon_cms/admin/users_controller.rb
+++ b/app/controllers/camaleon_cms/admin/users_controller.rb
@@ -18,6 +18,7 @@ module CamaleonCms
         add_breadcrumb I18n.t('camaleon_cms.admin.users.profile')
         user_id = params[:user_id]
         @user = user_id.present? ? current_site.the_user(user_id.to_i).object : cama_current_user.object
+        authorize! :manage, :users if user_id.present? && @user.id != cama_current_user.id
         edit
       end
 

--- a/openspec/changes/archive/2026-07-12-fix-profile-ido/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-fix-profile-ido/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-12-fix-profile-ido/design.md
+++ b/openspec/changes/archive/2026-07-12-fix-profile-ido/design.md
@@ -1,0 +1,31 @@
+## Context
+
+The `UsersController#profile` action (lines 17-22) is explicitly excluded from the `validate_role` before_action via `except: %i[profile profile_edit]`. Any authenticated user can view any other user's profile by passing `?user_id=X` to `GET /admin/profile`. The `profile_edit` action (which always operates on `cama_current_user`) is also excluded but does not accept a `user_id` parameter, so it only renders the current user's own profile — it is not vulnerable.
+
+The existing `validate_role` guard enforces: `user_id = user_id_param; (user_id.present? && cama_current_user.id.to_s == user_id.to_s) || authorize!(:manage, :users)`. This is precisely the correct check.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Prevent non-admin users from reading arbitrary user profiles via the `profile` action
+- Keep `profile_edit` working unchanged for self-service
+- Follow existing patterns (`validate_role` guard style)
+
+**Non-Goals:**
+- No changes to the `show`, `edit`, or `update` actions (already protected by `set_user` + `validate_role`)
+- No changes to `profile_edit` (not vulnerable)
+- No redesign of the authorization model
+
+## Decisions
+
+1. **Add inline authorization check inside the `profile` action, keep `profile` excluded from `validate_role`**
+   - Rationale: `validate_role` requires a `user_id` to compare — when `params[:user_id]` is absent (self-view without explicit ID), the guard receives `nil` and falls through to `authorize!(:manage, :users)`, which would **block** non-admin users from seeing their own profile. The `profile` action is the only action where the target user is optional (defaults to self). Adding `profile` to `validate_role` would break self-profile access for non-admin users.
+   - Implementation: `authorize! :manage, :users if user_id.present? && @user.id != cama_current_user.id`
+   - Alternative considered: Adding `profile` to `validate_role`'s `only` list. Rejected because it breaks self-view without `user_id`.
+
+2. **Ensure `profile_edit` remains excluded** — it only loads `cama_current_user.object` with no user-controlled ID, so it's not vulnerable. No change needed.
+
+## Risks / Trade-offs
+
+- [Minor] Existing admin flows that render another user's profile via `GET /admin/profile?user_id=X` will continue to work because admins have `:manage :users` permission. No breakage expected.
+- [None] The `the_admin_profile_url` decorator method (generates `/admin/profile?user_id=ID`) is only used in admin views accessible to users who already have appropriate permissions. No frontend impact.

--- a/openspec/changes/archive/2026-07-12-fix-profile-ido/proposal.md
+++ b/openspec/changes/archive/2026-07-12-fix-profile-ido/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+The `UsersController#profile` action is excluded from the `validate_role` authorization guard, allowing any authenticated low-privilege user (e.g., "client" role) to read any other user's profile data — including email, username, role, and custom fields — by passing an arbitrary `user_id` query parameter. This enables silent user enumeration and information disclosure.
+
+## What Changes
+
+- Add authorization enforcement to the `profile` action so that non-admin users can only view their own profile
+- Add request specs covering the profile action with various authorization scenarios
+
+## Capabilities
+
+### New Capabilities
+- `profile-authorization`: Enforce that the admin profile endpoint (`GET /admin/profile`) only returns the requested user's data when the current user is authorized (self or has `:manage :users` permission)
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/controllers/camaleon_cms/admin/users_controller.rb` — add authorization check to `profile` action or remove it from `validate_role`'s `except` list
+- `spec/requests/admin/users_controller/` — add request specs for the profile action

--- a/openspec/changes/archive/2026-07-12-fix-profile-ido/specs/profile-authorization/spec.md
+++ b/openspec/changes/archive/2026-07-12-fix-profile-ido/specs/profile-authorization/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Profile access is authorized
+The system SHALL enforce authorization on the `GET /admin/profile` endpoint. A user SHALL only see another user's profile if they are viewing their own profile (`params[:user_id]` matches the current user's ID) OR they have `:manage` permission on `:users` (admin role).
+
+#### Scenario: Self-profile without user_id
+- **WHEN** an authenticated user visits `/admin/profile` without a `user_id` parameter
+- **THEN** the system renders the current user's own profile
+
+#### Scenario: Self-profile with matching user_id
+- **WHEN** an authenticated user visits `/admin/profile?user_id=CURRENT_USER_ID`
+- **THEN** the system renders the current user's own profile
+
+#### Scenario: Admin views another user's profile
+- **WHEN** an admin user visits `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system renders the other user's profile
+
+#### Scenario: Non-admin tries to view another user's profile
+- **WHEN** a non-admin user visits `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system denies access and redirects to the admin dashboard
+
+#### Scenario: Non-admin tries to view another user's profile (unauthorized response)
+- **WHEN** a non-admin user sends a request to `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system returns an HTTP 403 Forbidden or redirects to the dashboard with an error message

--- a/openspec/changes/archive/2026-07-12-fix-profile-ido/tasks.md
+++ b/openspec/changes/archive/2026-07-12-fix-profile-ido/tasks.md
@@ -1,0 +1,16 @@
+## 1. Authorization Fix
+
+- [x] 1.1 Add inline `authorize!` check in `profile` action when targeting another user
+
+## 2. Tests
+
+- [x] 2.1 Add request spec for self-profile access (no `user_id` parameter)
+- [x] 2.2 Add request spec for self-profile access (matching `user_id` parameter)
+- [x] 2.3 Add request spec for admin viewing another user's profile
+- [x] 2.4 Add request spec for non-admin attempting to view another user's profile (denied)
+
+## 3. Verification
+
+- [x] 3.1 Run the new specs: `bin/rspec spec/requests/admin/users_controller/profile_spec.rb`
+- [x] 3.2 Run the related specs to check for regressions: `bin/rspec spec/requests/admin/users_controller/`
+- [x] 3.3 Run linter: `bin/rubocop -A`

--- a/openspec/specs/profile-authorization/spec.md
+++ b/openspec/specs/profile-authorization/spec.md
@@ -1,0 +1,28 @@
+## Purpose
+
+Define authorization requirements for the admin profile endpoint (`GET /admin/profile`).
+
+## Requirements
+
+### Requirement: Profile access is authorized
+The system SHALL enforce authorization on the `GET /admin/profile` endpoint. A user SHALL only see another user's profile if they are viewing their own profile (`params[:user_id]` matches the current user's ID) OR they have `:manage` permission on `:users` (admin role).
+
+#### Scenario: Self-profile without user_id
+- **WHEN** an authenticated user visits `/admin/profile` without a `user_id` parameter
+- **THEN** the system renders the current user's own profile
+
+#### Scenario: Self-profile with matching user_id
+- **WHEN** an authenticated user visits `/admin/profile?user_id=CURRENT_USER_ID`
+- **THEN** the system renders the current user's own profile
+
+#### Scenario: Admin views another user's profile
+- **WHEN** an admin user visits `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system renders the other user's profile
+
+#### Scenario: Non-admin tries to view another user's profile
+- **WHEN** a non-admin user visits `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system denies access and redirects to the admin dashboard
+
+#### Scenario: Non-admin tries to view another user's profile (unauthorized response)
+- **WHEN** a non-admin user sends a request to `/admin/profile?user_id=OTHER_USER_ID`
+- **THEN** the system returns an HTTP 403 Forbidden or redirects to the dashboard with an error message

--- a/spec/requests/admin/users_controller/profile_spec.rb
+++ b/spec/requests/admin/users_controller/profile_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Profile request', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin_user) do
+    create(:user, site: current_site, role: 'admin', password: 'admin_secret',
+                  password_confirmation: 'admin_secret')
+  end
+  let(:regular_user) do
+    create(:user, site: current_site, role: 'client', password: 'password',
+                  password_confirmation: 'password')
+  end
+  let(:other_user) do
+    create(:user, site: current_site, role: 'client', password: 'other_pass',
+                  password_confirmation: 'other_pass')
+  end
+
+  context 'when viewing own profile' do
+    before do
+      post cama_admin_login_path, params: { user: { username: regular_user.username, password: 'password' } }
+    end
+
+    it 'renders own profile without user_id parameter' do
+      get cama_admin_profile_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'renders own profile with matching user_id' do
+      get cama_admin_profile_path, params: { user_id: regular_user.id }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when admin views another user' do
+    before do
+      post cama_admin_login_path, params: { user: { username: admin_user.username, password: 'admin_secret' } }
+    end
+
+    it 'renders the other users profile' do
+      get cama_admin_profile_path, params: { user_id: regular_user.id }
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when non-admin tries to view another user' do
+    before do
+      post cama_admin_login_path, params: { user: { username: regular_user.username, password: 'password' } }
+    end
+
+    it 'denies access and redirects to dashboard' do
+      get cama_admin_profile_path, params: { user_id: admin_user.id }
+      expect(response).to redirect_to(cama_admin_dashboard_path)
+      expect(flash[:error]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fixes an information disclosure vulnerability in `Admin::UsersController#profile`. The `profile` action was excluded from the `validate_role` authorization guard, allowing any authenticated low-privilege user to view any other user's profile (email, username, role, custom fields) by passing `?user_id=X`.

## Changes

- **app/controllers/camaleon_cms/admin/users_controller.rb**: Added inline `authorize!` check in `profile` action when `user_id` targets a different user
- **spec/requests/admin/users_controller/profile_spec.rb**: 4 request specs covering self-view, admin cross-view, and non-admin denial

## Testing

- `bin/rspec spec/requests/admin/users_controller/` — 11/11 pass
- `bin/rubocop -A` — clean

Reported by Neo Andrew.