### PR TITLE
Sign in feature specs via the auth cookie instead of the login form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Tests:** Feature specs now sign in by setting the auth cookie instead of driving the login
+  form, and the sign-in actually verifies credentials — the old flow's "Welcome" assertion was
+  satisfied by the login page itself, so failed logins passed silently. The form-driven flow lives
+  on in `admin_form_sign_in`, covered by dedicated sign-in examples.
+  [#1221](https://github.com/owen2345/camaleon-cms/pull/1221).
+
 - **Tests:** The suite now installs a single shared Camaleon site per run instead of a full site
   before nearly every example, cutting a local full run from ~18 minutes to ~5. Test-only change:
   specs get the shared site through `init_site` and the factories, and `init_site(fresh: true)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,7 +205,7 @@
 
 - **Security fix:** Fix profile IDOR in \`Admin::UsersController#profile\` — add inline \`authorize!\` check when viewing another user, so low-privilege users can no longer enumerate arbitrary user accounts. [#1197](https://github.com/owen2345/camaleon-cms/pull/1197) — thanks, Neo Andrew, for reporting this.
 
-- **Security fix:** Fix improper authorization in draft autosave endpoint — scope draft lookups to post type, add \`authorize!\` checks before draft mutations, and validate \`post_parent\` against a real post, [#1196](https://github.com/owen2345/camaleon-cms/pull/1196) — thanks, Óscar Uribe, for reporting this.
+- **Security fix:** Fix improper authorization in draft autosave endpoint — scope draft lookups to post type, add \`authorize!\` checks before draft mutations, and validate \`post_parent\` against a real post, [#1196](https://github.com/owen2345/camaleon-cms/pull/1196) — thanks, Enrik Mustafa and Óscar Uribe, for reporting this.
 
 - **Security fix:** Prevent SVG XSS bypass via missing animation event handlers (\`onbegin\`/\`onend\`/\`onrepeat\`) in file upload content filter. DRY duplicated \`UNSAFE_EVENT_PATTERNS\` into shared \`CamaleonCms::ContentSecurity\` module, [#1195](https://github.com/owen2345/camaleon-cms/pull/1195) — thanks, Mohamed Almuhaya, for reporting this.
 

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -34,8 +34,10 @@ init_site              # exposes the suite-wide shared site as @site (+ @post)
 init_site(fresh: true) # replaces it with a per-example site — only for specs
                        # that need the slug to match the Capybara server host
                        # (e.g. multi-site UI flows)
-admin_sign_in          # authenticate admin user
-admin_sign_in(user, pass)
+admin_sign_in          # authenticate by setting the auth cookie (fast; verifies
+admin_sign_in(user, pass)  # the password and raises on mismatch)
+admin_form_sign_in     # authenticate through the real login form — use only in
+                       # specs that test the sign-in flow itself
 wait(2)                # wait for JS execution
 cama_root_relative_path # site URL helper
 confirm_dialog         # accept JS dialogs

--- a/spec/features/admin/session_spec.rb
+++ b/spec/features/admin/session_spec.rb
@@ -4,6 +4,10 @@ require 'rails_helper'
 
 describe 'the signin process', :js do
   init_site
+  it 'signs me in with valid credentials' do # rubocop:disable RSpec/NoExpectationExample
+    admin_form_sign_in
+  end
+
   it 'signs me in not valid' do
     visit "#{cama_root_relative_path}/admin/login"
     within('#login_user') do

--- a/spec/features/admin/users_spec.rb
+++ b/spec/features/admin/users_spec.rb
@@ -32,7 +32,10 @@ describe 'the Users', :js do
   end
 
   it 'Users login new user' do # rubocop:disable RSpec/NoExpectationExample
-    admin_sign_in(uname, 'tester123')
+    # the user created via the UI in the example above rolled back with its
+    # transaction, so create the credentials this example actually verifies
+    create(:user_admin, username: uname, email: uemail, password: 'tester123', password_confirmation: 'tester123')
+    admin_form_sign_in(uname, 'tester123')
   end
 
   it 'Users Edit' do

--- a/spec/support/common.rb
+++ b/spec/support/common.rb
@@ -22,16 +22,30 @@ def init_site(fresh: false)
   end
 end
 
-# sign in for admin panel
-# skip: true => close the skip button for intro
-def admin_sign_in(user = 'admin', pass = 'admin123')
+# sign in for admin panel by setting the auth cookie directly (the browser
+# must be on the app's origin to accept it, hence the static bootstrap visit).
+# The form-driven flow is covered by admin_form_sign_in in the dedicated
+# sign-in specs; the password is still verified here so a wrong one fails
+# loudly instead of silently producing a signed-out session.
+def admin_sign_in(username = 'admin', pass = 'admin123')
+  user = CamaManager.get_user_class_name.constantize.find_by!(username: username)
+  raise ArgumentError, "wrong password for #{username}" unless user.authenticate(pass)
+
+  visit '/favicon.ico' unless page.current_url.start_with?('http')
+  page.driver.browser.manage.add_cookie(name: 'auth_token', value: "#{user.auth_token}&rspec&127.0.0.1")
+end
+
+# sign in for admin panel through the real login form; use only for specs that
+# test the sign-in flow itself (the login page also says "Welcome", so assert
+# the dashboard path rather than page text).
+def admin_form_sign_in(user = 'admin', pass = 'admin123')
   visit "#{cama_root_relative_path}/admin/logout"
   within('#login_user') do
     fill_in 'user[username]', with: user
     fill_in 'user[password]', with: pass
   end
   click_button 'Log In'
-  expect(page).to have_text 'Welcome'
+  expect(page).to have_current_path(%r{/admin/dashboard}, ignore_query: true)
 end
 
 def cama_root_relative_path


### PR DESCRIPTION
## What and Why

Every feature example signed in by driving the real login form: visit logout, fill the form, POST, render the dashboard. `admin_sign_in` now authenticates by setting the `auth_token` cookie directly (the same shape request specs already use via `sign_in_as`), after a static-page visit to put the browser on the app's origin.

This is as much a correctness fix as a speed one. The old flow asserted `have_text 'Welcome'` — but the login page itself renders "**Welcome**, Please login", so a *failed* sign-in satisfied the assertion and the example continued silently signed out. The cookie helper verifies the password with `user.authenticate` and raises loudly on mismatch or unknown username.

The form-driven flow is preserved where it is the thing under test, as `admin_form_sign_in`, which asserts the dashboard path (a check the login page cannot satisfy):

- a new dedicated example in `session_spec`, next to the existing invalid-password example;
- the `users_spec` "login new user" example, which previously depended on a user whose creating transaction had already rolled back — it passed only because of the vacuous Welcome assertion. It now creates the credentials it verifies.

Feature tier locally: **~2m16s → ~2m01s** (~11%); the absolute saving should be larger on slower CI runners, where the three-request form round-trip costs more than a static hit.

## User-Visible Impact

None — test-and-docs-only changes; no runtime code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
