### PR TITLE
Fix inert slug-uniqueness validation on Rails 7.0+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Fix:** Slug-uniqueness validation was silently inert on Rails 7.0+. `UniqValidator` and
+  `PostUniqValidator` registered errors by pushing onto `errors[:base]`, which modern Rails
+  discards, so duplicate slugs (same taxonomy and parent) and recursive page hierarchies saved
+  without complaint; on Rails 6.1 the old pattern still worked. Errors are registered with
+  `errors.add` again. [#1222](https://github.com/owen2345/camaleon-cms/pull/1222).
+
+  **Notes for upgraders**
+
+  - On Rails 7.0+, saves that duplicate an existing slug under the same parent and taxonomy, or
+    that create a looping page hierarchy, fail validation again — matching what Rails ≤ 6.1
+    installs always enforced.
+  - Records duplicated while the validator was inert are not rewritten; they surface the
+    "requires different slug" error the next time they are edited.
+
 - **Tests:** Feature specs now sign in by setting the auth cookie instead of driving the login
   form, and the sign-in actually verifies credentials — the old flow's "Welcome" assertion was
   satisfied by the login page itself, so failed logins passed silently. The form-driven flow lives

--- a/app/validators/camaleon_cms/post_uniq_validator.rb
+++ b/app/validators/camaleon_cms/post_uniq_validator.rb
@@ -27,7 +27,7 @@ module CamaleonCms
                    .where.not(id: record.id)
                    .where.not(status: %i[draft draft_child trash])
       unless posts.empty?
-        record.errors[:base] <<
+        message =
           if slug_array.size > 1
             "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{posts.pluck(:slug).map do |slug|
               record.slug.to_s.translations.map do |lng, r_slug|
@@ -37,14 +37,15 @@ module CamaleonCms
           else
             "#{I18n.t('camaleon_cms.admin.post.message.requires_different_slug')}: #{record.slug} "
           end
+        record.errors.add(:base, message)
       end
 
       # avoid recursive page parent
       return unless record.post_parent.present? && ptype.manage_hierarchy? &&
                     record.parents.cama_pluck(:id).include?(record.id)
 
-      record.errors[:base] << I18n.t('camaleon_cms.admin.post.message.recursive_hierarchy',
-                                     default: 'Parent Post Recursive')
+      record.errors.add(:base, I18n.t('camaleon_cms.admin.post.message.recursive_hierarchy',
+                                      default: 'Parent Post Recursive'))
     end
   end
 end

--- a/app/validators/camaleon_cms/uniq_validator.rb
+++ b/app/validators/camaleon_cms/uniq_validator.rb
@@ -11,7 +11,7 @@ module CamaleonCms
 
       return unless slug_exists
 
-      record.errors[:base] << I18n.t('camaleon_cms.admin.post.message.requires_different_slug').to_s
+      record.errors.add(:base, I18n.t('camaleon_cms.admin.post.message.requires_different_slug').to_s)
     end
   end
 end

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -52,6 +52,12 @@ factories all resolve to it by default. Example-level mutations roll back with
 the transaction. Only create additional sites when the test is about
 multi-site behavior; explicit `create(:site)` still installs a real site.
 
+Site installation already claims the default slugs — user roles `admin` /
+`editor` / `contributor` / `client`, post types `post` / `page` — and slugs are
+unique per parent and taxonomy, so reuse those records (e.g.
+`site.user_roles.find_by!(slug: 'admin')`) instead of creating same-slug
+duplicates.
+
 ## RSpec Conventions
 
 ```ruby

--- a/spec/helpers/repro_xss_in_content_spec.rb
+++ b/spec/helpers/repro_xss_in_content_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 
 describe CamaleonCms::Frontend::ContentSelectHelper do
   let(:site) { create(:site) }
-  let(:post_type) { create(:post_type, slug: 'post', site: site) }
+  # the site install already creates a 'post' post type; a second one with the
+  # same slug under the same site is (correctly) rejected as a duplicate
+  let(:post_type) { site.post_types.find_by!(slug: 'post') }
   let(:xss_payload) { '<script>alert("xss")</script>' }
   let!(:post) do
     create(:post, post_type: post_type, title: 'Malicious Post', content: xss_payload, status: 'published').decorate

--- a/spec/lib/tasks/custom_fields_roles_rake_spec.rb
+++ b/spec/lib/tasks/custom_fields_roles_rake_spec.rb
@@ -80,8 +80,9 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
     before { task.reenable }
 
     it 'adds select_eval permission for admin roles with term_group -1' do
-      site = create(:site)
-      role = site.user_roles.create!(name: 'Admin Role', slug: 'admin', term_group: -1)
+      # slugs are unique per parent, so the scenarios below reuse the shared
+      # site's default admin role instead of creating a second admin-slugged one
+      role = CamaleonCms::UserRole.find_by!(slug: 'admin', term_group: -1)
       key = "_manager_#{role.parent_id}"
       role.set_meta(key, { themes: 1 })
 
@@ -93,8 +94,7 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
     end
 
     it 'skips admin roles that already have select_eval permission' do
-      site = create(:site)
-      role = site.user_roles.create!(name: 'Configured Admin', slug: 'admin', term_group: -1)
+      role = CamaleonCms::UserRole.find_by!(slug: 'admin', term_group: -1)
       key = "_manager_#{role.parent_id}"
       role.set_meta(key, { select_eval: 1, users: 1 })
 
@@ -107,11 +107,14 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
     end
 
     it 'does not update roles outside the admin term_group -1 scope' do
-      site = create(:site)
-      admin_editable = site.user_roles.create!(name: 'Editable Admin', slug: 'admin', term_group: nil)
-      editor_role = site.user_roles.create!(name: 'Editor', slug: 'editor', term_group: -1)
+      admin_editable = CamaleonCms::UserRole.find_by!(slug: 'admin').tap { |r| r.update!(term_group: nil) }
+      editor_role = CamaleonCms::UserRole.find_by!(slug: 'editor')
       admin_key = "_manager_#{admin_editable.parent_id}"
       editor_key = "_manager_#{editor_role.parent_id}"
+      # the default roles carry installed metas; the scenario needs roles
+      # without select_eval to prove the task leaves them alone
+      admin_editable.set_meta(admin_key, {})
+      editor_role.set_meta(editor_key, {})
 
       task.invoke
 
@@ -120,9 +123,11 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
     end
 
     it 'continues processing remaining admin roles when one update fails' do
+      # the admin scope is stubbed below, so the fixtures only need to be two
+      # distinct roles — duplicate admin slugs under one parent are now invalid
       site = create(:site)
-      broken_role = site.user_roles.create!(name: 'Broken Admin', slug: 'admin', term_group: -1)
-      healthy_role = site.user_roles.create!(name: 'Healthy Admin', slug: 'admin', term_group: -1)
+      broken_role = site.user_roles.create!(name: 'Broken Admin', slug: 'broken-admin', term_group: -1)
+      healthy_role = site.user_roles.create!(name: 'Healthy Admin', slug: 'healthy-admin', term_group: -1)
       broken_key = "_manager_#{broken_role.parent_id}"
       healthy_key = "_manager_#{healthy_role.parent_id}"
 

--- a/spec/requests/admin/settings/settings_controller_spec.rb
+++ b/spec/requests/admin/settings/settings_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CamaleonCms::Admin::SettingsController, type: :request do
   end
 
   describe '#test_email' do
-    let(:admin_role) { current_site.user_roles.create!(name: 'Admin', slug: 'admin') }
+    let(:admin_role) { current_site.user_roles.find_by!(slug: 'admin') }
     let(:admin_user) { create(:user, role: admin_role.slug, site: current_site) }
 
     before do

--- a/spec/requests/admin/user_roles_manager_permissions_spec.rb
+++ b/spec/requests/admin/user_roles_manager_permissions_spec.rb
@@ -116,7 +116,9 @@ RSpec.describe 'Admin::UserRolesController permission rendering', type: :request
   # submitted, so locking the view alone would have made the next save clear the stored meta.
   describe 'an editable role slugged admin' do
     let(:editable_admin) do
-      @site.user_roles.create!(name: 'Editable Admin', slug: 'admin', term_group: nil)
+      # slugs are unique per parent, so make the default admin role editable
+      # rather than creating a second admin-slugged role
+      @site.user_roles.find_by!(slug: 'admin').tap { |role| role.update!(name: 'Editable Admin', term_group: nil) }
     end
 
     before { editable_admin.set_meta("_manager_#{@site.id}", { themes: 1 }) }
@@ -149,7 +151,7 @@ RSpec.describe 'Admin::UserRolesController permission rendering', type: :request
   end
 
   describe 'a non-admin role' do
-    let(:editor) { @site.user_roles.create!(name: 'Editor', slug: 'editor') }
+    let(:editor) { @site.user_roles.find_by!(slug: 'editor') }
 
     it 'still renders from its own stored meta' do
       editor.set_meta("_manager_#{@site.id}", { themes: 1 })

--- a/spec/requests/security/post_status_output_escaping_spec.rb
+++ b/spec/requests/security/post_status_output_escaping_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe 'Security: post status output escaping', type: :request do
   # The source. A role holding only `edit` on the post type gets `:create_post` but not
   # `:publish_post`, which is the lowest privilege that can create content at all.
   describe 'reaching the column at contributor privilege' do
-    let(:contributor_role) { current_site.user_roles.create!(name: 'Contributor', slug: 'contributor') }
+    let(:contributor_role) { current_site.user_roles.find_by!(slug: 'contributor') }
     let(:contributor) { create(:user, role: contributor_role.slug, site: current_site) }
 
     before do

--- a/spec/requests/security/xss_flash_params_spec.rb
+++ b/spec/requests/security/xss_flash_params_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Security: XSS via params[:info] in flash messages', type: :request do
   let(:site) { CamaleonCms::Site.first }
-  let(:admin_role) { site.user_roles.create!(name: 'Admin', slug: 'admin') }
+  let(:admin_role) { site.user_roles.find_by!(slug: 'admin') }
   let(:admin_user) { create(:user, role: admin_role.slug, site: site) }
   let(:decorated_site) { site.decorate }
 

--- a/spec/validators/post_uniq_validator_spec.rb
+++ b/spec/validators/post_uniq_validator_spec.rb
@@ -28,6 +28,27 @@ RSpec.describe CamaleonCms::PostUniqValidator, type: :model do
       end
     end
 
+    context 'when the slug duplicates a published post of the same post type' do
+      it 'registers a base error' do
+        create(:post, post_type: post_type, slug: 'taken-slug', status: 'published')
+        duplicate = build(:post, post_type: post_type, slug: 'taken-slug')
+
+        expect(validate_post(duplicate))
+          .to contain_exactly(a_string_matching(I18n.t('camaleon_cms.admin.post.message.requires_different_slug')))
+      end
+    end
+
+    context 'when the parent chain loops back to the post' do
+      it 'registers a recursive-hierarchy error' do
+        post_type.set_option(:has_parent_structure, true)
+        page = create(:post, post_type: post_type, slug: 'loop-page')
+        page.post_parent = page.id
+
+        expect(validate_post(page))
+          .to include(I18n.t('camaleon_cms.admin.post.message.recursive_hierarchy', default: 'Parent Post Recursive'))
+      end
+    end
+
     context 'with SQL injection attempts in slug' do
       it 'does not execute injected SQL - boolean based' do
         create(:post, post_type: post_type, slug: 'legit-slug', status: 'published')

--- a/spec/validators/uniq_validator_spec.rb
+++ b/spec/validators/uniq_validator_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::UniqValidator, type: :model do
+  init_site
+
+  let(:existing_role) { CamaleonCms::UserRole.find_by!(slug: 'admin', parent_id: @site.id) }
+
+  it 'rejects a record whose slug duplicates another under the same parent and taxonomy' do
+    duplicate = CamaleonCms::UserRole.new(name: 'Duplicate Admin', slug: 'admin',
+                                          taxonomy: 'user_roles', parent_id: existing_role.parent_id)
+
+    expect(duplicate).not_to be_valid
+    expect(duplicate.errors[:base])
+      .to include(I18n.t('camaleon_cms.admin.post.message.requires_different_slug').to_s)
+  end
+
+  it 'accepts the same slug under a different parent' do
+    other_parent = create(:post_type)
+    same_slug_elsewhere = CamaleonCms::UserRole.new(name: 'Other Admin', slug: 'admin',
+                                                    taxonomy: 'user_roles', parent_id: other_parent.id)
+
+    expect(same_slug_elsewhere).to be_valid
+  end
+
+  it 'accepts re-validating the record that owns the slug' do
+    expect(existing_role).to be_valid
+  end
+end


### PR DESCRIPTION
## What and Why

`CamaleonCms::UniqValidator` and `CamaleonCms::PostUniqValidator` registered failures by pushing onto `record.errors[:base]`. Rails 7.0 removed the deprecation shim that used to forward that push, so `errors[:base]` returns a detached copy and the push registers nothing: both validators have been silently inert on Rails 7.0+. Duplicate slugs (same taxonomy and parent) saved cleanly — empirically, a second `admin`-slugged role under the same site passed `valid?` with zero errors — and the recursive page-parent guard never fired. On Rails 6.1, which the gem still supports (`rails >= 6.1`), the old pattern still worked but emitted a deprecation warning; `errors.add(:base, ...)` is exactly the API that warning pointed to, and it behaves identically across 6.1–8.x, so this change is a no-op there and a re-arming everywhere else.

The fix registers errors with `record.errors.add(:base, message)` in the three places the pattern appeared (a repo-wide audit found no others). Reproduction specs came first and fail against the old code: duplicate slug under the same parent and taxonomy, same slug under a different parent (allowed), a record re-validating its own slug (allowed), a duplicate published post slug, and a page whose parent chain loops back to itself.

Several existing specs depended on the validator being inert — they created roles or post types whose slugs duplicate the ones site installation already creates (`admin`, `editor`, `contributor`, `post`). They now reuse or transform the installed defaults, which also keeps their fixtures honest about what a real site contains.

## User-Visible Impact

Saving a term-taxonomy record (site, post type, category, tag, user role) or a post whose slug duplicates an existing one under the same parent fails validation again with "Requires different slug", as does saving a page whose parent chain loops — restoring the behavior Rails ≤ 6.1 installs always had. Records duplicated while the validator was inert are not rewritten; they surface the validation error the next time they are edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
