### PR TITLE
Security: Fix SVG stored XSS via Nokogiri parse-based detection + media security headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Security fix:** Fix SVG stored XSS via Nokogiri parse-based detection — replace regex denylist for SVG uploads with XML parser that resolves entities, blocks `script`/`on*`/`javascript:`/`data:`/embed tags, and disable XXE via `nonet`. Add Rack middleware serving SVGs under `/media/` with `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'`, [#1199](https://github.com/owen2345/camaleon-cms/pull/1199) — thanks, Jose Rivas (Zero Trust Offsec), for reporting this.
+
 - **Security fix:** Fix arbitrary server-side file read via media upload — validate path prefix before `File.open` in `upload_file` and `cama_tmp_upload`, coerce nil `formats` to `'*'`, and handle crop errors gracefully, [#1198](https://github.com/owen2345/camaleon-cms/pull/1198) — thanks, Jose Rivas (Zero Trust Offsec), for reporting this.
 
 - **Security fix:** Fix profile IDOR in \`Admin::UsersController#profile\` — add inline \`authorize!\` check when viewing another user, so low-privilege users can no longer enumerate arbitrary user accounts. [#1197](https://github.com/owen2345/camaleon-cms/pull/1197) — thanks, Neo Andrew, for reporting this.

--- a/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
@@ -6,8 +6,6 @@ module CamaleonCms
   module RuntimeUploaderConcern
     extend ActiveSupport::Concern
 
-    include ContentSecurity
-
     def upload_file(uploaded_io, settings = {})
       cached_name = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.original_filename : nil
       return { error: 'File is empty', file: nil, size: nil } if uploaded_io.blank?
@@ -28,7 +26,11 @@ module CamaleonCms
         uploaded_io = File.open(cama_resize_upload(uploaded_io.path, settings[:dimension]))
       end
 
-      return { error: 'Potentially malicious content found!' } if file_content_unsafe?(uploaded_io)
+      if svg_upload?(uploaded_io)
+        return { error: 'Potentially malicious content found!' } if svg_content_unsafe?(uploaded_io)
+      elsif file_content_unsafe?(uploaded_io)
+        return { error: 'Potentially malicious content found!' }
+      end
 
       settings[:uploaded_io] = uploaded_io
       settings = settings.to_h.symbolize_keys
@@ -342,15 +344,33 @@ module CamaleonCms
       { error: "Unable to download remote file: #{ERB::Util.html_escape(e.message)}" }
     end
 
+    def svg_upload?(uploaded_io)
+      file_path = if uploaded_io.is_a?(ActionDispatch::Http::UploadedFile)
+                    uploaded_io.original_filename
+                  else
+                    uploaded_io.path
+                  end
+      file_path&.end_with?('.svg')
+    end
+
+    def svg_content_unsafe?(uploaded_io)
+      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      content = file.read
+      file.rewind if file.respond_to?(:rewind)
+      CamaleonCms::SvgContentChecker.unsafe?(content)
+    end
+
     def file_content_unsafe?(uploaded_io)
       file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      return nil if svg_upload?(uploaded_io)
+
       file_content_unsafe = nil
 
       file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)
 
       file_content = file.read
       file.rewind if file.respond_to?(:rewind)
-      SUSPICIOUS_PATTERNS.each do |pattern|
+      CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
         if file_content&.match?(pattern)
           Rails.logger.info { "Potentially malicious content found: #{pattern.inspect}" }
           break file_content_unsafe = pattern.inspect

--- a/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
@@ -6,6 +6,8 @@ module CamaleonCms
   module RuntimeUploaderConcern
     extend ActiveSupport::Concern
 
+    include UploaderContentSecurity
+
     def upload_file(uploaded_io, settings = {})
       cached_name = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.original_filename : nil
       return { error: 'File is empty', file: nil, size: nil } if uploaded_io.blank?
@@ -342,42 +344,6 @@ module CamaleonCms
       { file: tempfile, error: nil }
     rescue StandardError => e
       { error: "Unable to download remote file: #{ERB::Util.html_escape(e.message)}" }
-    end
-
-    def svg_upload?(uploaded_io)
-      file_path = if uploaded_io.is_a?(ActionDispatch::Http::UploadedFile)
-                    uploaded_io.original_filename
-                  else
-                    uploaded_io.path
-                  end
-      file_path&.end_with?('.svg')
-    end
-
-    def svg_content_unsafe?(uploaded_io)
-      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      content = file.read
-      file.rewind if file.respond_to?(:rewind)
-      CamaleonCms::SvgContentChecker.unsafe?(content)
-    end
-
-    def file_content_unsafe?(uploaded_io)
-      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      return nil if svg_upload?(uploaded_io)
-
-      file_content_unsafe = nil
-
-      file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)
-
-      file_content = file.read
-      file.rewind if file.respond_to?(:rewind)
-      CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
-        if file_content&.match?(pattern)
-          Rails.logger.info { "Potentially malicious content found: #{pattern.inspect}" }
-          break file_content_unsafe = pattern.inspect
-        end
-      end
-
-      file_content_unsafe
     end
 
     def cama_crop_offsets_by_gravity(gravity, original_dimensions, cropped_dimensions)

--- a/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
@@ -28,11 +28,7 @@ module CamaleonCms
         uploaded_io = File.open(cama_resize_upload(uploaded_io.path, settings[:dimension]))
       end
 
-      if svg_upload?(uploaded_io)
-        return { error: 'Potentially malicious content found!' } if svg_content_unsafe?(uploaded_io)
-      elsif file_content_unsafe?(uploaded_io)
-        return { error: 'Potentially malicious content found!' }
-      end
+      return { error: 'Potentially malicious content found!' } if file_content_unsafe?(uploaded_io)
 
       settings[:uploaded_io] = uploaded_io
       settings = settings.to_h.symbolize_keys

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -49,11 +49,7 @@ module CamaleonCms
         uploaded_io = File.open(cama_resize_upload(uploaded_io.path, settings[:dimension]))
       end
 
-      if svg_upload?(uploaded_io)
-        return { error: 'Potentially malicious content found!' } if svg_content_unsafe?(uploaded_io)
-      elsif file_content_unsafe?(uploaded_io)
-        return { error: 'Potentially malicious content found!' }
-      end
+      return { error: 'Potentially malicious content found!' } if file_content_unsafe?(uploaded_io)
 
       settings = settings.to_sym
       settings[:uploaded_io] = uploaded_io

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -5,8 +5,6 @@ require 'tempfile'
 
 module CamaleonCms
   module UploaderHelper
-    include ContentSecurity
-
     include ActionView::Helpers::NumberHelper
     include CamaleonCms::CamaleonHelper
 
@@ -50,7 +48,11 @@ module CamaleonCms
         uploaded_io = File.open(cama_resize_upload(uploaded_io.path, settings[:dimension]))
       end
 
-      return { error: 'Potentially malicious content found!' } if file_content_unsafe?(uploaded_io)
+      if svg_upload?(uploaded_io)
+        return { error: 'Potentially malicious content found!' } if svg_content_unsafe?(uploaded_io)
+      elsif file_content_unsafe?(uploaded_io)
+        return { error: 'Potentially malicious content found!' }
+      end
 
       settings = settings.to_sym
       settings[:uploaded_io] = uploaded_io
@@ -428,8 +430,26 @@ module CamaleonCms
       { error: "Unable to download remote file: #{ERB::Util.html_escape(e.message)}" }
     end
 
+    def svg_upload?(uploaded_io)
+      file_path = if uploaded_io.is_a?(ActionDispatch::Http::UploadedFile)
+                    uploaded_io.original_filename
+                  else
+                    uploaded_io.path
+                  end
+      file_path&.end_with?('.svg')
+    end
+
+    def svg_content_unsafe?(uploaded_io)
+      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      content = file.read
+      file.rewind if file.respond_to?(:rewind)
+      CamaleonCms::SvgContentChecker.unsafe?(content)
+    end
+
     def file_content_unsafe?(uploaded_io)
       file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      return nil if svg_upload?(uploaded_io)
+
       file_content_unsafe = nil
 
       file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)
@@ -439,7 +459,7 @@ module CamaleonCms
       # resulted in 0-byte uploads when the file was a Tempfile (see report).
       file_content = file.read
       file.rewind if file.respond_to?(:rewind)
-      SUSPICIOUS_PATTERNS.each do |pattern|
+      CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
         if file_content&.match?(pattern)
           Rails.logger.info { "Potentially malicious content found: #{pattern.inspect}" }
           break file_content_unsafe = pattern.inspect

--- a/app/helpers/camaleon_cms/uploader_helper.rb
+++ b/app/helpers/camaleon_cms/uploader_helper.rb
@@ -5,6 +5,7 @@ require 'tempfile'
 
 module CamaleonCms
   module UploaderHelper
+    include UploaderContentSecurity
     include ActionView::Helpers::NumberHelper
     include CamaleonCms::CamaleonHelper
 
@@ -428,45 +429,6 @@ module CamaleonCms
       { file: tempfile, error: nil }
     rescue StandardError => e
       { error: "Unable to download remote file: #{ERB::Util.html_escape(e.message)}" }
-    end
-
-    def svg_upload?(uploaded_io)
-      file_path = if uploaded_io.is_a?(ActionDispatch::Http::UploadedFile)
-                    uploaded_io.original_filename
-                  else
-                    uploaded_io.path
-                  end
-      file_path&.end_with?('.svg')
-    end
-
-    def svg_content_unsafe?(uploaded_io)
-      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      content = file.read
-      file.rewind if file.respond_to?(:rewind)
-      CamaleonCms::SvgContentChecker.unsafe?(content)
-    end
-
-    def file_content_unsafe?(uploaded_io)
-      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      return nil if svg_upload?(uploaded_io)
-
-      file_content_unsafe = nil
-
-      file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)
-
-      # Read the file for pattern scanning, then rewind so subsequent consumers
-      # (e.g. upload handlers) can read the full content. Failing to rewind
-      # resulted in 0-byte uploads when the file was a Tempfile (see report).
-      file_content = file.read
-      file.rewind if file.respond_to?(:rewind)
-      CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
-        if file_content&.match?(pattern)
-          Rails.logger.info { "Potentially malicious content found: #{pattern.inspect}" }
-          break file_content_unsafe = pattern.inspect
-        end
-      end
-
-      file_content_unsafe
     end
 
     # helper for resize and crop method

--- a/lib/camaleon_cms.rb
+++ b/lib/camaleon_cms.rb
@@ -3,6 +3,7 @@ require 'camaleon_cms/version'
 require 'camaleon_cms/content_security'
 require 'camaleon_cms/svg_content_checker'
 require 'camaleon_cms/media_security_headers'
+require 'camaleon_cms/uploader_content_security'
 
 module CamaleonCms
 end

--- a/lib/camaleon_cms.rb
+++ b/lib/camaleon_cms.rb
@@ -1,6 +1,8 @@
 require 'camaleon_cms/engine'
 require 'camaleon_cms/version'
 require 'camaleon_cms/content_security'
+require 'camaleon_cms/svg_content_checker'
+require 'camaleon_cms/media_security_headers'
 
 module CamaleonCms
 end

--- a/lib/camaleon_cms/content_security.rb
+++ b/lib/camaleon_cms/content_security.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CamaleonCms
-  # Deprecated: SVG content security is now handled by CamaleonCms::SvgContentChecker
+  # SVG content security is now handled by CamaleonCms::SvgContentChecker
   # (Nokogiri XML parse-based detection). These patterns are retained for non-SVG file
   # scanning as a defense-in-depth layer.
   module ContentSecurity

--- a/lib/camaleon_cms/content_security.rb
+++ b/lib/camaleon_cms/content_security.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 module CamaleonCms
+  # Deprecated: SVG content security is now handled by CamaleonCms::SvgContentChecker
+  # (Nokogiri XML parse-based detection). These patterns are retained for non-SVG file
+  # scanning as a defense-in-depth layer.
   module ContentSecurity
     UNSAFE_EVENT_PATTERNS = %w[
       onabort onafter onbefore onbegin onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -82,6 +82,9 @@ module CamaleonCms
         end
       end
 
+      # Security headers for SVG media files
+      app.middleware.insert_before ::ActionDispatch::Static, CamaleonCms::MediaSecurityHeaders
+
       # Static files
       app.middleware.use ::ActionDispatch::Static, "#{root}/public"
 

--- a/lib/camaleon_cms/media_security_headers.rb
+++ b/lib/camaleon_cms/media_security_headers.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  class MediaSecurityHeaders
+    SVG_PATH_PATTERN = %r{\A/media/.*\.svg\z}
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+
+      if env['REQUEST_METHOD'] == 'GET' && env['PATH_INFO']&.match?(SVG_PATH_PATTERN)
+        headers['X-Content-Type-Options'] = 'nosniff'
+        headers['Content-Security-Policy'] = "script-src 'none'"
+      end
+
+      [status, headers, body]
+    end
+  end
+end

--- a/lib/camaleon_cms/svg_content_checker.rb
+++ b/lib/camaleon_cms/svg_content_checker.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  module SvgContentChecker
+    BANNED_TAGS = %w[
+      script foreignObject iframe object embed animate set handler
+    ].freeze
+
+    module_function
+
+    def unsafe?(svg_content)
+      return true if svg_content.nil? || svg_content.empty? # rubocop:disable Rails/Blank
+
+      doc = Nokogiri::XML(svg_content, &:nonet)
+      return true unless doc.root
+
+      banned_tags_query = BANNED_TAGS.map { |tag| "local-name() = '#{tag}'" }.join(' or ')
+      return true if doc.xpath("//*[#{banned_tags_query}]").any?
+
+      return true if doc.xpath('//@*[starts-with(local-name(), "on")]').any?
+
+      return true if doc.xpath('//@*[local-name() = "href"]').any? do |attr|
+        attr.value.strip.match?(/\A(javascript|data|vbscript):/i)
+      end
+
+      serialized = doc.to_xml
+      return true if serialized.match?(/<script[\s>]/i)
+      return true if serialized.match?(/(javascript|data|vbscript):/i)
+
+      false
+    rescue Nokogiri::XML::SyntaxError
+      true
+    end
+  end
+end

--- a/lib/camaleon_cms/uploader_content_security.rb
+++ b/lib/camaleon_cms/uploader_content_security.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  module UploaderContentSecurity
+    def svg_upload?(uploaded_io)
+      file_path = if uploaded_io.is_a?(ActionDispatch::Http::UploadedFile)
+                    uploaded_io.original_filename
+                  else
+                    uploaded_io.path
+                  end
+      file_path&.end_with?('.svg')
+    end
+
+    def svg_content_unsafe?(uploaded_io)
+      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      content = file.read
+      file.rewind if file.respond_to?(:rewind)
+      CamaleonCms::SvgContentChecker.unsafe?(content)
+    end
+
+    def file_content_unsafe?(uploaded_io)
+      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
+      return nil if svg_upload?(uploaded_io)
+
+      file_content_unsafe = nil
+      file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)
+      file_content = file.read
+      file.rewind if file.respond_to?(:rewind)
+      CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
+        if file_content&.match?(pattern)
+          Rails.logger.info { "Potentially malicious content found: #{pattern.inspect}" }
+          break file_content_unsafe = pattern.inspect
+        end
+      end
+      file_content_unsafe
+    end
+  end
+end

--- a/lib/camaleon_cms/uploader_content_security.rb
+++ b/lib/camaleon_cms/uploader_content_security.rb
@@ -11,16 +11,15 @@ module CamaleonCms
       file_path&.end_with?('.svg')
     end
 
-    def svg_content_unsafe?(uploaded_io)
-      file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      content = file.read
-      file.rewind if file.respond_to?(:rewind)
-      CamaleonCms::SvgContentChecker.unsafe?(content)
-    end
-
     def file_content_unsafe?(uploaded_io)
       file = uploaded_io.is_a?(ActionDispatch::Http::UploadedFile) ? uploaded_io.tempfile : uploaded_io
-      return nil if svg_upload?(uploaded_io)
+      if svg_upload?(uploaded_io)
+        content = file.read
+        file.rewind if file.respond_to?(:rewind)
+        return true if CamaleonCms::SvgContentChecker.unsafe?(content)
+
+        return nil
+      end
 
       file_content_unsafe = nil
       file.set_encoding(Encoding::BINARY) if file.respond_to?(:binmode) && file.respond_to?(:set_encoding)

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/design.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/design.md
@@ -40,11 +40,12 @@ Parse uploaded SVG files with Nokogiri and reject the upload if dangerous conten
 | Regex denylist expansion | Rejected — fundamentally incomplete; new bypasses emerge as web APIs evolve |
 
 Detection logic:
-1. Parse the SVG with `Nokogiri::XML(content)` — this resolves DTD entities automatically
-2. Check for `<script>` elements → reject
+1. Parse the SVG with `Nokogiri::XML(content, &:nonet)` — `nonet` blocks XXE network access; entities are not expanded (preventing billion-laughs)
+2. Check for banned tags (`script`, `foreignObject`, `iframe`, `object`, `embed`, `animate`, `set`, `handler`) via XPath `local-name()` — catches HTML embedding and dynamic attribute mutation
 3. Check for attributes starting with `on` (event handlers) → reject
-4. Check for `href` and `xlink:href` attributes with `javascript:` URIs → reject
-5. If no dangerous content found, pass through to normal upload processing
+4. Check for `href` attributes with `javascript:`, `data:`, or `vbscript:` URIs → reject
+5. Serialize back to XML and run string pattern checks for `<script>` and `javascript:`/`data:`/`vbscript:` — catches DTD entity declarations and CDATA sections
+6. If no dangerous content found, pass through to normal upload processing
 
 **Decision 2: Rack middleware for SVG serving headers**
 
@@ -69,6 +70,16 @@ Middleware behavior:
 Since Nokogiri-based detection resolves all entities and rejects dangerous content before storage, the regex-based `file_content_unsafe?` scan is redundant for SVG files. The `file_content_unsafe?` method will skip SVG files entirely (detected by `.svg` extension or `image/svg+xml` content type). The method is retained for non-SVG files as a safety net.
 
 The `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` constants in `ContentSecurity` can be removed or deprecated.
+
+**Decision 4: Extract shared content-security methods into `UploaderContentSecurity` module**
+
+During code review, the `Metrics/ModuleLength` RuboCop rule flagged both `RuntimeUploaderConcern` and `UploaderHelper` because the new SVG methods pushed them past 339 lines. Since these two files already had near-identical implementations of `file_content_unsafe?` and the new SVG methods, the fix was to extract all three methods (`svg_upload?`, `svg_content_unsafe?`, `file_content_unsafe?`) into `lib/camaleon_cms/uploader_content_security.rb` — a shared module included by both classes.
+
+| Alternative | Verdict |
+|---|---|
+| Extract to shared module | **Chosen** — reduces duplication, fixes line count, single source of truth for content-scanning logic |
+| Inline `rubocop:disable` | Rejected — masks the underlying duplication problem |
+| Raise threshold to 400 | Rejected — would need re-raising in every future PR that touches these files |
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/design.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/design.md
@@ -1,0 +1,79 @@
+## Context
+
+The current SVG upload security relies on a regex-based denylist (`SUSPICIOUS_PATTERNS` / `UNSAFE_EVENT_PATTERNS` in `ContentSecurity`) that scans raw file bytes for dangerous patterns. This has fundamental weaknesses:
+
+1. Entity encoding bypasses byte-level scans (`javascript&#58;` does not match `/javascript:/i`)
+2. XML DTD entity substitution bypasses all patterns (`&x;` resolves to `<script>` after parsing)
+3. The denylist is inherently incomplete — missing event handlers (pointer, animation, transition events) and a concatenation bug (`onunloadonsubmit`) leave gaps
+4. Even if scanning catches some attacks, successfully uploaded SVGs are served from `public/media/` as static files with `Content-Type: image/svg+xml` and no security headers, rendering inline in the site origin
+
+The regex patterns are duplicated in `runtime_uploader_concern.rb` and `uploader_helper.rb`, extracted to `lib/camaleon_cms/content_security.rb` in a prior change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Replace the regex-based content scan for SVGs with Nokogiri XML parse-based detection that rejects dangerous SVGs before storage
+- Add a Rack middleware to serve SVG files under `/media/` with `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'` headers
+- Remove the now-redundant `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` for SVGs
+- Keep regex-based scanning as a safety net for non-SVG files
+
+**Non-Goals:**
+- No changes to non-SVG upload handling
+- No changes to the upload storage path or file naming conventions
+- No changes to thumbnail generation or image processing
+- No breaking API changes
+
+## Decisions
+
+**Decision 1: Nokogiri XML parse-based SVG content rejection**
+
+Parse uploaded SVG files with Nokogiri and reject the upload if dangerous content is detected. Nokogiri is already available in the Rails dependency tree (required by ActionPack). Rejection is preferred over sanitization because:
+- Simpler implementation — detect and reject, no XML reconstruction
+- Clearer security boundary — dangerous content never reaches storage
+- User can re-upload a clean SVG; no legitimate reason to have event handlers or scripts in a CMS media upload
+
+| Alternative | Verdict |
+|---|---|
+| Nokogiri XML parse + reject if dangerous | **Chosen** — Nokogiri resolves all entities automatically, making entity-based bypasses impossible; simpler and safer than sanitization |
+| Nokogiri XML parse + strip + store sanitized | Rejected — more complex (XML reconstruction), risk of content corruption, no benefit over rejection |
+| Loofah HTML5 sanitizer | Rejected — Loofah targets HTML, not SVG; SVG-specific elements and namespaces would be lost |
+| Regex denylist expansion | Rejected — fundamentally incomplete; new bypasses emerge as web APIs evolve |
+
+Detection logic:
+1. Parse the SVG with `Nokogiri::XML(content)` — this resolves DTD entities automatically
+2. Check for `<script>` elements → reject
+3. Check for attributes starting with `on` (event handlers) → reject
+4. Check for `href` and `xlink:href` attributes with `javascript:` URIs → reject
+5. If no dangerous content found, pass through to normal upload processing
+
+**Decision 2: Rack middleware for SVG serving headers**
+
+Insert a middleware before `ActionDispatch::Static` that adds security headers to SVG responses under `/media/`.
+
+| Alternative | Verdict |
+|---|---|
+| Rack middleware | **Chosen** — no file movement needed, existing URLs preserved, adds defense-in-depth |
+| Controller route catch-all | Rejected — requires moving SVGs out of `public/` or complex routing; would break existing URLs |
+| Nginx/Apache config | Rejected — Rails should own its security; dev/test environments also need protection |
+
+Middleware behavior:
+- Intercepts all GET requests where `PATH_INFO` matches `/media/.*\.svg\z`
+- Adds `X-Content-Type-Options: nosniff`
+- Adds `Content-Security-Policy: script-src 'none'`
+- Leaves response body unchanged (SVG still renders visually, but scripts are blocked)
+
+`Content-Security-Policy: script-src 'none'` is preferred over `Content-Disposition: attachment` because it does not break SVG display when referenced from `<img>` tags or when navigating directly to the URL — the SVG renders normally, only JavaScript execution is blocked.
+
+**Decision 3: Remove regex-based SVG scanning**
+
+Since Nokogiri-based detection resolves all entities and rejects dangerous content before storage, the regex-based `file_content_unsafe?` scan is redundant for SVG files. The `file_content_unsafe?` method will skip SVG files entirely (detected by `.svg` extension or `image/svg+xml` content type). The method is retained for non-SVG files as a safety net.
+
+The `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` constants in `ContentSecurity` can be removed or deprecated.
+
+## Risks / Trade-offs
+
+- **[Nokogiri performance]** → XML parsing is slower than raw byte scanning. For typical SVGs (10-100KB), the overhead is negligible. The `filesystem_max_size` setting (default 100MB) bounds worst-case impact.
+- **[XML parsing errors]** → Malformed SVG might fail to parse. Mitigation: wrap in a rescue block; if parsing fails, reject the upload with a clear error message rather than accepting potentially ambiguous content.
+- **[Legitimate SVGs rejected for false positives]** → A clean SVG that happens to contain `javascript:` in benign text content (e.g., a blog post rendered as SVG) would be rejected. Mitigation: extremely unlikely in practice; `javascript:` in SVG text content is vanishingly rare in CMS media uploads.
+- **[Middleware ordering]** → The middleware must be positioned before `ActionDispatch::Static` to intercept static file responses. Mitigation: use `insert_before` in the engine initializer, which reliably positions middleware in Rails 8.x.
+- **[CSP scope]** → `Content-Security-Policy: script-src 'none'` only affects the SVG document itself. It does not protect against clickjacking or other attacks on the parent page. Mitigation: this is intentional — the middleware's purpose is SVG XSS prevention, not general security hardening.

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/proposal.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+The SVG upload content scanner uses a regex-based denylist on raw file bytes. This is bypassed by: (1) HTML entity encoding of dangerous strings (e.g., `javascript&#58;`), (2) XML DTD entity substitution to inject arbitrary content, and (3) missing event handler attributes (`onpointerdown`, `onanimationend`, etc.). The concatenation bug `onunloadonsubmit` also causes `onunload` and `onsubmit` to be missing. Additionally, uploaded SVGs are served from `public/media/` as static files with no security headers, allowing stored XSS in the site origin when a user opens the file.
+
+## What Changes
+
+- Replace the regex-based content scanning for SVG uploads with Nokogiri XML parse-based detection that rejects dangerous SVGs before storage — parse resolves all entities, check for dangerous elements/attributes, reject if found
+- Add a Rack middleware that intercepts SVG responses under `/media/` and adds `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'` headers, preventing script execution even if a malicious SVG is served
+- Remove the now-redundant regex-based `SUSPICIOUS_PATTERNS` for SVG files (retain for non-SVG files as a safety net)
+- Remove the `UNSAFE_EVENT_PATTERNS` list (replaced by parse-based detection)
+
+## Capabilities
+
+### New Capabilities
+
+- `svg-upload-sanitization`: SVG upload content security — the system MUST parse uploaded SVG files with an XML parser, resolve all entities, and reject the upload if dangerous elements (script, etc.) or attributes (event handlers, javascript: URIs) are present. Safe SVGs without dangerous content are accepted.
+- `media-serving-security`: SVG response security headers — the system MUST serve SVG media files with `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'` headers to prevent inline script execution in the browser.
+
+### Modified Capabilities
+
+- `upload-content-security`: The `file_content_unsafe?` method no longer scans SVG files using the regex denylist — SVG content checks are handled by the parse-based pipeline that rejects dangerous files before storage. The regex scanning is retained for non-SVG file types.
+
+## Impact
+
+- `lib/camaleon_cms/content_security.rb` — the `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` constants are no longer needed for SVG scanning (consider removal or deprecation)
+- `app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb` — add SVG parse-based content check that rejects dangerous uploads before storage
+- `app/helpers/camaleon_cms/uploader_helper.rb` — same change in duplicated implementation
+- `lib/camaleon_cms/engine.rb` — register the Rack middleware for SVG security headers
+- New middleware file (e.g., `lib/camaleon_cms/media_security_headers.rb`)
+- `spec/support/fixtures/` — add test SVG fixtures for entity encoding, DTD entities, missing event handlers
+- `spec/helpers/uploader_helper_spec.rb` — update tests for parse-based SVG content checking
+- Add request spec for middleware SVG headers

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/media-serving-security/spec.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/media-serving-security/spec.md
@@ -1,0 +1,29 @@
+## Purpose
+
+Define the security requirements for serving SVG media files. SVG files served from `/media/` MUST include security headers that prevent inline script execution in the browser.
+
+## Requirements
+
+### Requirement: SVG responses include X-Content-Type-Options nosniff
+
+The system SHALL set `X-Content-Type-Options: nosniff` on HTTP responses for SVG files served from the `/media/` URL path.
+
+#### Scenario: SVG response has nosniff header
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.svg`
+- **THEN** the response includes the `X-Content-Type-Options: nosniff` header
+
+### Requirement: SVG responses include Content-Security-Policy script-src 'none'
+
+The system SHALL set `Content-Security-Policy: script-src 'none'` on HTTP responses for SVG files served from the `/media/` URL path, blocking JavaScript execution while allowing the SVG to render visually.
+
+#### Scenario: SVG response has CSP script-src 'none' header
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.svg`
+- **THEN** the response includes the `Content-Security-Policy: script-src 'none'` header
+
+### Requirement: Non-SVG media files are unaffected
+
+The system SHALL NOT add the SVG security headers to non-SVG media files served from `/media/`.
+
+#### Scenario: PNG response is unchanged
+- **WHEN** a browser requests a PNG file at `/media/{site_id}/image.png`
+- **THEN** the response does NOT include `Content-Security-Policy: script-src 'none'`

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/svg-upload-sanitization/spec.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/svg-upload-sanitization/spec.md
@@ -1,0 +1,69 @@
+## Purpose
+
+Define the security requirements for detecting dangerous content in uploaded SVG files. SVG files MUST be parsed with an XML parser that resolves all entities, and the upload MUST be rejected if dangerous elements or attributes are present. Safe SVGs without dangerous content are accepted.
+
+## Requirements
+
+### Requirement: Reject SVGs with script elements
+
+The system SHALL reject SVG uploads that contain `<script>` elements.
+
+#### Scenario: SVG with script tag is rejected
+- **WHEN** a user uploads an SVG file containing a `<script>` element
+- **THEN** the system returns an error and does NOT store the file
+
+### Requirement: Reject SVGs with event handler attributes
+
+The system SHALL reject SVG uploads that contain attributes starting with `on` (event handlers).
+
+#### Scenario: SVG with onclick is rejected
+- **WHEN** a user uploads an SVG file containing an `onclick` attribute
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with onpointerdown is rejected
+- **WHEN** a user uploads an SVG file containing an `onpointerdown` attribute
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with onbegin animation event is rejected
+- **WHEN** a user uploads an SVG file containing an `onbegin` attribute on an `<animate>` element
+- **THEN** the system returns an error and does NOT store the file
+
+### Requirement: Reject SVGs with javascript: URIs
+
+The system SHALL reject SVG uploads that contain `href` or `xlink:href` attributes with `javascript:` URIs. Entity-encoded variants are caught because XML parsing resolves all entities before inspection.
+
+#### Scenario: SVG with javascript: in href is rejected
+- **WHEN** a user uploads an SVG file containing an `href` attribute with `javascript:` URI
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with entity-encoded javascript: in href is rejected
+- **WHEN** a user uploads an SVG file containing `href="javascript&#58;alert(1)"`
+- **THEN** the system returns an error and does NOT store the file (entity is resolved during XML parsing, javascript: is detected)
+
+### Requirement: Reject SVGs with DTD entities containing dangerous content
+
+The system SHALL reject SVG uploads that use internal DTD entities to inject dangerous content. XML parsing resolves all entities, allowing the expanded content to be inspected.
+
+#### Scenario: SVG with DTD entity containing script tag is rejected
+- **WHEN** a user uploads an SVG file with `<!ENTITY x "<script>alert(1)</script>">` and `&x;` in the body
+- **THEN** the system returns an error and does NOT store the file (entity is expanded during parsing, script element is detected)
+
+#### Scenario: SVG with DTD entity containing javascript: is rejected
+- **WHEN** a user uploads an SVG file with `<!ENTITY xlink "javascript:">` and `xlink:href="&xlink;alert(1)"`
+- **THEN** the system returns an error and does NOT store the file (entity is expanded during parsing, javascript: URI is detected)
+
+### Requirement: Safe SVGs are accepted
+
+The system SHALL accept SVG uploads that contain no dangerous elements, attributes, or URIs.
+
+#### Scenario: Safe SVG without dangerous content is accepted
+- **WHEN** a user uploads an SVG file with no script elements, event handlers, or javascript: URIs
+- **THEN** the system stores the file normally
+
+### Requirement: XML parse errors reject the upload
+
+The system SHALL reject SVG uploads that fail to parse as valid XML.
+
+#### Scenario: Malformed SVG is rejected
+- **WHEN** a user uploads a file that cannot be parsed as valid XML
+- **THEN** the system returns an error and does NOT store the file

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/upload-content-security/spec.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/specs/upload-content-security/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Reject uploaded files with event handler attributes
+
+The system SHALL reject file uploads whose content contains known executable event handler attributes before storing or persisting the file.
+
+**Change**: SVG files are no longer scanned for event handlers using the regex denylist — SVG content checks are handled by the XML parse-based checker in the `svg-upload-sanitization` capability. Non-SVG files continue to be scanned by the regex pipeline.
+
+#### Scenario: Non-SVG file with onclick is rejected
+- **WHEN** a user uploads a non-SVG file whose content includes an `onclick` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: Non-SVG file with onload is rejected
+- **WHEN** a user uploads a non-SVG file whose content includes an `onload` attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+#### Scenario: SVG with event handlers is rejected (not scanned by regex)
+- **WHEN** a user uploads an SVG file containing event handler attributes
+- **THEN** the system rejects the upload via the parse-based checker (see `svg-upload-sanitization`)
+
+### Requirement: Reject uploaded files with `<script>` tags
+
+The system SHALL reject file uploads whose content contains `<script>` elements.
+
+**Change**: SVG `<script>` elements are handled by the XML parse-based checker; non-SVG files continue to use the regex denylist.
+
+#### Scenario: Non-SVG with `<script>` is rejected
+- **WHEN** a user uploads a non-SVG file containing a `<script>` tag
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Reject uploaded files with `javascript:` URIs
+
+The system SHALL reject file uploads whose content contains `javascript:` URIs in attributes.
+
+**Change**: SVG `javascript:` URIs are handled by the XML parse-based checker; non-SVG files continue to use the regex denylist.
+
+#### Scenario: Non-SVG with javascript: in href is rejected
+- **WHEN** a user uploads a non-SVG file containing `javascript:` in an href or src attribute
+- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
+
+### Requirement: Safe file scanning does not consume the IO stream
+
+After scanning for malicious content, the file pointer SHALL be rewound so subsequent consumers can read the full content.
+
+*(Unchanged — applies to all file types)*
+
+#### Scenario: Tempfile is readable after scan
+- **WHEN** the system scans a Tempfile for unsafe content and the scan passes
+- **THEN** the Tempfile pointer is at the beginning and the full content can be read again

--- a/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/tasks.md
+++ b/openspec/changes/archive/2026-07-12-fix-svg-xss-parse-based/tasks.md
@@ -1,0 +1,33 @@
+## 1. Implement Nokogiri SVG content checker
+
+- [x] 1.1 Create `lib/camaleon_cms/svg_content_checker.rb` module with an `unsafe?(svg_content)` method that parses SVG with Nokogiri, checks for `<script>` elements, `on*` attributes, `href`/`xlink:href` with `javascript:` URIs, and returns true if dangerous content is found
+- [x] 1.2 Handle XML parse errors: rescue `Nokogiri::XML::SyntaxError` and return unsafe (reject on unparseable content)
+- [x] 1.3 Add test fixtures: SVG with `<script>`, SVG with `onclick`, SVG with entity-encoded `javascript:`, SVG with DTD entity, safe SVG
+- [x] 1.4 Add unit tests for `SvgContentChecker.unsafe?` covering all fixture cases
+
+## 2. Integrate SVG content checker into upload pipeline
+
+- [x] 2.1 In `runtime_uploader_concern.rb`: after `file_content_unsafe?` check, add SVG detection (`.svg` extension) and call `SvgContentChecker.unsafe?` — reject upload if dangerous
+- [x] 2.2 In `uploader_helper.rb`: same integration at the corresponding point in the duplicated `upload_file` method
+- [x] 2.3 Update `file_content_unsafe?` to skip regex scanning for SVG files (they're handled by the parse-based checker)
+- [x] 2.4 Add integration test: upload SVG with `onclick` → upload rejected with error message
+
+## 3. Implement Rack middleware for SVG security headers
+
+- [x] 3.1 Create `lib/camaleon_cms/media_security_headers.rb` middleware class that intercepts `PATH_INFO` matching `/media/.*\.svg\z` and adds `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'`
+- [x] 3.2 Register middleware in `lib/camaleon_cms/engine.rb` using `insert_before ActionDispatch::Static`
+- [x] 3.3 Add request spec: SVG under `/media/` responds with nosniff and CSP headers
+- [x] 3.4 Add request spec: PNG under `/media/` does NOT get security headers
+
+## 4. Clean up redundant code
+
+- [x] 4.1 Add deprecation comment to `UNSAFE_EVENT_PATTERNS` and `SUSPICIOUS_PATTERNS` in `lib/camaleon_cms/content_security.rb` (retained for non-SVG file scanning)
+- [x] 4.2 Remove `include ContentSecurity` from `runtime_uploader_concern.rb` and `uploader_helper.rb` (replaced references with `CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS`)
+- [x] 4.3 Remove existing `file_content_unsafe?` tests for SVG files that are now handled by the parse-based checker
+
+## 5. Final verification
+
+- [x] 5.1 Run `bin/rubocop -A` (lint)
+- [x] 5.2 Run `bin/brakeman --no-pager` (security) — 0 warnings
+- [x] 5.3 Run `(cd spec/dummy && bin/rails zeitwerk:check)` (load verification) — all good
+- [x] 5.4 Run `bin/rspec` (full test suite) — 124 examples, 0 failures

--- a/openspec/specs/media-serving-security/spec.md
+++ b/openspec/specs/media-serving-security/spec.md
@@ -1,0 +1,29 @@
+## Purpose
+
+Define the security requirements for serving SVG media files. SVG files served from `/media/` MUST include security headers that prevent inline script execution in the browser.
+
+## Requirements
+
+### Requirement: SVG responses include X-Content-Type-Options nosniff
+
+The system SHALL set `X-Content-Type-Options: nosniff` on HTTP responses for SVG files served from the `/media/` URL path.
+
+#### Scenario: SVG response has nosniff header
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.svg`
+- **THEN** the response includes the `X-Content-Type-Options: nosniff` header
+
+### Requirement: SVG responses include Content-Security-Policy script-src 'none'
+
+The system SHALL set `Content-Security-Policy: script-src 'none'` on HTTP responses for SVG files served from the `/media/` URL path, blocking JavaScript execution while allowing the SVG to render visually.
+
+#### Scenario: SVG response has CSP script-src 'none' header
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.svg`
+- **THEN** the response includes the `Content-Security-Policy: script-src 'none'` header
+
+### Requirement: Non-SVG media files are unaffected
+
+The system SHALL NOT add the SVG security headers to non-SVG media files served from `/media/`.
+
+#### Scenario: PNG response is unchanged
+- **WHEN** a browser requests a PNG file at `/media/{site_id}/image.png`
+- **THEN** the response does NOT include `Content-Security-Policy: script-src 'none'`

--- a/openspec/specs/svg-upload-sanitization/spec.md
+++ b/openspec/specs/svg-upload-sanitization/spec.md
@@ -1,0 +1,69 @@
+## Purpose
+
+Define the security requirements for detecting dangerous content in uploaded SVG files. SVG files MUST be parsed with an XML parser that resolves all entities, and the upload MUST be rejected if dangerous elements or attributes are present. Safe SVGs without dangerous content are accepted.
+
+## Requirements
+
+### Requirement: Reject SVGs with script elements
+
+The system SHALL reject SVG uploads that contain `<script>` elements.
+
+#### Scenario: SVG with script tag is rejected
+- **WHEN** a user uploads an SVG file containing a `<script>` element
+- **THEN** the system returns an error and does NOT store the file
+
+### Requirement: Reject SVGs with event handler attributes
+
+The system SHALL reject SVG uploads that contain attributes starting with `on` (event handlers).
+
+#### Scenario: SVG with onclick is rejected
+- **WHEN** a user uploads an SVG file containing an `onclick` attribute
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with onpointerdown is rejected
+- **WHEN** a user uploads an SVG file containing an `onpointerdown` attribute
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with onbegin animation event is rejected
+- **WHEN** a user uploads an SVG file containing an `onbegin` attribute on an `<animate>` element
+- **THEN** the system returns an error and does NOT store the file
+
+### Requirement: Reject SVGs with javascript: URIs
+
+The system SHALL reject SVG uploads that contain `href` or `xlink:href` attributes with `javascript:` URIs. Entity-encoded variants are caught because XML parsing resolves all entities before inspection.
+
+#### Scenario: SVG with javascript: in href is rejected
+- **WHEN** a user uploads an SVG file containing an `href` attribute with `javascript:` URI
+- **THEN** the system returns an error and does NOT store the file
+
+#### Scenario: SVG with entity-encoded javascript: in href is rejected
+- **WHEN** a user uploads an SVG file containing `href="javascript&#58;alert(1)"`
+- **THEN** the system returns an error and does NOT store the file (entity is resolved during XML parsing, javascript: is detected)
+
+### Requirement: Reject SVGs with DTD entities containing dangerous content
+
+The system SHALL reject SVG uploads that use internal DTD entities to inject dangerous content. XML parsing resolves all entities, allowing the expanded content to be inspected.
+
+#### Scenario: SVG with DTD entity containing script tag is rejected
+- **WHEN** a user uploads an SVG file with `<!ENTITY x "<script>alert(1)</script>">` and `&x;` in the body
+- **THEN** the system returns an error and does NOT store the file (entity is expanded during parsing, script element is detected)
+
+#### Scenario: SVG with DTD entity containing javascript: is rejected
+- **WHEN** a user uploads an SVG file with `<!ENTITY xlink "javascript:">` and `xlink:href="&xlink;alert(1)"`
+- **THEN** the system returns an error and does NOT store the file (entity is expanded during parsing, javascript: URI is detected)
+
+### Requirement: Safe SVGs are accepted
+
+The system SHALL accept SVG uploads that contain no dangerous elements, attributes, or URIs.
+
+#### Scenario: Safe SVG without dangerous content is accepted
+- **WHEN** a user uploads an SVG file with no script elements, event handlers, or javascript: URIs
+- **THEN** the system stores the file normally
+
+### Requirement: XML parse errors reject the upload
+
+The system SHALL reject SVG uploads that fail to parse as valid XML.
+
+#### Scenario: Malformed SVG is rejected
+- **WHEN** a user uploads a file that cannot be parsed as valid XML
+- **THEN** the system returns an error and does NOT store the file

--- a/openspec/specs/upload-content-security/spec.md
+++ b/openspec/specs/upload-content-security/spec.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-Define the security requirements for content scanning of uploaded files. Uploaded files MUST be scanned for executable content patterns before being persisted, to prevent stored XSS attacks via uploaded SVGs and other file types.
+Define the security requirements for content scanning of uploaded files. Uploaded files MUST be scanned for executable content patterns before being persisted, to prevent stored XSS attacks via uploaded files.
 
 ## Requirements
 
@@ -8,49 +8,45 @@ Define the security requirements for content scanning of uploaded files. Uploade
 
 The system SHALL reject file uploads whose content contains known executable event handler attributes before storing or persisting the file.
 
-#### Scenario: File with `onclick` is rejected
-- **WHEN** a user uploads a file whose content includes an `onclick` attribute
+**Change**: SVG files are no longer scanned for event handlers using the regex denylist — SVG content checks are handled by the XML parse-based checker in the `svg-upload-sanitization` capability. Non-SVG files continue to be scanned by the regex pipeline.
+
+#### Scenario: Non-SVG file with onclick is rejected
+- **WHEN** a user uploads a non-SVG file whose content includes an `onclick` attribute
 - **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
 
-#### Scenario: File with `onload` is rejected
-- **WHEN** a user uploads a file whose content includes an `onload` attribute
+#### Scenario: Non-SVG file with onload is rejected
+- **WHEN** a user uploads a non-SVG file whose content includes an `onload` attribute
 - **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
 
-#### Scenario: File with `onbegin` is rejected
-- **WHEN** a user uploads an SVG whose content includes `<animate onbegin="...">`
-- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
-
-#### Scenario: File with `onend` is rejected
-- **WHEN** a user uploads an SVG whose content includes `<animate onend="...">`
-- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
-
-#### Scenario: File with `onrepeat` is rejected
-- **WHEN** a user uploads an SVG whose content includes `<animate onrepeat="...">`
-- **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
-
-#### Scenario: Safe SVG without event handlers is accepted
-- **WHEN** a user uploads an SVG file with no executable content patterns
-- **THEN** the system accepts and persists the file successfully
+#### Scenario: SVG with event handlers is rejected (not scanned by regex)
+- **WHEN** a user uploads an SVG file containing event handler attributes
+- **THEN** the system rejects the upload via the parse-based checker (see `svg-upload-sanitization`)
 
 ### Requirement: Reject uploaded files with `<script>` tags
 
 The system SHALL reject file uploads whose content contains `<script>` elements.
 
-#### Scenario: SVG with `<script>` is rejected
-- **WHEN** a user uploads an SVG file containing a `<script>` tag
+**Change**: SVG `<script>` elements are handled by the XML parse-based checker; non-SVG files continue to use the regex denylist.
+
+#### Scenario: Non-SVG with `<script>` is rejected
+- **WHEN** a user uploads a non-SVG file containing a `<script>` tag
 - **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
 
 ### Requirement: Reject uploaded files with `javascript:` URIs
 
 The system SHALL reject file uploads whose content contains `javascript:` URIs in attributes.
 
-#### Scenario: File with `javascript:` in href is rejected
-- **WHEN** a user uploads a file containing `javascript:` in an href or src attribute
+**Change**: SVG `javascript:` URIs are handled by the XML parse-based checker; non-SVG files continue to use the regex denylist.
+
+#### Scenario: Non-SVG with javascript: in href is rejected
+- **WHEN** a user uploads a non-SVG file containing `javascript:` in an href or src attribute
 - **THEN** the system returns `'Potentially malicious content found!'` and does NOT persist the file
 
 ### Requirement: Safe file scanning does not consume the IO stream
 
 After scanning for malicious content, the file pointer SHALL be rewound so subsequent consumers can read the full content.
+
+*(Unchanged — applies to all file types)*
 
 #### Scenario: Tempfile is readable after scan
 - **WHEN** the system scans a Tempfile for unsafe content and the scan passes

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -90,19 +90,6 @@ describe CamaleonCms::UploaderHelper do
   end
 
   describe 'file upload with unsafe content' do
-    let(:unsafe_file_path) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/unsafe-test-xss.svg" }
-    let(:unsafe_svg_animation_path) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures/unsafe-svg-onbegin.svg" }
-
-    it "doesn't allow the file upload, returning an error" do
-      expect(upload_file(File.open(unsafe_file_path), { folder: '/' })[:error])
-        .to eql('Potentially malicious content found!')
-    end
-
-    it "doesn't allow an SVG with animation event handlers (onbegin/onend/onrepeat)" do
-      expect(upload_file(File.open(unsafe_svg_animation_path), { folder: '/' })[:error])
-        .to eql('Potentially malicious content found!')
-    end
-
     it 'does not consume the Tempfile when scanning for suspicious content' do
       tmp = Tempfile.new(['cama-test'])
       begin

--- a/spec/lib/svg_content_checker_spec.rb
+++ b/spec/lib/svg_content_checker_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::SvgContentChecker do
+  let(:fixtures) { "#{CAMALEON_CMS_ROOT}/spec/support/fixtures" }
+
+  describe '.unsafe?' do
+    it 'rejects SVG with script tag' do
+      content = File.read("#{fixtures}/unsafe-test-xss.svg")
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with onclick attribute' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <rect onclick="alert(1)" width="50" height="50"/>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with onpointerdown event handler' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <rect onpointerdown="alert(1)" width="50" height="50"/>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with onbegin animation event' do
+      content = File.read("#{fixtures}/unsafe-svg-onbegin.svg")
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with javascript: in href' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <a href="javascript:alert(1)">click</a>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with entity-encoded javascript: in href' do
+      content = File.read("#{fixtures}/svg-javascript-encoded.svg")
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with DTD entity containing script tag' do
+      content = File.read("#{fixtures}/svg-dtd-entity.svg")
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'accepts safe SVG without dangerous content' do
+      content = File.read("#{fixtures}/svg-safe.svg")
+      expect(described_class.unsafe?(content)).to be(false)
+    end
+
+    it 'rejects nil content' do
+      expect(described_class.unsafe?(nil)).to be(true)
+    end
+
+    it 'rejects empty content' do
+      expect(described_class.unsafe?('')).to be(true)
+    end
+
+    it 'rejects SVG with foreignObject containing iframe' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+          <foreignObject width="100" height="100">
+            <iframe src="https://phishing.com"></iframe>
+          </foreignObject>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with data: URI in href' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <a href="data:text/html,<script>alert(1)</script>">click</a>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with object tag' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <object data="javascript:alert(1)"></object>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects SVG with embed tag' do
+      content = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <embed src="javascript:alert(1)"/>
+        </svg>
+      SVG
+      expect(described_class.unsafe?(content)).to be(true)
+    end
+
+    it 'rejects non-XML content (binary garbage)' do
+      expect(described_class.unsafe?("\xFF\xFE\x00\x01")).to be(true)
+    end
+  end
+end

--- a/spec/requests/admin/media_controller/upload_spec.rb
+++ b/spec/requests/admin/media_controller/upload_spec.rb
@@ -48,6 +48,58 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#upload', type: :request do
     end
   end
 
+  context 'when uploading SVG with dangerous content' do
+    let(:admin_role) { current_site.user_roles.create!(name: 'Media Admin', slug: 'media_admin') }
+    let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
+
+    before do
+      admin_role.set_meta("_manager_#{current_site.id}", { 'media' => 1 })
+      allow_any_instance_of(described_class).to receive(:verify_media_authorization).and_return(true)
+      sign_in_as(admin_user, site: current_site)
+    end
+
+    it 'rejects SVG with onclick attribute' do
+      unsafe_svg = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <rect onclick="alert(1)" width="50" height="50"/>
+        </svg>
+      SVG
+      file = Tempfile.new(['test', '.svg'])
+      file.write(unsafe_svg)
+      file.rewind
+      rack_file = Rack::Test::UploadedFile.new(file.path, 'image/svg+xml')
+
+      post '/admin/media/upload', params: { file_upload: rack_file, folder: '' }
+
+      expect(response.body).to include('Potentially malicious content found!')
+    ensure
+      file&.close!
+      file&.unlink
+    end
+
+    it 'accepts safe SVG without dangerous content' do
+      safe_svg = <<~SVG
+        <?xml version="1.0" encoding="UTF-8"?>
+        <svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+          <circle cx="50" cy="50" r="40" fill="red"/>
+        </svg>
+      SVG
+      file = Tempfile.new(['test', '.svg'])
+      file.write(safe_svg)
+      file.rewind
+      rack_file = Rack::Test::UploadedFile.new(file.path, 'image/svg+xml')
+
+      post '/admin/media/upload', params: { file_upload: rack_file, folder: '' }
+
+      expect(response.body).not_to include('Potentially malicious content found!')
+      expect(response.body).not_to include('error')
+    ensure
+      file&.close!
+      file&.unlink
+    end
+  end
+
   context 'when user does NOT have media management permission' do
     let(:limited_role) { current_site.user_roles.create!(name: 'Limited User', slug: 'limited_user') }
     let(:limited_user) { create(:user, role: limited_role.slug, site: current_site) }

--- a/spec/requests/media_security_headers_spec.rb
+++ b/spec/requests/media_security_headers_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::MediaSecurityHeaders, type: :request do
+  init_site
+
+  let(:svg_path) { '/media/1/test.svg' }
+  let(:png_path) { '/media/1/test.png' }
+
+  before do
+    FileUtils.mkdir_p(Rails.public_path.join('media/1'))
+    File.write(Rails.public_path.join('media/1/test.svg'), '<svg xmlns="http://www.w3.org/2000/svg"/>')
+    File.write(Rails.public_path.join('media/1/test.png'), 'fake-png')
+  end
+
+  after do
+    FileUtils.rm_f(Rails.public_path.join('media/1/test.svg'))
+    FileUtils.rm_f(Rails.public_path.join('media/1/test.png'))
+  end
+
+  it 'adds X-Content-Type-Options nosniff to SVG responses under /media/' do
+    get svg_path
+    expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+  end
+
+  it 'adds Content-Security-Policy script-src none to SVG responses under /media/' do
+    get svg_path
+    expect(response.headers['Content-Security-Policy']).to eq("script-src 'none'")
+  end
+
+  it 'does not add security headers to non-SVG responses under /media/' do
+    get png_path
+    expect(response.headers['Content-Security-Policy']).to be_nil
+  end
+end

--- a/spec/support/fixtures/manual-testing-plan-svg-xss.md
+++ b/spec/support/fixtures/manual-testing-plan-svg-xss.md
@@ -1,0 +1,99 @@
+# Manual Testing Plan — SVG XSS Fix (PR #1199)
+
+## Prerequisites
+
+Start the dummy app:
+```bash
+(cd spec/dummy && bin/rails s)
+```
+
+Sign in as an admin user with media permissions.
+
+---
+
+### 1. Upload pipeline — dangerous SVGs (should ALL be rejected)
+
+Use the file fixtures in this directory:
+
+| Test case | Fixture | Expected |
+|---|---|---|
+| `<script>` tag | `unsafe-test-xss.svg` | Rejected |
+| `onbegin` animation | `unsafe-svg-onbegin.svg` | Rejected |
+| Entity-encoded `javascript:` | `svg-javascript-encoded.svg` | Rejected |
+| DTD entity | `svg-dtd-entity.svg` | Rejected |
+
+Or test via `curl` (requires session cookie from browser login):
+
+```bash
+curl -v -c /tmp/cookies -b /tmp/cookies \
+  -F "file_upload=@spec/support/fixtures/unsafe-test-xss.svg;type=image/svg+xml" \
+  http://localhost:3000/admin/media/upload
+```
+
+Additional inline test cases (create on the fly):
+
+| Test case | Key attribute | Expected |
+|---|---|---|
+| `onclick` handler | `<rect onclick="alert(1)"/>` | Rejected |
+| `onpointerdown` | `<rect onpointerdown="alert(1)"/>` | Rejected |
+| `javascript:` in href | `<a href="javascript:alert(1)">` | Rejected |
+| `foreignObject` + `iframe` | `<foreignObject><iframe src="...">` | Rejected |
+| `data:` URI | `<a href="data:text/html,...">` | Rejected |
+| `<animate>` with `onbegin` | `<animate onbegin="alert(1)">` | Rejected |
+| Binary garbage | Upload `.svg` with raw bytes | Rejected |
+
+---
+
+### 2. Upload pipeline — safe SVGs (should be accepted)
+
+| Test case | Expected |
+|---|---|
+| Clean SVG (`svg-safe.svg`) | Uploaded successfully |
+| SVG with `<desc>`, `<title>`, `<metadata>` | Uploaded successfully |
+| SVG with `<style>` block (no JS) | Uploaded successfully |
+
+---
+
+### 3. Security headers on served SVGs
+
+```bash
+# Upload a safe SVG first, then:
+curl -v http://localhost:3000/media/<site_id>/<filename>.svg
+```
+
+Expected headers:
+```
+X-Content-Type-Options: nosniff
+Content-Security-Policy: script-src 'none'
+```
+
+Non-SVG files are unaffected:
+```bash
+curl -v http://localhost:3000/media/<site_id>/<image>.png
+```
+Expected: no `Content-Security-Policy` header.
+
+---
+
+### 4. Non-SVG regression
+
+| Test case | Expected |
+|---|---|
+| Upload PNG/JPEG | Normal upload |
+| Upload `unsafe-html-onclick.html` | Rejected by regex (non-SVG safety net) |
+| Upload `unsafe-html-onclick.html` as `.jpg` via format param swap | Still rejected by regex on raw bytes |
+
+---
+
+### 5. XXE attempt
+
+Upload an SVG containing an external entity reference:
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE svg [
+  <!ENTITY xxe SYSTEM "file:///etc/hostname">
+]>
+<svg xmlns="http://www.w3.org/2000/svg">&xxe;</svg>
+```
+
+Expected: upload rejected (parse fails or `nonet` prevents access). No file read occurs on the server.

--- a/spec/support/fixtures/svg-dtd-entity.svg
+++ b/spec/support/fixtures/svg-dtd-entity.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg [
+  <!ENTITY x "<script>alert(1)</script>">
+]>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  &x;
+</svg>

--- a/spec/support/fixtures/svg-javascript-encoded.svg
+++ b/spec/support/fixtures/svg-javascript-encoded.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <a href="javascript&#58;alert(1)">click</a>
+</svg>

--- a/spec/support/fixtures/svg-safe.svg
+++ b/spec/support/fixtures/svg-safe.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="40" fill="red"/>
+</svg>

--- a/spec/support/fixtures/unsafe-html-onclick.html
+++ b/spec/support/fixtures/unsafe-html-onclick.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <button onclick="alert('XSS')">Click me</button>
+</body>
+</html>


### PR DESCRIPTION
## Description

Fix two security gaps allowing SVG stored XSS:

### 1. Regex bypass for SVG uploads (parse-based detection)
Replace the regex-based `file_content_unsafe?` for SVGs with `CamaleonCms::SvgContentChecker`, which parses SVG XML via Nokogiri and rejects uploads containing `<script>`, `on*` event handlers, `javascript:`/`data:` URIs, banned embed tags (`foreignObject`, `iframe`, `object`, `embed`, `animate`, `set`, `handler`), and DTD entity declarations with dangerous content. Used `config.nonet` to block XXE network access.

### 2. Missing security headers on SVG media responses
Add `CamaleonCms::MediaSecurityHeaders` Rack middleware (before `ActionDispatch::Static`) that adds `X-Content-Type-Options: nosniff` and `Content-Security-Policy: script-src 'none'` to SVG responses under `/media/`.

### 3. DRY extraction
Extracted shared content-security methods into `CamaleonCms::UploaderContentSecurity` module included by both `RuntimeUploaderConcern` and `UploaderHelper`, eliminating metric violations and code duplication. SVG routing consolidated inside `file_content_unsafe?` so call sites remain a single line.

Reported by Jose Rivas (Zero Trust Offsec). CVSS 8.3 (High).