### PR TITLE
Fix six high-severity post-2.9.2 regressions (audit hardening batch 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ node_modules
 # Local Bundler overrides (e.g. a path/branch override for cama_contact_form while it is
 # developed alongside this repo). Machine-specific: committing it breaks CI, which has no such path.
 /.bundle/
+
+# Security audit reports. These describe unpatched vulnerabilities in detail; publishing one to a
+# public repo hands attackers a roadmap before the fixes ship.
+SECURITY-AUDIT*
+
+# Regression audit reports. Working documents that track unfixed breakage between releases;
+# they go stale as fixes land and are not repo content.
+REGRESSION-AUDIT*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- **Fix:** Six high-severity regressions introduced after 2.9.2, found by a full-range audit and
+  each pinned by a spec that reproduced it: engine boot failed on production hosts that serve
+  static files from nginx/Apache instead of Rails; one installed plugin or theme without a
+  `helpers` key in its config crashed every request; `GET /search` 500ed because `ct` was
+  unreachable on controllers, which also broke plugins calling `current_plugin`; frontend search
+  matched nothing for mixed-case queries on PostgreSQL and ignored an empty result set from the
+  `on_render_search` hook; `/sitemap.html` crashed for any site with a category and ignored the
+  `on_render_sitemap` skip lists; and login, password reset, and `site.the_user` became
+  case-sensitive. All six restore the 2.9.2 behavior.
+  [#1223](https://github.com/owen2345/camaleon-cms/pull/1223).
+
 - **Fix:** Slug-uniqueness validation was silently inert on Rails 7.0+. `UniqValidator` and
   `PostUniqValidator` registered errors by pushing onto `errors[:base]`, which modern Rails
   discards, so duplicate slugs (same taxonomy and parent) and recursive page hierarchies saved

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -20,7 +20,9 @@ module CamaleonCms
 
       def login_post
         data_user = user_permit_data
-        @user = current_site.users.find_by(username: data_user[:username])
+        # Custom class finder (not the dynamic finder): usernames are stored downcased,
+        # so the lookup must lower-case both sides regardless of DB collation.
+        @user = current_site.users.find_by_username(data_user[:username]) # rubocop:disable Rails/DynamicFindBy
         captcha_validate = captcha_verify_if_under_attack('login')
         r = { user: @user, params: params, password: data_user[:password], captcha_validate: captcha_validate,
               stop_process: false }
@@ -96,7 +98,9 @@ module CamaleonCms
         return if params[:user].blank?
 
         data_user = user_permit_data
-        @user = current_site.users.find_by(email: data_user[:email])
+        # Custom class finder: emails are stored downcased, so the lookup must
+        # lower-case both sides regardless of DB collation.
+        @user = current_site.users.find_by_email(data_user[:email]) # rubocop:disable Rails/DynamicFindBy
         if @user.present?
           send_password_reset_email(@user)
           flash[:notice] = t('camaleon_cms.admin.login.message.send_mail_succes')

--- a/app/controllers/camaleon_cms/camaleon_controller.rb
+++ b/app/controllers/camaleon_cms/camaleon_controller.rb
@@ -5,6 +5,9 @@ module CamaleonCms
     add_flash_types :notice
     add_flash_types :info
 
+    # Controller-context helper surface (ct, cama_t, cama_cache_fetch, ...): plugin hook
+    # functions run on the controller and actions like FrontendController#search call these.
+    include CamaleonCms::CamaleonHelper
     include CamaleonCms::SessionRuntimeConcern
     include CamaleonCms::RequestContextConcern
     include CamaleonCms::HookLifecycleConcern

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -124,9 +124,9 @@ module CamaleonCms
       layout_ = lookup_context.template_exists?('layouts/search') ? 'search' : nil
       r = { layout: layout_, render: 'search', posts: nil }
       hooks_run('on_render_search', r)
-      q_params = params[:q]
-      params[:q] = (q_params || '').downcase
-      @posts = r[:posts].presence ||
+      q_params = params[:q].to_s.downcase
+      params[:q] = q_params
+      @posts = r[:posts] ||
                items.where('LOWER(title) LIKE ? OR LOWER(content_filtered) LIKE ?', "%#{q_params}%", "%#{q_params}%")
       @posts_size = @posts.size
       @posts = @posts.paginate(page: params[:page], per_page: current_site.front_per_page)

--- a/app/decorators/camaleon_cms/site_decorator.rb
+++ b/app/decorators/camaleon_cms/site_decorator.rb
@@ -146,7 +146,7 @@ module CamaleonCms
       return unless id_or_username.is_a?(String)
 
       begin
-        object.users.find_by(username: id_or_username).decorate
+        object.users.find_by_username(id_or_username).decorate # rubocop:disable Rails/DynamicFindBy
       rescue StandardError
         nil
       end

--- a/app/helpers/camaleon_cms/camaleon_helper.rb
+++ b/app/helpers/camaleon_cms/camaleon_helper.rb
@@ -40,7 +40,8 @@ module CamaleonCms
     # generate loop categories html sitemap links
     # this is a helper for sitemap generator to print categories, sub categories and post contents in html list format
     def cama_sitemap_cats_generator(cats, skip_config = {})
-      skip_config = { skip_cat_ids: [], skip_post_ids: [] } unless skip_config.is_a?(Hash)
+      skip_config = {} unless skip_config.is_a?(Hash)
+      skip_config = { skip_cat_ids: [], skip_post_ids: [] }.merge!(skip_config)
       res = []
       cats.decorate.each do |cat|
         next if skip_config[:skip_cat_ids].include?(cat.id)

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -36,7 +36,9 @@ module CamaleonCms
     # login a user using username and password
     # return boolean: true => authenticated, false => authentication failed
     def login_user_with_password(username, password)
-      user = current_site.users.find_by(username: username)
+      # Custom class finder: usernames are stored downcased, so the lookup must
+      # lower-case both sides regardless of DB collation.
+      user = current_site.users.find_by_username(username) # rubocop:disable Rails/DynamicFindBy
       r = { user: user, params: params, password: password, captcha_validate: true }
       hooks_run('user_before_login', r)
       user&.authenticate(password)

--- a/app/views/camaleon_cms/default_theme/sitemap.html.erb
+++ b/app/views/camaleon_cms/default_theme/sitemap.html.erb
@@ -6,7 +6,7 @@
         <li>
             <h3><a href="<%= ptype.the_url %>"><%= ptype.the_title %></a></h3>
             <% if ptype.manage_categories? %>
-                <%= raw(cama_sitemap_cats_generator(ptype.the_categories)) %>
+                <%= raw(cama_sitemap_cats_generator(ptype.the_categories, @r)) %>
             <% else %>
                 <ul>
                     <% ptype.the_posts.decorate.each do |post| next if @r[:skip_post_ids].include?(post.id) %>

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -82,8 +82,14 @@ module CamaleonCms
         end
       end
 
-      # Security headers for SVG media files
-      app.middleware.insert_before ::ActionDispatch::Static, CamaleonCms::MediaSecurityHeaders
+      # Security headers for SVG media files. ActionDispatch::Static is only in the host
+      # stack when public_file_server is enabled; anchoring on it unconditionally aborts
+      # boot on hosts that serve public/ from nginx/Apache.
+      if app.config.public_file_server.enabled
+        app.middleware.insert_before ::ActionDispatch::Static, CamaleonCms::MediaSecurityHeaders
+      else
+        app.middleware.use CamaleonCms::MediaSecurityHeaders
+      end
 
       # Static files
       app.middleware.use ::ActionDispatch::Static, "#{root}/public"

--- a/lib/plugin_routes.rb
+++ b/lib/plugin_routes.rb
@@ -237,7 +237,7 @@ class PluginRoutes
       r = cache_variable('site_plugin_helpers')
       return r if r
 
-      res = enabled_apps(site).flat_map { |settings| settings['helpers'].presence }
+      res = enabled_apps(site).flat_map { |settings| settings['helpers'].presence }.compact
       cache_variable('site_plugin_helpers', res)
     end
 
@@ -246,7 +246,7 @@ class PluginRoutes
       r = cache_variable('plugins_helper')
       return r if r
 
-      res = all_apps.flat_map { |settings| settings['helpers'].presence }
+      res = all_apps.flat_map { |settings| settings['helpers'].presence }.compact
       cache_variable('plugins_helper', res.uniq)
     end
 

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/design.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/design.md
@@ -1,0 +1,73 @@
+# Design: fix-audit-hardening-batch-1
+
+## Context
+
+A five-stream regression audit of `2.9.2..master` (report kept locally as
+`REGRESSION-AUDIT-2026-08-03.md`, gitignored) confirmed twelve high-severity regressions. The six
+addressed here are one-line-to-small restorations of 2.9.2 behavior; the remaining six (STI data
+integrity, user-deletion cascades, upload false positives, path-root restrictions) are larger and
+deferred to follow-up changes. Implementation landed on `fix/regression-audit-hardening-batch-1`
+(PR #1223) before this change was written, so the artifacts capture completed work; every fix was
+demonstrated red→green by a spec that reproduced the regression first.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Pin the six restored behaviors as OpenSpec requirements so they cannot regress silently again.
+- Keep each fix byte-minimal and faithful to the 2.9.2 contract.
+
+**Non-Goals:**
+
+- The other six audit highs (H7–H12) and all medium findings — follow-up changes.
+- Restoring the full 2.9.2 controller include list (`ShortCodeHelper`, `HtmlHelper`,
+  `UserRolesHelper` remain view-only); only `CamaleonHelper` is restored, which covers the
+  demonstrated crashes.
+
+## Decisions
+
+- **D1 — Conditional middleware insertion over `rescue`:** the engine checks
+  `app.config.public_file_server.enabled` and either inserts before `ActionDispatch::Static` or
+  appends the middleware (still ahead of the engine's own static handler, since proxy operations
+  replay in call order). A `rescue` around `insert_before` would mask genuine stack errors; the
+  config flag is exactly the condition Rails itself uses to add the middleware.
+- **D2 — `.compact` at the producer, not the consumer:** nils are dropped inside
+  `PluginRoutes.all_helpers`/`site_plugin_helpers` rather than guarded at
+  `CamaleonController`'s `include`, because `site_plugin_helpers` is also a public API whose
+  callers should never see nils.
+- **D3 — Restore `CamaleonHelper` only, included before the runtime concerns:** the include sits
+  above the concern includes so any future concern method of the same name would take precedence.
+  The wider 2.9.2 include list is not restored wholesale because the runtime concerns duplicate
+  parts of those helpers (e.g. `RuntimeShortcodeThemeConcern` vs `ShortCodeHelper`) and the
+  include order would silently swap implementations — that cleanup needs its own change.
+- **D4 — Merge semantics for the sitemap guard:** `skip_config` is normalized to a Hash and then
+  merged over the defaults, and the shipped template passes `@r` (the `on_render_sitemap` hook
+  config) through — restoring the 2.9.2 skip contract while keeping the newer explicit-argument
+  interface for external callers.
+- **D5 — Keep the custom finders' names and pin the cop:** `find_by_username`/`find_by_email`
+  look like dynamic finders to `Rails/DynamicFindBy` but are real class methods; renaming them
+  would break external callers, so the call sites carry `rubocop:disable` pins exactly like the
+  existing `find_by_slug` sites.
+- **D6 — Unit spec for the boot regression runs the dummy app in a subprocess** with
+  `CAMA_TEST_DISABLE_FILE_SERVER=1` (a test-env hook), because the crash only exists in a
+  middleware configuration the in-process test app never has.
+
+## Risks / Trade-offs
+
+- [Appended middleware position differs from the enabled-case position] → In the disabled case
+  no Rails static middleware serves `/media/` anyway; the headers middleware still wraps
+  whatever reaches the router, and real static serving happens in the web server, where these
+  headers must be configured at the proxy (unchanged from 2.9.2, which had no middleware at all).
+- [The stub-based `login_user_with_password` spec was rewritten against real records] → the old
+  stub pinned the exact-match implementation and would have re-broken on any internal change;
+  real records pin the observable contract instead.
+- [`is_a?(Hash)` + merge accepts hook configs carrying extra keys] → intended: `@r` holds the
+  full sitemap render config; the generator reads only the two skip lists.
+
+## Migration Plan
+
+None required — every change restores prior behavior; no data or config migration.
+
+## Open Questions
+
+None. Follow-up scope for the remaining audit findings is tracked in the audit report, not here.

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/proposal.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: fix-audit-hardening-batch-1
+
+## Why
+
+A full regression audit of `2.9.2..master` confirmed twelve high-severity regressions; the six
+smallest were fixed in PR #1223 as surgical restorations of 2.9.2 behavior. Each restored behavior
+is a durable contract (boot resilience, plugin compatibility, search, sitemap, sign-in) that had no
+spec-level requirement, which is exactly why it could regress silently — CI never exercised the
+configurations involved. This change pins them as requirements.
+
+## What Changes
+
+- Engine boot no longer depends on `ActionDispatch::Static` being present: the media
+  security-headers middleware is inserted conditionally, so hosts with `public_file_server`
+  disabled (nginx/Apache serving `public/`) boot again.
+- `PluginRoutes.all_helpers` / `site_plugin_helpers` tolerate installed plugins and themes that
+  declare no `helpers` key — the lists no longer carry `nil` entries that crashed
+  `CamaleonController` at class load.
+- `CamaleonCms::CamaleonHelper` is included in the controller chain again, restoring the
+  controller-context surface (`ct`, `cama_t`, `cama_cache_fetch`, …) that `GET /search`, plugin
+  hook functions, and `current_plugin` rely on.
+- Frontend search builds its SQL pattern from the downcased query and honors an empty result set
+  supplied by the `on_render_search` hook.
+- The HTML sitemap generator applies its default skip lists correctly (guard was inverted) and the
+  default-theme template passes the `on_render_sitemap` hook config through again.
+- Login, password reset, and `site.the_user(username)` use the custom lowercasing finders
+  `find_by_username` / `find_by_email` again, restoring case-insensitive lookups on
+  case-sensitive collations.
+
+None are breaking: every item restores documented or long-standing 2.9.2 behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `plugin-helper-registration`: which helper declarations installed plugins/themes may omit, and
+  what `PluginRoutes` helper lists may contain.
+- `frontend-search-matching`: case-insensitive query matching and the `on_render_search` hook
+  override contract for the frontend search action.
+- `html-sitemap-rendering`: the HTML sitemap renders the category tree and honors the
+  `on_render_sitemap` skip lists.
+- `case-insensitive-credential-lookup`: username/email lookups for login, password reset, and
+  `the_user` are case-insensitive given downcased storage.
+
+### Modified Capabilities
+
+- `media-serving-security`: the SVG security-headers middleware SHALL be installed under both
+  static-file-server configurations, and its installation SHALL NOT abort boot when
+  `ActionDispatch::Static` is absent.
+- `frontend-controller-helper-compatibility`: the controller-context helper surface extends to
+  `CamaleonHelper`'s methods on `CamaleonController` and all subclasses (frontend, admin, and
+  plugin controllers).
+
+## Impact
+
+- `lib/camaleon_cms/engine.rb` (middleware insertion), `lib/plugin_routes.rb` (helper lists)
+- `app/controllers/camaleon_cms/camaleon_controller.rb` (helper include),
+  `frontend_controller.rb` (search), `admin/sessions_controller.rb` (login/forgot lookups)
+- `app/helpers/camaleon_cms/camaleon_helper.rb` (sitemap generator),
+  `session_helper.rb` (password login), `app/decorators/camaleon_cms/site_decorator.rb`
+  (`the_user`)
+- `app/views/camaleon_cms/default_theme/sitemap.html.erb` (hook config pass-through)
+- Regression specs added in PR #1223 under `spec/requests/frontend/`, `spec/lib/`,
+  `spec/features/admin/`, and `spec/decorators/`.

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/case-insensitive-credential-lookup/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/case-insensitive-credential-lookup/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Username and email lookups are case-insensitive
+
+Usernames and emails are stored downcased, so every lookup that resolves user-typed input SHALL
+compare case-insensitively via the custom class finders `find_by_username` / `find_by_email`
+(which lower-case both sides in SQL), regardless of the database collation. This covers the login
+action, the password-reset email lookup, `SessionHelper#login_user_with_password`, and
+`SiteDecorator#the_user(username)`.
+
+#### Scenario: Mixed-case username signs in
+
+- **WHEN** a user whose stored username is `admin` submits the login form with username `Admin`
+  and their correct password
+- **THEN** authentication succeeds and the user reaches the dashboard
+
+#### Scenario: Mixed-case address receives the password-reset email
+
+- **WHEN** a user whose stored email is `admin@local.com` submits `Admin@Local.com` on the
+  forgot-password form
+- **THEN** the reset email is sent and the success message is shown
+
+#### Scenario: Theme API resolves a mixed-case username
+
+- **WHEN** a theme calls `site.the_user('ADMIN')` for a user stored as `admin`
+- **THEN** the decorated user is returned instead of `nil`

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/frontend-controller-helper-compatibility/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/frontend-controller-helper-compatibility/spec.md
@@ -1,21 +1,4 @@
-## Purpose
-
-Maintain the frontend controller helper API relied on by inheriting plugin controllers.
-
-## Requirements
-
-### Requirement: Preserve frontend helper methods on frontend controllers
-The system SHALL expose `cama_url_to_fixed` and `verify_front_visibility` on `FrontendController` and on
-frontend controllers that inherit from it.
-
-#### Scenario: Calling a restored URL helper from a frontend controller
-- **WHEN** a frontend controller action calls `cama_url_to_fixed`
-- **THEN** the call SHALL execute without a `NoMethodError`
-
-#### Scenario: Calling a restored visibility helper from a plugin controller
-- **WHEN** a plugin frontend controller inheriting from `FrontendController` calls
-  `verify_front_visibility`
-- **THEN** the call SHALL execute without a `NoMethodError`
+## ADDED Requirements
 
 ### Requirement: CamaleonHelper methods are reachable in controller context
 

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/frontend-search-matching/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/frontend-search-matching/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Search queries match case-insensitively
+
+The frontend search action SHALL downcase the visitor's query in Ruby before interpolating it into
+the SQL pattern compared against `LOWER(title)` / `LOWER(content_filtered)`, so matching is
+case-insensitive regardless of the database collation's own case behavior. `params[:q]` SHALL
+carry the downcased query for views and hooks, matching the 2.9.2 contract.
+
+#### Scenario: Mixed-case query finds a lower-case title on a case-sensitive collation
+
+- **WHEN** a published post is titled `über uns`
+- **AND** a visitor searches for `ÜBER` (a form only a Unicode-aware downcase can fold)
+- **THEN** the results page lists the post
+
+### Requirement: The search hook may replace the result set, including with an empty one
+
+When an `on_render_search` hook assigns `r[:posts]`, the action SHALL use that collection as the
+result set even when it is empty; the default LIKE query SHALL run only when the hook leaves
+`r[:posts]` as `nil`.
+
+#### Scenario: A hook-supplied empty result set is respected
+
+- **WHEN** an `on_render_search` hook sets `r[:posts]` to an empty collection
+- **THEN** the page renders "no results" and the default LIKE query is not used

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/html-sitemap-rendering/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/html-sitemap-rendering/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: The HTML sitemap renders the category tree
+
+`GET /sitemap.html` SHALL render the category tree — each category with its posts and
+subcategories — for every post type that manages categories. `cama_sitemap_cats_generator` SHALL
+apply default (empty) skip lists when the caller passes none, so a bare
+`cama_sitemap_cats_generator(cats)` call never raises.
+
+#### Scenario: Sitemap renders for a site with categories
+
+- **WHEN** a visitor requests `/sitemap.html` on a site with at least one category
+- **THEN** the response is HTTP 200
+- **AND** the body contains the category's title and link
+
+### Requirement: The sitemap hook's skip lists are honored in the HTML variant
+
+The `on_render_sitemap` hook config (`skip_cat_ids`, `skip_post_ids`) SHALL be passed through to
+the HTML category generator by the shipped template, so hooks can exclude categories and posts
+from the HTML sitemap exactly as they can from the XML variant.
+
+#### Scenario: A hook-excluded category is absent from the HTML sitemap
+
+- **WHEN** an `on_render_sitemap` hook adds a category's id to `skip_cat_ids`
+- **THEN** `/sitemap.html` renders without that category's entry

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/media-serving-security/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/media-serving-security/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Header middleware installation does not depend on the host's static file server
+
+The system SHALL install `CamaleonCms::MediaSecurityHeaders` in the middleware stack under both
+static-file configurations: before `ActionDispatch::Static` when the host application has
+`public_file_server.enabled` set to true, and appended ahead of the engine's own static file
+handler when it does not. Application boot SHALL NOT raise when `ActionDispatch::Static` is absent
+from the host stack.
+
+#### Scenario: Boot with the public file server disabled
+
+- **WHEN** the host application boots with `config.public_file_server.enabled = false`
+  (the standard production configuration behind nginx/Apache)
+- **THEN** `Rails.application.initialize!` completes without error
+- **AND** `CamaleonCms::MediaSecurityHeaders` is present in the middleware stack
+
+#### Scenario: Headers still precede static serving when the file server is enabled
+
+- **WHEN** the host application boots with `config.public_file_server.enabled = true`
+- **THEN** `CamaleonCms::MediaSecurityHeaders` sits before `ActionDispatch::Static`, so SVG
+  responses served statically still carry the security headers

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/plugin-helper-registration/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/specs/plugin-helper-registration/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: The helpers key is optional in plugin and theme configs
+
+The system SHALL treat the `helpers` key of an installed plugin's or theme's config as optional:
+an app that omits the key, or declares an empty list, SHALL NOT affect helper registration for
+other apps and SHALL NOT prevent the application from booting or serving requests.
+
+#### Scenario: An installed plugin without helpers does not break the install
+
+- **WHEN** an installed plugin's `config.json` has no `helpers` key
+- **AND** `CamaleonCms::CamaleonController` includes every entry of `PluginRoutes.all_helpers`
+  at class-body load
+- **THEN** class loading completes without error
+
+### Requirement: PluginRoutes helper lists contain only helper class names
+
+`PluginRoutes.all_helpers` and `PluginRoutes.site_plugin_helpers` SHALL return arrays containing
+only the helper class name strings declared by installed apps — never `nil` — so every entry is
+safe to `constantize`.
+
+#### Scenario: Apps without helpers are omitted from the aggregate list
+
+- **WHEN** the installed apps are one with no `helpers` key, one with `helpers: []`, and one
+  declaring `helpers: ["CamaleonCms::CamaleonHelper"]`
+- **THEN** `PluginRoutes.all_helpers` returns exactly `["CamaleonCms::CamaleonHelper"]`
+
+#### Scenario: Site-scoped helper list is nil-free
+
+- **WHEN** a site's enabled apps include one without a `helpers` key
+- **THEN** `PluginRoutes.site_plugin_helpers(site)` contains no `nil` entries

--- a/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/tasks.md
+++ b/openspec/changes/archive/2026-08-03-fix-audit-hardening-batch-1/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: fix-audit-hardening-batch-1
+
+Implementation landed on `fix/regression-audit-hardening-batch-1` (PR #1223); every fix was
+demonstrated red→green by a spec reproducing the regression before the fix was applied.
+
+## 1. Boot and plugin registration
+
+- [x] 1.1 Guard the `MediaSecurityHeaders` insertion on `public_file_server.enabled` in
+  `lib/camaleon_cms/engine.rb`; add the subprocess boot spec and the
+  `CAMA_TEST_DISABLE_FILE_SERVER` test-env hook
+- [x] 1.2 Drop nils in `PluginRoutes.all_helpers`/`site_plugin_helpers`
+  (`lib/plugin_routes.rb`) and cover helper-less apps in `spec/lib/plugin_routes_spec.rb`
+
+## 2. Controller helper surface and frontend rendering
+
+- [x] 2.1 Include `CamaleonCms::CamaleonHelper` in `CamaleonController` ahead of the runtime
+  concerns; cover `GET /search` in `spec/requests/frontend/search_spec.rb`
+- [x] 2.2 Downcase the search query before the SQL pattern and honor hook-supplied empty result
+  sets in `FrontendController#search`; cover with the non-ASCII case-folding example
+- [x] 2.3 Fix the inverted `skip_config` guard in `cama_sitemap_cats_generator`, pass `@r`
+  through from the default-theme template, and cover `/sitemap.html` in
+  `spec/requests/frontend/sitemap_spec.rb`
+
+## 3. Case-insensitive credential lookups
+
+- [x] 3.1 Restore `find_by_username`/`find_by_email` (with `Rails/DynamicFindBy` pins) in the
+  login action, the password-reset lookup, `SessionHelper#login_user_with_password`, and
+  `SiteDecorator#the_user`
+- [x] 3.2 Cover mixed-case sign-in and reset in `spec/features/admin/session_spec.rb`, the
+  decorator lookup in `spec/decorators/site_decorator_spec.rb`, and rewrite the stub-based
+  `login_user_with_password` example against real records
+
+## 4. Verification and close-out
+
+- [x] 4.1 Full gates green: `bin/rspec`, `bin/rubocop`, `bin/brakeman --no-pager`,
+  `(cd spec/dummy && bin/rails zeitwerk:check)`
+- [x] 4.2 Archive this change on the branch as part of PR #1223

--- a/openspec/specs/case-insensitive-credential-lookup/spec.md
+++ b/openspec/specs/case-insensitive-credential-lookup/spec.md
@@ -1,0 +1,30 @@
+## Purpose
+
+Define how user-typed usernames and email addresses are resolved against their stored, downcased forms. Every lookup that resolves such input must compare case-insensitively regardless of the database collation, so mixed-case input still finds the stored user.
+
+## Requirements
+
+### Requirement: Username and email lookups are case-insensitive
+
+Usernames and emails are stored downcased, so every lookup that resolves user-typed input SHALL
+compare case-insensitively via the custom class finders `find_by_username` / `find_by_email`
+(which lower-case both sides in SQL), regardless of the database collation. This covers the login
+action, the password-reset email lookup, `SessionHelper#login_user_with_password`, and
+`SiteDecorator#the_user(username)`.
+
+#### Scenario: Mixed-case username signs in
+
+- **WHEN** a user whose stored username is `admin` submits the login form with username `Admin`
+  and their correct password
+- **THEN** authentication succeeds and the user reaches the dashboard
+
+#### Scenario: Mixed-case address receives the password-reset email
+
+- **WHEN** a user whose stored email is `admin@local.com` submits `Admin@Local.com` on the
+  forgot-password form
+- **THEN** the reset email is sent and the success message is shown
+
+#### Scenario: Theme API resolves a mixed-case username
+
+- **WHEN** a theme calls `site.the_user('ADMIN')` for a user stored as `admin`
+- **THEN** the decorated user is returned instead of `nil`

--- a/openspec/specs/frontend-search-matching/spec.md
+++ b/openspec/specs/frontend-search-matching/spec.md
@@ -1,0 +1,29 @@
+## Purpose
+
+Define the matching contract of the frontend search action: visitor queries match case-insensitively regardless of the database collation, and the `on_render_search` hook may replace the result set — including with an empty one.
+
+## Requirements
+
+### Requirement: Search queries match case-insensitively
+
+The frontend search action SHALL downcase the visitor's query in Ruby before interpolating it into
+the SQL pattern compared against `LOWER(title)` / `LOWER(content_filtered)`, so matching is
+case-insensitive regardless of the database collation's own case behavior. `params[:q]` SHALL
+carry the downcased query for views and hooks, matching the 2.9.2 contract.
+
+#### Scenario: Mixed-case query finds a lower-case title on a case-sensitive collation
+
+- **WHEN** a published post is titled `über uns`
+- **AND** a visitor searches for `ÜBER` (a form only a Unicode-aware downcase can fold)
+- **THEN** the results page lists the post
+
+### Requirement: The search hook may replace the result set, including with an empty one
+
+When an `on_render_search` hook assigns `r[:posts]`, the action SHALL use that collection as the
+result set even when it is empty; the default LIKE query SHALL run only when the hook leaves
+`r[:posts]` as `nil`.
+
+#### Scenario: A hook-supplied empty result set is respected
+
+- **WHEN** an `on_render_search` hook sets `r[:posts]` to an empty collection
+- **THEN** the page renders "no results" and the default LIKE query is not used

--- a/openspec/specs/html-sitemap-rendering/spec.md
+++ b/openspec/specs/html-sitemap-rendering/spec.md
@@ -1,0 +1,29 @@
+## Purpose
+
+Define the rendering contract of the HTML sitemap at `/sitemap.html`: the category tree renders for every post type that manages categories, and the `on_render_sitemap` hook's skip lists exclude entries from the HTML variant exactly as they do from the XML one.
+
+## Requirements
+
+### Requirement: The HTML sitemap renders the category tree
+
+`GET /sitemap.html` SHALL render the category tree — each category with its posts and
+subcategories — for every post type that manages categories. `cama_sitemap_cats_generator` SHALL
+apply default (empty) skip lists when the caller passes none, so a bare
+`cama_sitemap_cats_generator(cats)` call never raises.
+
+#### Scenario: Sitemap renders for a site with categories
+
+- **WHEN** a visitor requests `/sitemap.html` on a site with at least one category
+- **THEN** the response is HTTP 200
+- **AND** the body contains the category's title and link
+
+### Requirement: The sitemap hook's skip lists are honored in the HTML variant
+
+The `on_render_sitemap` hook config (`skip_cat_ids`, `skip_post_ids`) SHALL be passed through to
+the HTML category generator by the shipped template, so hooks can exclude categories and posts
+from the HTML sitemap exactly as they can from the XML variant.
+
+#### Scenario: A hook-excluded category is absent from the HTML sitemap
+
+- **WHEN** an `on_render_sitemap` hook adds a category's id to `skip_cat_ids`
+- **THEN** `/sitemap.html` renders without that category's entry

--- a/openspec/specs/media-serving-security/spec.md
+++ b/openspec/specs/media-serving-security/spec.md
@@ -27,3 +27,24 @@ The system SHALL NOT add the SVG security headers to non-SVG media files served 
 #### Scenario: PNG response is unchanged
 - **WHEN** a browser requests a PNG file at `/media/{site_id}/image.png`
 - **THEN** the response does NOT include `Content-Security-Policy: script-src 'none'`
+
+### Requirement: Header middleware installation does not depend on the host's static file server
+
+The system SHALL install `CamaleonCms::MediaSecurityHeaders` in the middleware stack under both
+static-file configurations: before `ActionDispatch::Static` when the host application has
+`public_file_server.enabled` set to true, and appended ahead of the engine's own static file
+handler when it does not. Application boot SHALL NOT raise when `ActionDispatch::Static` is absent
+from the host stack.
+
+#### Scenario: Boot with the public file server disabled
+
+- **WHEN** the host application boots with `config.public_file_server.enabled = false`
+  (the standard production configuration behind nginx/Apache)
+- **THEN** `Rails.application.initialize!` completes without error
+- **AND** `CamaleonCms::MediaSecurityHeaders` is present in the middleware stack
+
+#### Scenario: Headers still precede static serving when the file server is enabled
+
+- **WHEN** the host application boots with `config.public_file_server.enabled = true`
+- **THEN** `CamaleonCms::MediaSecurityHeaders` sits before `ActionDispatch::Static`, so SVG
+  responses served statically still carry the security headers

--- a/openspec/specs/plugin-helper-registration/spec.md
+++ b/openspec/specs/plugin-helper-registration/spec.md
@@ -1,0 +1,35 @@
+## Purpose
+
+Define how helper classes declared by installed plugins and themes are aggregated and registered on the controller chain. The `helpers` key of an app's config is optional, and the aggregated helper lists must contain only helper class name strings that are safe to constantize.
+
+## Requirements
+
+### Requirement: The helpers key is optional in plugin and theme configs
+
+The system SHALL treat the `helpers` key of an installed plugin's or theme's config as optional:
+an app that omits the key, or declares an empty list, SHALL NOT affect helper registration for
+other apps and SHALL NOT prevent the application from booting or serving requests.
+
+#### Scenario: An installed plugin without helpers does not break the install
+
+- **WHEN** an installed plugin's `config.json` has no `helpers` key
+- **AND** `CamaleonCms::CamaleonController` includes every entry of `PluginRoutes.all_helpers`
+  at class-body load
+- **THEN** class loading completes without error
+
+### Requirement: PluginRoutes helper lists contain only helper class names
+
+`PluginRoutes.all_helpers` and `PluginRoutes.site_plugin_helpers` SHALL return arrays containing
+only the helper class name strings declared by installed apps — never `nil` — so every entry is
+safe to `constantize`.
+
+#### Scenario: Apps without helpers are omitted from the aggregate list
+
+- **WHEN** the installed apps are one with no `helpers` key, one with `helpers: []`, and one
+  declaring `helpers: ["CamaleonCms::CamaleonHelper"]`
+- **THEN** `PluginRoutes.all_helpers` returns exactly `["CamaleonCms::CamaleonHelper"]`
+
+#### Scenario: Site-scoped helper list is nil-free
+
+- **WHEN** a site's enabled apps include one without a `helpers` key
+- **THEN** `PluginRoutes.site_plugin_helpers(site)` contains no `nil` entries

--- a/spec/decorators/site_decorator_spec.rb
+++ b/spec/decorators/site_decorator_spec.rb
@@ -17,6 +17,14 @@ RSpec.describe CamaleonCms::SiteDecorator do
     end
   end
 
+  describe '#the_user' do
+    it 'finds users case-insensitively by username' do
+      shared_site = CamaleonCms::Site.first.decorate
+
+      expect(shared_site.the_user('ADMIN')).to be_present
+    end
+  end
+
   describe '#draw_languages' do
     it 'escapes labels returned by the block' do
       output = decorator.draw_languages('langs', true) { |_lang, _current| '<script>alert(1)</script>' }

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -17,7 +17,9 @@ Rails.application.configure do
   config.log_level = :warn
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.public_file_server.enabled = true
+  # The env flag lets spec/lib/engine_boot_spec.rb boot without ActionDispatch::Static,
+  # mirroring production hosts that serve public/ from nginx/Apache.
+  config.public_file_server.enabled = ENV['CAMA_TEST_DISABLE_FILE_SERVER'].blank?
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/spec/features/admin/session_spec.rb
+++ b/spec/features/admin/session_spec.rb
@@ -27,6 +27,21 @@ describe 'the signin process', :js do
     expect(page).to have_text 'Send email reset success'
   end
 
+  # Usernames and emails are stored downcased, so mixed-case input must keep matching
+  # regardless of the database collation's case sensitivity.
+  it 'signs me in with a mixed-case username' do # rubocop:disable RSpec/NoExpectationExample
+    admin_form_sign_in('Admin')
+  end
+
+  it 'sends the reset email for a mixed-case address' do
+    visit "#{cama_root_relative_path}/admin/forgot"
+    within('#login_user') do
+      fill_in 'user_email', with: 'Admin@Local.com'
+    end
+    click_button 'Submit'
+    expect(page).to have_text 'Send email reset success'
+  end
+
   it 'Enable Register' do
     admin_sign_in
     visit "#{cama_root_relative_path}/admin/settings/site?tab=config"

--- a/spec/helpers/session_helper_spec.rb
+++ b/spec/helpers/session_helper_spec.rb
@@ -10,17 +10,11 @@ RSpec.describe CamaleonCms::SessionHelper, type: :helper do
   end
 
   describe '#login_user_with_password' do
-    it 'authenticates found user' do
-      user = instance_double(CamaleonCms::User)
-      users = instance_double(ActiveRecord::Relation)
-      site = instance_double(CamaleonCms::Site, users: users)
-
-      allow(helper).to receive_messages(current_site: site, params: {})
-      allow(users).to receive(:find_by).with(username: 'admin').and_return(user)
+    it 'authenticates found user regardless of username case' do
+      allow(helper).to receive_messages(current_site: CamaleonCms::Site.first, params: {})
       allow(helper).to receive(:hooks_run)
-      allow(user).to receive(:authenticate).with('secret').and_return(true)
 
-      expect(helper.login_user_with_password('admin', 'secret')).to be(true)
+      expect(helper.login_user_with_password('Admin', 'admin123')).to be_truthy
     end
   end
 

--- a/spec/lib/engine_boot_spec.rb
+++ b/spec/lib/engine_boot_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'open3'
+
+RSpec.describe CamaleonCms::Engine do
+  # Hosts that serve public/ from nginx/Apache run with public_file_server disabled,
+  # so ActionDispatch::Static is absent from their middleware stack. CI runs with the
+  # file server enabled, which is why this needs its own boot in a subprocess.
+  it 'boots when public_file_server is disabled' do
+    output, status = Open3.capture2e(
+      { 'CAMA_TEST_DISABLE_FILE_SERVER' => '1' },
+      'bin/rails', 'runner', 'print "BOOTED-OK"',
+      chdir: Rails.root.to_s
+    )
+
+    expect(output).to include('BOOTED-OK'), "boot failed:\n#{output}"
+    expect(status).to be_success
+  end
+end

--- a/spec/lib/plugin_routes_spec.rb
+++ b/spec/lib/plugin_routes_spec.rb
@@ -128,4 +128,36 @@ RSpec.describe PluginRoutes do
       expect { described_class.class_variable_get(:@@cache) }.to raise_error(NameError)
     end
   end
+
+  describe '.all_helpers' do
+    after { described_class.send(:cache).delete('plugins_helper') }
+
+    it 'omits apps that declare no helpers' do
+      described_class.send(:cache).delete('plugins_helper')
+      apps = [
+        { 'key' => 'no_helpers_key' },
+        { 'key' => 'empty_helpers', 'helpers' => [] },
+        { 'key' => 'with_helpers', 'helpers' => ['CamaleonCms::CamaleonHelper'] }
+      ]
+      allow(described_class).to receive(:all_apps).and_return(apps)
+
+      expect(described_class.all_helpers).to eq(['CamaleonCms::CamaleonHelper'])
+    end
+  end
+
+  describe '.site_plugin_helpers' do
+    after { described_class.send(:cache).delete('site_plugin_helpers') }
+
+    it 'omits enabled apps that declare no helpers' do
+      described_class.send(:cache).delete('site_plugin_helpers')
+      apps = [
+        { 'key' => 'no_helpers_key' },
+        { 'key' => 'with_helpers', 'helpers' => ['CamaleonCms::CamaleonHelper'] }
+      ]
+      site = instance_double(CamaleonCms::Site)
+      allow(described_class).to receive(:enabled_apps).with(site).and_return(apps)
+
+      expect(described_class.site_plugin_helpers(site)).to eq(['CamaleonCms::CamaleonHelper'])
+    end
+  end
 end

--- a/spec/requests/frontend/search_spec.rb
+++ b/spec/requests/frontend/search_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Frontend search', type: :request do
+  init_site
+
+  it 'renders the search results page' do
+    get '/search', params: { q: 'anything' }, headers: { 'HTTP_HOST' => @site.slug }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'matches posts case-insensitively for non-ASCII queries' do
+    # SQLite's LOWER()/LIKE are ASCII-only, so an uppercase Ü in the query can only
+    # match the stored lowercase title when Ruby downcases the query before the SQL —
+    # the same guarantee PostgreSQL installs need for plain ASCII queries.
+    @site.post_types.find_by(slug: 'post')
+         .add_post(title: 'über uns', slug: 'ueber-uns-search-fixture', content: 'search fixture content')
+
+    get '/search', params: { q: 'ÜBER' }, headers: { 'HTTP_HOST' => @site.slug }
+
+    expect(response.body).to include('über uns')
+  end
+end

--- a/spec/requests/frontend/sitemap_spec.rb
+++ b/spec/requests/frontend/sitemap_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Frontend HTML sitemap', type: :request do
+  init_site
+
+  it 'renders the category tree' do
+    get '/sitemap.html', headers: { 'HTTP_HOST' => @site.slug }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Uncategorized')
+  end
+end


### PR DESCRIPTION
## What and Why

A full regression audit of `2.9.2..master` found twelve confirmed high-severity regressions; this PR fixes the six that are small, surgical restorations of 2.9.2 behavior. Each fix landed with a spec that reproduced the regression first:

- **Engine boot**: the SVG media security-headers middleware was inserted before `ActionDispatch::Static` unconditionally, but Rails only adds that middleware when `public_file_server` is enabled — production hosts serving `public/` from nginx/Apache failed to boot (from #1199). The insertion is now conditional, with the middleware appended instead when the host runs no static file server.
- **Plugin helper lists**: `PluginRoutes.all_helpers`/`site_plugin_helpers` kept a `nil` for every installed plugin or theme without a `helpers` key in its config, and `CamaleonController` crashed on `nil.constantize` at class load — one helper-less app took the whole install down (from #1163). Nils are dropped.
- **Controller helper surface**: `CamaleonHelper` is included in the controller chain again — `GET /search` no longer 500s on `ct`, and plugin hook code calling `current_plugin` (which relies on `cama_cache_fetch`) works again; hook functions execute on the controller and depend on this surface (from #1182).
- **Frontend search**: the SQL pattern is built from the downcased query again, restoring matches for mixed-case queries on case-sensitive collations (PostgreSQL), and an empty result set supplied by the `on_render_search` hook is honored instead of discarded (from #1167).
- **HTML sitemap**: an inverted guard left the skip lists `nil`, so `/sitemap.html` crashed for any site with at least one category; the default-theme template also passes the `on_render_sitemap` hook config through again, restoring the skip contract (from #1178).
- **Case-insensitive lookups**: login, password reset, and `site.the_user(username)` use the custom lowercasing class finders `find_by_username`/`find_by_email` again — usernames and emails are stored downcased, so exact `find_by` matching broke mixed-case input on PostgreSQL/SQLite (from #1168, where the `Rails/DynamicFindBy` cleanup mistook the custom class finders for dynamic finders; they are now pinned against the cop like the existing `find_by_slug` call sites).

The new boot spec runs the dummy app in a subprocess with the static file server disabled, mirroring the production configuration CI never exercises. The remaining audit findings (STI/data-integrity, uploads, and association fixes) are larger and intentionally left for follow-up PRs.

## User-Visible Impact

Restores frontend search, the HTML sitemap, mixed-case sign-in and password reset, plugin helper/controller compatibility, and production boot behind nginx/Apache to their 2.9.2 behavior; no intended behavior changes beyond these restorations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)