### PR TITLE
Speed up the test suite with a shared per-run site install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Tests:** The suite now installs a single shared Camaleon site per run instead of a full site
+  before nearly every example, cutting a local full run from ~18 minutes to ~5. Test-only change:
+  specs get the shared site through `init_site` and the factories, and `init_site(fresh: true)`
+  keeps a per-example site for multi-site UI specs.
+  [#1220](https://github.com/owen2345/camaleon-cms/pull/1220).
+
 - **Fix:** Admin headings and tooltips showed raw HTML entities in place of the characters they
   encode, so a site named `Ben & Jerry's` read `Ben &amp; Jerry&#39;s`. Affected the site settings
   page, the post edit form, the sites form, the categories and tags indexes, and the custom fields

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -30,13 +30,25 @@ bundle exec rake app:db:test:prepare
 ## Test Helpers (`spec/support/common.rb`)
 
 ```ruby
-init_site              # creates @site and @post
+init_site              # exposes the suite-wide shared site as @site (+ @post)
+init_site(fresh: true) # replaces it with a per-example site — only for specs
+                       # that need the slug to match the Capybara server host
+                       # (e.g. multi-site UI flows)
 admin_sign_in          # authenticate admin user
 admin_sign_in(user, pass)
 wait(2)                # wait for JS execution
 cama_root_relative_path # site URL helper
 confirm_dialog         # accept JS dialogs
 ```
+
+### Shared site (`spec/support/shared_site.rb`)
+
+Installing a Camaleon site costs ~0.6s, so one canonical site is installed
+per suite run (committed, outside the per-example transactions) and reused
+everywhere: `init_site`, `Cama::Site.first`, and the `post`/`post_type`/`user`
+factories all resolve to it by default. Example-level mutations roll back with
+the transaction. Only create additional sites when the test is about
+multi-site behavior; explicit `create(:site)` still installs a real site.
 
 ## RSpec Conventions
 
@@ -74,7 +86,7 @@ end
 FactoryBot.define do
   factory :site, class: 'CamaleonCms::Site' do
     name { Faker::Name.unique.name }
-    slug { 'test-site' }
+    sequence(:slug) { |n| "test-site-#{n}" } # Capybara server host:port in feature specs
     description { Faker::Lorem.sentence }
 
     transient do
@@ -89,6 +101,10 @@ FactoryBot.define do
 end
 ```
 
+Factories that belong to a site (`post`, `post_type`, `user`) default to the
+suite-wide shared site (`CamaleonCms::Site.first`) instead of installing a new
+one; pass `site:` explicitly when the test needs a different site.
+
 ## Feature Spec Pattern (Admin UI Tests)
 
 ```ruby
@@ -99,7 +115,7 @@ require 'rails_helper'
 describe 'Posts workflows for Admin', :js do
   let(:post) { site.the_post('sample-post').decorate }
   let(:post_type_id) { site.post_types.where(slug: :post).pick(:id) }
-  let!(:site) { create(:site).decorate }
+  let!(:site) { CamaleonCms::Site.first.decorate }
 
   it 'Creates a new post' do
     admin_sign_in

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe CamaleonCms::SiteDecorator do
   let(:decorator) { site.decorate }
 
   before do
+    # a second site exists (the suite-wide shared one), so pin this spec's own
+    # site as current instead of relying on single-site fallback resolution
+    store_current_site(decorator)
     allow(site).to receive(:get_languages).and_return(%w[en es])
     allow(decorator.h).to receive(:asset_path).and_return('/assets/en.png')
     allow(decorator.h).to receive(:cama_url_to_fixed) do |_helper_name, options|

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -12,7 +12,9 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = true
 
-  config.log_level = :debug
+  # :debug logs every SQL statement to log/test.log, which measurably slows the
+  # suite and grows the file unboundedly.
+  config.log_level = :warn
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true

--- a/spec/factories/post.rb
+++ b/spec/factories/post.rb
@@ -9,7 +9,7 @@ FactoryBot.define do
       site { nil }
     end
 
-    post_type { association :post_type, site: site || create(:site) }
+    post_type { association :post_type, site: site || CamaleonCms::Site.first || create(:site) }
     owner { association :user, site: site }
 
     factory :pending_post do

--- a/spec/factories/post_type.rb
+++ b/spec/factories/post_type.rb
@@ -4,6 +4,6 @@ FactoryBot.define do
     sequence(:slug) { |n| "posttyp#{n}" }
     description { Faker::Lorem.sentence }
     data_options {}
-    site
+    site { CamaleonCms::Site.first || create(:site) }
   end
 end

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -4,15 +4,13 @@ include CamaleonCms::HooksHelper
 FactoryBot.define do
   factory :site, class: 'CamaleonCms::Site' do
     name { Faker::Name.unique.name }
-    slug do
+    # Feature specs need the slug to match the Capybara server host so multi-site
+    # resolution finds the site; elsewhere it only has to be unique, since a
+    # suite-wide shared site already exists (see spec/support/shared_site.rb).
+    sequence(:slug) do |n|
       current_session = Capybara.current_session
-      current_session.server ? "#{current_session.server.host}:#{current_session.server.port}" : 'key'
+      current_session.server ? "#{current_session.server.host}:#{current_session.server.port}" : "test-site-#{n}"
     end
-    # sequence(:slug) do |n|
-    #   next "site#{n}" unless Capybara.current_session.server
-    #
-    #   "#{Capybara.current_session.server.host}:#{Capybara.current_session.server.port}"
-    # end
     description { Faker::Lorem.sentence }
 
     transient do
@@ -21,8 +19,14 @@ FactoryBot.define do
     end
 
     after(:create) do |site, evaluator|
+      # site_after_install resolves current_site, which needs a request once a
+      # second site exists; pin the new site as current for the install instead.
+      previous_site = CurrentRequest.site
+      CurrentRequest.site = site.decorate
       site_after_install(site, evaluator.theme)
       site.set_option('save_intro', true) if evaluator.skip_intro
+    ensure
+      CurrentRequest.site = previous_site
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     username { Faker::Internet.unique.user_name }
     password { '12345678' }
     password_confirmation { '12345678' }
-    site
+    site { CamaleonCms::Site.first || create(:site) }
 
     factory :user_admin do
       role { 'admin' }

--- a/spec/features/admin/posts_spec.rb
+++ b/spec/features/admin/posts_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 describe 'Posts workflows for Admin', :js do
   let(:post) { site.the_post('sample-post').decorate }
   let(:post_type_id) { site.post_types.where(slug: :post).pick(:id) }
-  let!(:site) { create(:site).decorate }
+  let!(:site) { CamaleonCms::Site.first.decorate }
 
   it 'Creates a new post' do
     admin_sign_in

--- a/spec/features/admin/sites_spec.rb
+++ b/spec/features/admin/sites_spec.rb
@@ -18,7 +18,10 @@ def create_site
 end
 
 describe 'the Sites', :js do
-  init_site
+  # This spec creates a second site via the UI; once two sites exist, resolution
+  # matches the request host against site slugs, so the base site's slug must be
+  # the Capybara server host — the shared site's slug is not.
+  init_site(fresh: true)
 
   it 'Sites list' do
     admin_sign_in

--- a/spec/features/frontend/post_type_spec.rb
+++ b/spec/features/frontend/post_type_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Posttype frontend', :js do
   before do
-    @site = create(:site).decorate
+    @site = CamaleonCms::Site.first.decorate
     @post = @site.the_post('sample-post').decorate
     @post_type = @post.post_type.decorate
   end

--- a/spec/find_by_slug_usage_spec.rb
+++ b/spec/find_by_slug_usage_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'find_by_slug usage (organic behavioural coverage)' do # rubocop:
   let(:localized_slug) { '<!--:en-->multilang-post<!--:--><!--:es-->multilang-post<!--:-->' }
   let(:plain_key) { 'multilang-post' }
 
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:decorator) { site.decorate }
 
   # ------------------------------------------------------------------

--- a/spec/helpers/repro_xss_in_content_spec.rb
+++ b/spec/helpers/repro_xss_in_content_spec.rb
@@ -5,11 +5,15 @@ require 'rails_helper'
 describe CamaleonCms::Frontend::ContentSelectHelper do
   let(:site) { create(:site) }
   let(:post_type) { create(:post_type, slug: 'post', site: site) }
-
   let(:xss_payload) { '<script>alert("xss")</script>' }
-
   let!(:post) do
     create(:post, post_type: post_type, title: 'Malicious Post', content: xss_payload, status: 'published').decorate
+  end
+
+  before do
+    # a second site exists (the suite-wide shared one), so pin this spec's own
+    # site as current instead of relying on single-site fallback resolution
+    store_current_site(site.decorate)
   end
 
   describe '#the_content' do

--- a/spec/mailers/send_mail_spec.rb
+++ b/spec/mailers/send_mail_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'CamaleonCms::HtmlMailer' do
   before do
-    @site = create(:site).decorate
+    @site = CamaleonCms::Site.first.decorate
   end
 
   describe 'empty content' do

--- a/spec/models/user_role_spec.rb
+++ b/spec/models/user_role_spec.rb
@@ -12,7 +12,10 @@ RSpec.describe CamaleonCms::UserRole, type: :model do
     end
 
     it 'can read default roles created for a site' do
-      site = create(:site).decorate
+      # default roles are created when a site is installed as the main site;
+      # with users_share_sites a secondary site reuses them, so assert on the
+      # suite-wide shared (main) site.
+      site = CamaleonCms::Site.first.decorate
 
       expect(described_class.where(parent_id: site.id)).not_to be_empty
     end

--- a/spec/requests/admin/categories_controller/idor_spec.rb
+++ b/spec/requests/admin/categories_controller/idor_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe CamaleonCms::Admin::CategoriesController, '#set_category', type: :request do
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:post_type_a) { create(:post_type, site: site) }
   let(:post_type_b) { create(:post_type, site: site) }
   let!(:category_b) { CamaleonCms::Category.create!(name: 'Category B', site_id: site.id, parent_id: post_type_b.id, taxonomy: :category, status: post_type_b.id) }

--- a/spec/requests/admin/mass_assignment_spec.rb
+++ b/spec/requests/admin/mass_assignment_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Admin Mass Assignment Protection', type: :request do
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:admin) { create(:user, site: site, role: 'admin') }
   let(:post_type) { create(:post_type, site: site) }
 

--- a/spec/requests/security/contact_form_output_escaping_spec.rb
+++ b/spec/requests/security/contact_form_output_escaping_spec.rb
@@ -9,7 +9,7 @@ require 'rails_helper'
 # `raw`. Two trust levels reach those sinks, and the admin panel is same-origin with the frontend, so
 # script landing here runs with an administrator's session.
 RSpec.describe 'Security: contact form output escaping', type: :request do
-  let!(:site) { create(:site).decorate }
+  let!(:site) { CamaleonCms::Site.first.decorate }
 
   # `required` is stored as the string "true" by the form editor (hidden_field_tag + check_box_tag),
   # not as a JSON boolean — the plugin calls `.to_bool`, which Camaleon defines only on String.

--- a/spec/requests/security/nav_menus_mass_assignment_spec.rb
+++ b/spec/requests/security/nav_menus_mass_assignment_spec.rb
@@ -3,12 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'Security: Nav Menus Mass Assignment', type: :request do
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:admin) { create(:user_admin, site: nil) }
 
   before do
-    CamaleonCms::Site.delete_all
-    site
     post cama_admin_login_path, params: { user: { username: admin.username, password: '12345678' } }
   end
 

--- a/spec/requests/security/open_redirect_session_spec.rb
+++ b/spec/requests/security/open_redirect_session_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Security: Open Redirect in SessionHelper', type: :request do
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:user) { create(:user, site: site, password: 'password', password_confirmation: 'password') }
 
   it 'does not redirect to external URLs via return_to cookie' do

--- a/spec/requests/security/xss_flash_params_spec.rb
+++ b/spec/requests/security/xss_flash_params_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe 'Security: XSS via params[:info] in flash messages', type: :request do
-  let(:site) { create(:site) }
+  let(:site) { CamaleonCms::Site.first }
   let(:admin_role) { site.user_roles.create!(name: 'Admin', slug: 'admin') }
   let(:admin_user) { create(:user, role: admin_role.slug, site: site) }
   let(:decorated_site) { site.decorate }

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -1,18 +1,24 @@
 # include ApplicationHelper
 
-# do login for admin panel and also verify if the site was created
-# if site is not created, then create a new site
-def init_site
+# expose the suite-wide shared site (see spec/support/shared_site.rb) as @site.
+# fresh: true replaces it with a site created inside the example's transaction —
+# needed by feature specs whose site slug must match the Capybara server host
+# (multi-site resolution matches request host against slugs once a second site
+# exists).
+def init_site(fresh: false)
   before do
-    CamaleonCms::Site.delete_all
-    @site = create(:site).decorate
+    if fresh
+      CamaleonCms::Site.delete_all
+      @site = create(:site).decorate
+    else
+      @site = (CamaleonCms::Site.first || create(:site)).decorate
+    end
     @post = @site.the_post('sample-post').decorate
   end
 
   after do
     @site = nil
     @post = nil
-    Cama::Site.instance_variable_set(:@main_site, nil)
   end
 end
 
@@ -26,7 +32,6 @@ def admin_sign_in(user = 'admin', pass = 'admin123')
   end
   click_button 'Log In'
   expect(page).to have_text 'Welcome'
-  wait(2)
 end
 
 def cama_root_relative_path

--- a/spec/support/shared_site.rb
+++ b/spec/support/shared_site.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Installing a Camaleon site (default plugins, theme, sample content, admin
+# user) costs ~0.6s and used to happen before nearly every example. Install one
+# canonical site per suite run instead, committed outside the per-example
+# transactions so every example can reuse it; example-level mutations still
+# roll back with their transaction.
+RSpec.configure do |config|
+  config.before(:suite) do
+    connection = ActiveRecord::Base.connection
+    (connection.tables - %w[schema_migrations ar_internal_metadata]).each do |table|
+      connection.execute("DELETE FROM #{connection.quote_table_name(table)}")
+    end
+    # Drop caches memoized during boot (they may hold sites the purge just
+    # deleted); set_default_user_roles resolves Site.main_site while installing.
+    CamaleonCms::Site.instance_variable_set(:@main_site, nil)
+    PluginRoutes.instance_variable_set(:@all_sites, nil)
+    PluginRoutes.instance_variable_get(:@cache)&.clear
+    FactoryBot.create(:site)
+  end
+
+  config.before do
+    # The shared site outlives examples, but these class-level caches must not:
+    # an example that adds a site or toggles a plugin would poison later ones.
+    CamaleonCms::Site.instance_variable_set(:@main_site, nil)
+    PluginRoutes.instance_variable_set(:@all_sites, nil)
+    PluginRoutes.instance_variable_get(:@cache)&.clear
+  end
+end


### PR DESCRIPTION
## What and Why

The suite spent most of its time repeatedly installing Camaleon sites. `init_site` wiped and reinstalled a full site — default plugins, theme, sample content, admin user, plus two full route reloads — before nearly every example, and the `post`/`post_type`/`user` factories each installed yet another site when not handed one, at ~0.6s per install. On top of that, every feature-spec sign-in carried a hard 2-second sleep, and the test environment logged every SQL statement to disk.

This PR installs **one canonical site per suite run**, committed in `before(:suite)` outside the per-example transactions, and points `init_site`, the factories, and the specs that hand-rolled their own site at it. Example-level mutations still roll back with the transaction. Class-level site caches (the `PluginRoutes` sites cache and `Site.main_site`) are reset between examples — and before the suite-level install itself, since boot memoizes sites the purge deletes — so nothing leaks across examples or runs. Multi-site UI specs keep a per-example site via the new `init_site(fresh: true)` escape hatch, because once a second site exists resolution matches the request host against site slugs, and only a per-example site can carry the Capybara server's host:port slug.

The sign-in sleep is gone (the existing `have_text 'Welcome'` expectation already waits), test logging drops to `:warn`, and the site factory slug is now a unique sequence so explicitly-created extra sites cannot collide.

Full suite locally: **~18 minutes → ~5 minutes** (3.7×).

`docs/ai/testing.md` documents the shared-site model, the `fresh:` option, and the factory fallbacks.

## User-Visible Impact

None — test-and-docs-only changes; no runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
