### PR TITLE
Fix the #1173 fallout: STI tolerance, user deletion, association inverses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+- **Fix:** Fallout from the native-STI conversion ([#1173](https://github.com/owen2345/camaleon-cms/pull/1173),
+  which shipped with no changelog entry): rows with custom `taxonomy`/`post_class` values raised
+  `SubclassNotFound` on read and create — they load and save as the base class again; deleting a
+  user orphaned their comments (the anonymous-user reassignment had become dead code, and comment
+  rendering then crashed) and destroyed their widgets — both restored to 2.9.2 behavior; and wrong
+  `inverse_of` declarations made `.owner` raise on taxonomies, post types, and post tags (and on
+  widgets for custom `user_model` installs), and overwrote menu items' parent with the Site on
+  `site.nav_menu_items` loads. [#1224](https://github.com/owen2345/camaleon-cms/pull/1224).
+
+  **Notes for upgraders**
+
+  - Installs that deleted users while running a post-2.9.2 master build should run
+    `rake camaleon_cms:reassign_orphaned_comments` once: comments whose user is gone are
+    reassigned to each site's anonymous user; comments with an existing user are untouched.
+  - Posts of a deleted user with no surviving admin now keep `user_id` NULL (2.9.2 left a
+    dangling id); display already handled both.
+
 - **Fix:** Six high-severity regressions introduced after 2.9.2, found by a full-range audit and
   each pinned by a spec that reproduced it: engine boot failed on production hosts that serve
   static files from nginx/Apache instead of Rails; one installed plugin or theme without a

--- a/app/decorators/camaleon_cms/post_comment_decorator.rb
+++ b/app/decorators/camaleon_cms/post_comment_decorator.rb
@@ -7,9 +7,9 @@ module CamaleonCms
       h.l(object.created_at, format: format.to_sym)
     end
 
-    # return owner of this comment
+    # return owner of this comment, or nil for rows whose user is missing
     def the_user
-      object.user.decorate
+      object.user&.decorate
     end
     alias the_author the_user
 
@@ -26,11 +26,13 @@ module CamaleonCms
     end
 
     def the_author_name
-      object.author.presence || object.user.full_name
+      # `fullname` is the model method; `full_name` never existed, so this fallback
+      # crashed for any comment stored without an author string.
+      object.author.presence || object.user&.fullname
     end
 
     def the_author_email
-      object.author_email.presence || object.user.email
+      object.author_email.presence || object.user&.email
     end
 
     def the_author_url

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -17,7 +17,7 @@ module CamaleonCms
     has_many :categories, class_name: 'CamaleonCms::Category', through: :term_relationships, source: :term_taxonomy
     has_many :post_tags, class_name: 'CamaleonCms::PostTag', through: :term_relationships, source: :term_taxonomy
     has_many :comments, class_name: 'CamaleonCms::PostComment', dependent: :destroy
-    has_many :drafts, -> { where(status: 'draft_child') }, class_name: 'CamaleonCms::Post', inverse_of: :owner,
+    has_many :drafts, -> { where(status: 'draft_child') }, class_name: 'CamaleonCms::Post', inverse_of: :parent,
                                                            foreign_key: :post_parent, dependent: :destroy
     has_many :children, class_name: 'CamaleonCms::Post', foreign_key: :post_parent, dependent: :destroy,
                         primary_key: :id, inverse_of: :parent

--- a/app/models/camaleon_cms/post_default.rb
+++ b/app/models/camaleon_cms/post_default.rb
@@ -26,9 +26,21 @@ module CamaleonCms
     # "Post" -> "CamaleonCms::Post"
     def self.find_sti_class(type_name)
       full_class_name = type_name.start_with?('CamaleonCms::') ? type_name : "CamaleonCms::#{type_name}"
-      full_class_name.constantize
-    rescue NameError
-      super
+      klass = begin
+        full_class_name.constantize
+      rescue NameError
+        nil
+      end
+      return klass if klass && klass <= base_class
+
+      # `super` resolves fully-qualified external classes (plugin STI outside the
+      # CamaleonCms namespace) and enforces ancestry; values it cannot place load as
+      # the base class, as every row did before native STI.
+      begin
+        super
+      rescue ActiveRecord::SubclassNotFound
+        base_class
+      end
     end
 
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}posts"

--- a/app/models/camaleon_cms/post_tag.rb
+++ b/app/models/camaleon_cms/post_tag.rb
@@ -5,6 +5,6 @@ module CamaleonCms
     has_many :posts, foreign_key: :objectid, through: :term_relationships, source: :object
     belongs_to :post_type, foreign_key: :parent_id, inverse_of: :post_tags, optional: true
     belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
-                       inverse_of: :post_tags
+                       inverse_of: false
   end
 end

--- a/app/models/camaleon_cms/post_type.rb
+++ b/app/models/camaleon_cms/post_type.rb
@@ -15,7 +15,7 @@ module CamaleonCms
              class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :destroy, inverse_of: :owner
 
     belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
-                       inverse_of: :post_type_owners
+                       inverse_of: false
     belongs_to :site, foreign_key: :parent_id, optional: true, inverse_of: :post_types
 
     scope :visible_menu, -> { where(term_group: nil) }

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -13,7 +13,9 @@ module CamaleonCms
                           inverse_of: :site
     has_many :nav_menus, class_name: 'CamaleonCms::NavMenu', foreign_key: :parent_id, dependent: :destroy,
                          inverse_of: :site
-    has_many :nav_menu_items, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :term_group, inverse_of: :parent,
+    # inverse_of: false — this joins by term_group (the site id), while NavMenuItem#parent
+    # reads parent_id (the menu id); an inverse here overwrites items' real menu parent.
+    has_many :nav_menu_items, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :term_group, inverse_of: false,
                               dependent: :destroy
     has_many :widgets, class_name: 'CamaleonCms::Widget::Main', foreign_key: :parent_id, dependent: :destroy,
                        inverse_of: :site

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -40,15 +40,20 @@ module CamaleonCms
 
       # Standard conversion for "site" -> "CamaleonCms::Site"
       # or "nav_menu_item" -> "CamaleonCms::NavMenuItem"
-      full_class_name = "CamaleonCms::#{type_name.camelize}"
-      full_class_name.constantize
-    rescue NameError
-      # Universal safety net: runtime scan across loaded taxonomy memory models
-      found_subclass = CamaleonCms::TermTaxonomy.descendants.find do |klass|
-        klass.sti_name == type_name.to_s
+      klass = begin
+        "CamaleonCms::#{type_name.camelize}".constantize
+      rescue NameError
+        nil
       end
+      # The ancestry guard keeps a value like "meta" from instantiating an unrelated
+      # CamaleonCms class against the term_taxonomy table.
+      return klass if klass && klass <= base_class
 
-      found_subclass || super
+      # Runtime scan across loaded taxonomy models, then the root: rows whose taxonomy
+      # value maps to no descendant (plugin-defined or legacy data) load as the base
+      # class, as every row did before native STI.
+      CamaleonCms::TermTaxonomy.descendants.find { |k| k.sti_name == type_name.to_s } ||
+        base_class
     end
 
     # callbacks
@@ -65,7 +70,7 @@ module CamaleonCms
     # has_many :posts, foreign_key: :objectid, through: :term_relationships, :source => :objects
     belongs_to :parent, class_name: 'CamaleonCms::TermTaxonomy', optional: true
     belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, optional: true,
-                       inverse_of: :term_taxonomies
+                       inverse_of: false
 
     # return all children taxonomy
     # sample: sub categories of a category

--- a/app/models/camaleon_cms/user.rb
+++ b/app/models/camaleon_cms/user.rb
@@ -8,7 +8,8 @@ if PluginRoutes.static_system_info['user_model'].blank?
 
       default_scope { order(role: :asc) }
 
-      has_many :widgets, class_name: 'CamaleonCms::Widget::Main', dependent: :destroy,
+      # No `dependent:` — a deleted user's widgets keep rendering; only the owner is gone.
+      has_many :widgets, class_name: 'CamaleonCms::Widget::Main', # rubocop:disable Rails/HasManyOrHasOneDependent
                          inverse_of: :owner
 
       validates :username, presence: true

--- a/app/models/camaleon_cms/widget/main.rb
+++ b/app/models/camaleon_cms/widget/main.rb
@@ -13,7 +13,9 @@ module CamaleonCms
       # excerpt: string for message
       # renderer: string (path to the template for render this widget)
 
-      belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, inverse_of: :widgets,
+      # inverse_of: false — custom `user_model` classes get only UserMethods, which
+      # defines no `widgets` collection the inverse could point at.
+      belongs_to :owner, class_name: CamaManager.get_user_class_name.to_s, foreign_key: :user_id, inverse_of: false,
                          optional: true
       belongs_to :site, class_name: 'CamaleonCms::Site', foreign_key: :parent_id, inverse_of: :widgets, optional: true
 

--- a/app/models/concerns/camaleon_cms/user_methods.rb
+++ b/app/models/concerns/camaleon_cms/user_methods.rb
@@ -34,7 +34,9 @@ module CamaleonCms
       # relations
       has_many :all_posts, class_name: 'CamaleonCms::Post', foreign_key: :user_id, inverse_of: :owner,
                            dependent: :nullify
-      has_many :all_comments, class_name: 'CamaleonCms::PostComment', dependent: :nullify
+      # No `dependent:` — the rows must still carry this user_id when the
+      # `after_destroy :reassign_comments` callback moves them to the anonymous user.
+      has_many :all_comments, class_name: 'CamaleonCms::PostComment' # rubocop:disable Rails/HasManyOrHasOneDependent
 
       belongs_to :site, class_name: 'CamaleonCms::Site', optional: true
 

--- a/lib/tasks/orphaned_comments.rake
+++ b/lib/tasks/orphaned_comments.rake
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+namespace :camaleon_cms do
+  desc 'Reassign comments whose user no longer exists to the owning site\'s anonymous user'
+  task reassign_orphaned_comments: :environment do
+    user_table = CamaManager.get_user_class_name.constantize.table_name
+    comment_table = CamaleonCms::PostComment.table_name
+
+    orphans = CamaleonCms::PostComment
+              .where("#{comment_table}.user_id IS NULL OR #{comment_table}.user_id NOT IN " \
+                     "(SELECT id FROM #{user_table})")
+    reassigned = 0
+    skipped = 0
+
+    orphans.find_each do |comment|
+      site = comment.post&.post_type&.site
+      if site.nil?
+        skipped += 1
+        next
+      end
+
+      comment.update_column(:user_id, site.get_anonymous_user.id) # rubocop:disable Rails/SkipsModelValidations
+      reassigned += 1
+    end
+
+    Rails.logger.info(
+      "camaleon_cms:reassign_orphaned_comments reassigned #{reassigned} comment(s)" \
+      "#{skipped > 0 ? ", skipped #{skipped} without a resolvable site" : ''}"
+    )
+  end
+end

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/design.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/design.md
@@ -1,0 +1,84 @@
+# Design: fix-1173-fallout-batch
+
+## Context
+
+PR #1173 converted `TermTaxonomy` (discriminator `taxonomy`) and `PostDefault` (discriminator
+`post_class`) to native Rails STI, added user-content lifecycle options, and sprinkled
+`inverse_of` across associations — with no changelog entry. The `2.9.2..master` audit confirmed
+three fallout clusters (H8, H9, wrong `inverse_of`s), all verified by live execution. Batch 1
+(#1223) covered the small restorations; this change covers the #1173 cluster. There are no
+migrations in the range, so every fix must work against unchanged 2.9.2 schemas and row values.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Existing databases with custom discriminator values load and save again.
+- User deletion behaves as on 2.9.2 (comments → anonymous user, widgets survive), with the
+  master-era orphan damage repairable.
+- Association traversals stop raising/mislabeling.
+
+**Non-Goals:**
+
+- H7 (post-content sanitization scope), H10–H12 (theme activation, uploads) — separate batches.
+- Defining user-side `has_many` collections (`term_taxonomies`, `post_tags`, …) to make the
+  guessed inverses real — that would add public API speculatively.
+- Rewriting `post_class`/`taxonomy` values or adding migrations.
+
+## Decisions
+
+- **D1 — `base_class` fallback instead of raising (H8):** unknown discriminators instantiate the
+  STI root (`TermTaxonomy` / `PostDefault`), which is exactly what 2.9.2 instantiated for every
+  row. Alternatives rejected: raising (breaks existing data), `becomes`-style dynamic subclass
+  creation (magic, no consumer). `base_class` is verified to resolve to the intended roots
+  (`CamaleonRecord` is abstract).
+- **D2 — Non-descendant resolutions are treated as unknown (H8):** `find_sti_class` on
+  `TermTaxonomy` constantized any `CamaleonCms::<Camelized>` name without checking ancestry, so a
+  taxonomy value of `meta` would instantiate `CamaleonCms::Meta` against the `term_taxonomy`
+  table. The fallback now requires `klass <= base_class`. `PostDefault` keeps its `super` call
+  before the fallback because AR's own resolution handles fully-qualified external plugin
+  classes and already enforces ancestry.
+- **D3 — Restore comment reassignment by removing `dependent: :nullify` (H9):** the
+  `after_destroy :reassign_comments` callback is correct; the nullify callback (registered later,
+  running earlier as a `before_destroy`) emptied its working set. Alternatives rejected: moving
+  reassignment to `before_destroy` (changes its transactional position for no gain), reassigning
+  inside the nullify handler (couples two mechanisms). `all_posts` keeps `dependent: :nullify` —
+  `reassign_posts` runs first (declared earlier), so nullify only touches the
+  no-surviving-admin remainder that 2.9.2 left dangling.
+- **D4 — Widgets keep their rows; the association stays (H9):** `dependent: :destroy` is removed
+  from the built-in user's `has_many :widgets`; the association itself remains as additive API.
+  `Widget::Main#owner` drops its `inverse_of: :widgets` (→ `inverse_of: false`) because custom
+  `user_model` classes get only `UserMethods`, which defines no `widgets` collection — the
+  inverse was valid solely for the built-in model.
+- **D5 — `inverse_of: false` over inventing user-side associations:** the `owner` inverses named
+  associations that have never existed (`term_taxonomies`, `post_type_owners`, `post_tags` on the
+  user). Declaring `inverse_of: false` restores 2.9.2 runtime semantics and satisfies
+  `Rails/InverseOf` explicitly. `Site#nav_menu_items` also gets `inverse_of: false`: it joins by
+  `term_group` (site id) while `NavMenuItem#parent` reads `parent_id` (menu id) — no correct
+  inverse exists. `Post#drafts` instead gets the genuinely correct `inverse_of: :parent`
+  (same foreign key, right association).
+- **D6 — Orphan repair is a rake task, not a migration:** per house convention
+  (`cross_site_field_groups.rake`, `site_custom_field_groups.rake`), data repair ships as
+  `camaleon_cms:reassign_orphaned_comments`, resolving each orphaned comment's site through
+  `post → post_type → site` and assigning `Site#get_anonymous_user`. Decorator readers
+  additionally become nil-safe so unrepaired rows render blank instead of 500ing.
+
+## Risks / Trade-offs
+
+- [Base-class instances for plugin subclasses not yet loaded in lazy-loading dev mode] → the
+  `descendants` scan can miss an unloaded subclass and fall back to the root; degraded typing in
+  dev is strictly better than raising, and production eager-loads.
+- [Keeping `all_posts` nullify diverges from 2.9.2's dangling ids in the no-admin case] →
+  deliberate: `NULL` is the safer representation and `Post#author` display already rescues.
+- [`inverse_of: false` forgoes future automatic inverse benefits] → matches 2.9.2; a later change
+  can introduce real user-side collections deliberately.
+
+## Migration Plan
+
+No schema changes. Operators upgrading from a master-era deployment run
+`rake camaleon_cms:reassign_orphaned_comments` once to repair comments orphaned by the
+regression; installs coming from 2.9.2 need nothing.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/proposal.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/proposal.md
@@ -1,0 +1,64 @@
+# Proposal: fix-1173-fallout-batch
+
+## Why
+
+PR #1173 (native Rails STI for taxonomies and posts) shipped with no changelog entry and, per the
+`2.9.2..master` regression audit, introduced the largest cluster of unresolved high-severity
+regressions: existing rows with non-built-in discriminator values now raise
+`ActiveRecord::SubclassNotFound` on read *and* create (audit H8); deleting a user orphans their
+comments — the anonymous-user reassignment became dead code — and hard-destroys their widgets
+(audit H9); and several `inverse_of` declarations name associations that do not exist or point at
+the wrong association, so `.owner` raises `InverseOfAssociationNotFoundError` for external
+callers and association-loaded records return wrongly-typed navigation targets.
+
+## What Changes
+
+- `TermTaxonomy.find_sti_class` and `PostDefault.find_sti_class` fall back to the STI root
+  (`base_class`) for unknown discriminator values instead of raising, restoring 2.9.2's tolerance
+  for custom taxonomy/post-class rows on both the read and write paths. A resolution that names a
+  non-descendant class is treated as unknown rather than instantiated.
+- User deletion reassigns the deleted user's comments to the site's anonymous user again
+  (`dependent: :nullify` is removed from `all_comments`, reviving `after_destroy
+  :reassign_comments`), and no longer destroys the user's widgets (`dependent: :destroy` removed
+  from the built-in user's `widgets` association). `all_posts`' `dependent: :nullify` is kept —
+  it only affects the no-surviving-admin case, where 2.9.2 left dangling ids.
+- `PostCommentDecorator` tolerates a missing comment author (nil-safe `the_user`,
+  `the_author_name`, `the_author_email`) so rows orphaned while the regression was live render
+  instead of raising, and a repair task
+  (`rake camaleon_cms:reassign_orphaned_comments`) reassigns them to each site's anonymous user.
+- Wrong `inverse_of` declarations are corrected: `owner` on `TermTaxonomy`, `PostType`,
+  `PostTag`, and `Widget::Main` becomes `inverse_of: false` (the named user-side associations do
+  not exist — on any user model for the first three, on custom `user_model` classes for the
+  widget); `Site#nav_menu_items` becomes `inverse_of: false` (it loads by `term_group` but
+  poisoned the `parent_id`-based `NavMenuItem#parent`, which made the admin menu-item
+  custom-fields form show every site field group); `Post#drafts` gets the correct
+  `inverse_of: :parent`.
+
+None are breaking: every item restores 2.9.2-observable behavior or fixes association metadata
+that could only raise or mislead.
+
+## Capabilities
+
+### New Capabilities
+
+- `sti-discriminator-compatibility`: how unknown or foreign discriminator values in the
+  `term_taxonomy.taxonomy` and `posts.post_class` columns are instantiated.
+- `user-deletion-content-reassignment`: what happens to a deleted user's comments, posts, and
+  widgets, including the repair path for orphaned comments.
+- `association-target-integrity`: association traversals return correctly-typed targets and never
+  raise for valid data (`owner` readers, `site.nav_menu_items` → `item.parent`,
+  `post.drafts` → `draft.owner`).
+
+### Modified Capabilities
+
+<!-- none — no existing capability's requirements change -->
+
+## Impact
+
+- `app/models/camaleon_cms/term_taxonomy.rb`, `post_default.rb` (STI resolution)
+- `app/models/concerns/camaleon_cms/user_methods.rb`, `app/models/camaleon_cms/user.rb`
+  (deletion behavior), `app/decorators/camaleon_cms/post_comment_decorator.rb` (nil safety)
+- `app/models/camaleon_cms/{term_taxonomy,post_type,post_tag,post,site}.rb`,
+  `app/models/camaleon_cms/widget/main.rb` (`inverse_of` corrections)
+- New `lib/tasks/orphaned_comments.rake`
+- Model and lib specs covering each restored behavior

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/association-target-integrity/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/association-target-integrity/spec.md
@@ -1,0 +1,46 @@
+## ADDED Requirements
+
+### Requirement: Owner associations never raise and return the owning user
+
+`owner` on `CamaleonCms::TermTaxonomy` (and its subclasses), `CamaleonCms::PostType`,
+`CamaleonCms::PostTag`, and `CamaleonCms::Widget::Main` SHALL be readable without
+`ActiveRecord::InverseOfAssociationNotFoundError` on every supported user model — including host
+apps configuring a custom `user_model` — returning the owning user record or `nil`.
+`TermTaxonomyDecorator#the_owner` SHALL return the owner again instead of swallowing the raise
+into `nil`.
+
+#### Scenario: Reading a category's owner
+
+- **WHEN** a category row's `user_id` points at an existing user
+- **THEN** `category.owner` returns that user and `category.decorate.the_owner` returns the
+  decorated user
+
+#### Scenario: Owner reflections are valid
+
+- **WHEN** the `owner` association of `Category`, `PostType`, `PostTag`, or `Widget::Main` is
+  accessed on a new record
+- **THEN** no `InverseOfAssociationNotFoundError` is raised
+
+### Requirement: Records loaded through site.nav_menu_items keep their real parent
+
+`NavMenuItem#parent` SHALL reference the item's `NavMenu` (via `parent_id`) even when the record
+was loaded through `Site#nav_menu_items` (which joins by `term_group`); the association load
+SHALL NOT overwrite `parent` with the `Site`. The admin nav-menu-item custom-fields form relies
+on this to show the menu's field groups rather than every group in the site.
+
+#### Scenario: Parent of a site-loaded menu item is its menu
+
+- **WHEN** a nav menu item is loaded via `site.nav_menu_items`
+- **THEN** `item.parent` is the item's `NavMenu`
+
+### Requirement: Drafts expose their author through owner and their post through parent
+
+`Post#drafts` SHALL set each draft's `parent` inverse to the owning post, and `draft.owner` SHALL
+remain the draft's author user — loading drafts through the association SHALL NOT retarget
+`owner` at the parent `Post`.
+
+#### Scenario: Draft author survives association loading
+
+- **WHEN** a draft is loaded via `post.drafts`
+- **THEN** `draft.owner` is the author user (or `nil`), never a `Post`
+- **AND** `draft.parent` is the owning post without an extra query

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/sti-discriminator-compatibility/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/sti-discriminator-compatibility/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Unknown discriminator values instantiate the STI root
+
+`CamaleonCms::TermTaxonomy.find_sti_class` and `CamaleonCms::PostDefault.find_sti_class` SHALL
+return the STI root (`base_class`) for a discriminator value that maps to no known class, instead
+of raising `ActiveRecord::SubclassNotFound`. This applies to both reading existing rows and
+creating new records with an explicit discriminator value, matching the pre-STI 2.9.2 behavior
+where `taxonomy` and `post_class` were plain string columns.
+
+#### Scenario: Reading an existing row with a custom taxonomy value
+
+- **WHEN** the `term_taxonomy` table holds a row whose `taxonomy` is `custom_tax` (written by a
+  plugin or by a 2.9.2-era install)
+- **THEN** `TermTaxonomy.find(id)` returns a `CamaleonCms::TermTaxonomy` instance with
+  `taxonomy == 'custom_tax'`
+- **AND** relation loads that include the row do not raise
+
+#### Scenario: Creating a record with a custom taxonomy value
+
+- **WHEN** code calls `CamaleonCms::TermTaxonomy.new(taxonomy: 'custom_tax', name: 'X')` and saves
+- **THEN** the row persists with `taxonomy == 'custom_tax'`
+
+#### Scenario: Reading a posts row with an unknown post_class
+
+- **WHEN** the `posts` table holds a row whose `post_class` names no resolvable class
+- **THEN** loading it returns a `CamaleonCms::PostDefault` instance with the column value
+  preserved
+
+### Requirement: Built-in discriminator values keep their subclasses
+
+The base-class fallback SHALL NOT change resolution for known values: built-in taxonomy values
+(`category`, `post_tag`, `post_type`, `nav_menu`, `nav_menu_item`, `site`, `theme`, `plugin`,
+`user_roles`, `widget`, `sidebar`) and post classes (`Post`, `Widget::Assigned`, legacy
+`CamaleonCms::`-prefixed names) SHALL continue to instantiate their subclasses.
+
+#### Scenario: A category row still loads as Category
+
+- **WHEN** a row with `taxonomy == 'category'` is loaded through `TermTaxonomy.find`
+- **THEN** the instance is a `CamaleonCms::Category`
+
+### Requirement: A discriminator resolving to a non-descendant class is treated as unknown
+
+If a discriminator value camelizes to the name of a class that is not a descendant of the STI
+root (e.g. a taxonomy value of `meta` resolving to `CamaleonCms::Meta`), the system SHALL treat
+the value as unknown and instantiate the STI root, rather than instantiating an unrelated class
+against the wrong table.
+
+#### Scenario: A taxonomy value naming an unrelated class loads as the root
+
+- **WHEN** a `term_taxonomy` row's `taxonomy` is `meta`
+- **THEN** loading it returns a `CamaleonCms::TermTaxonomy` instance, not `CamaleonCms::Meta`

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/user-deletion-content-reassignment/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/specs/user-deletion-content-reassignment/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: A deleted user's comments are reassigned to the site's anonymous user
+
+When a user is destroyed, every comment they authored SHALL be reassigned to the owning site's
+anonymous user (created on demand by `Site#get_anonymous_user`) — never left with a `NULL`
+`user_id`. Comment rendering after the deletion SHALL keep working.
+
+#### Scenario: Comment survives its author's deletion
+
+- **WHEN** a user who commented on another user's post is destroyed
+- **THEN** the comment still exists and its `user_id` is the site's anonymous user's id
+- **AND** `the_author_name` on the decorated comment renders without error
+
+### Requirement: A deleted user's widgets survive
+
+Destroying a user SHALL NOT destroy the widgets they created; sidebar widgets keep rendering
+after their creator's account is removed, as on 2.9.2.
+
+#### Scenario: Widget survives its creator's deletion
+
+- **WHEN** a user who created a sidebar widget is destroyed
+- **THEN** the widget row still exists
+
+### Requirement: A deleted user's posts go to a surviving admin, else are detached
+
+`before_destroy` reassignment of the deleted user's posts (and the comments on them) to another
+admin of the same site SHALL be attempted first; posts with no surviving admin SHALL have
+`user_id` set to `NULL` rather than keeping a dangling id.
+
+#### Scenario: Posts move to the surviving admin
+
+- **WHEN** a site has a second admin and a post author is destroyed
+- **THEN** the author's posts belong to the surviving admin
+
+### Requirement: Comment rendering tolerates a missing author and orphans are repairable
+
+`PostCommentDecorator#the_user`, `#the_author_name`, and `#the_author_email` SHALL NOT raise when
+the comment's user is missing (rows orphaned while the regression was live).
+`rake camaleon_cms:reassign_orphaned_comments` SHALL reassign comments with a missing user to the
+owning site's anonymous user, and SHALL NOT modify comments whose user exists.
+
+#### Scenario: Orphaned comment renders and is repaired
+
+- **WHEN** a comment row's `user_id` is `NULL`
+- **THEN** `the_author_name` returns blank output instead of raising
+- **AND** after running `camaleon_cms:reassign_orphaned_comments` the comment's `user_id` is the
+  site's anonymous user's id

--- a/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/tasks.md
+++ b/openspec/changes/archive/2026-08-03-fix-1173-fallout-batch/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: fix-1173-fallout-batch
+
+## 1. Red specs
+
+- [x] 1.1 STI compatibility specs: custom `taxonomy` row read/create, unknown `post_class` row
+  read, built-in subclass resolution unchanged, non-descendant value loads as root
+- [x] 1.2 User-deletion specs: comment reassigned to anonymous user, widget survives, posts to
+  surviving admin; decorator nil-safety; orphaned-comments rake task spec
+- [x] 1.3 Association-integrity specs: `owner` readers do not raise and return the user;
+  `site.nav_menu_items` item keeps its `NavMenu` parent; `post.drafts` draft keeps its author
+
+## 2. Implementation
+
+- [x] 2.1 `TermTaxonomy.find_sti_class`: descendant guard + `base_class` fallback;
+  `PostDefault.find_sti_class`: `base_class` fallback after `super`
+- [x] 2.2 Remove `dependent: :nullify` from `all_comments`; remove `dependent: :destroy` from
+  the built-in user's `widgets`; nil-safe `PostCommentDecorator` readers; add
+  `lib/tasks/orphaned_comments.rake`
+- [x] 2.3 `inverse_of: false` on `owner` (TermTaxonomy, PostType, PostTag, Widget::Main) and
+  `Site#nav_menu_items`; `inverse_of: :parent` on `Post#drafts`
+
+## 3. Verification and close-out
+
+- [x] 3.1 Red→green demonstrated; full gates: `bin/rspec`, `bin/rubocop`,
+  `bin/brakeman --no-pager`, `(cd spec/dummy && bin/rails zeitwerk:check)`
+- [x] 3.2 PR opened; changelog entry (documents the #1173 fallout and the repair task)
+- [x] 3.3 Archive this change on the branch as part of the PR

--- a/openspec/specs/association-target-integrity/spec.md
+++ b/openspec/specs/association-target-integrity/spec.md
@@ -1,0 +1,50 @@
+## Purpose
+
+Association traversals return correctly-typed targets and never raise for valid data: `owner` readers work on every supported user model, and records loaded through scoped collections keep their real `parent`/`owner` targets.
+
+## Requirements
+
+### Requirement: Owner associations never raise and return the owning user
+
+`owner` on `CamaleonCms::TermTaxonomy` (and its subclasses), `CamaleonCms::PostType`,
+`CamaleonCms::PostTag`, and `CamaleonCms::Widget::Main` SHALL be readable without
+`ActiveRecord::InverseOfAssociationNotFoundError` on every supported user model — including host
+apps configuring a custom `user_model` — returning the owning user record or `nil`.
+`TermTaxonomyDecorator#the_owner` SHALL return the owner again instead of swallowing the raise
+into `nil`.
+
+#### Scenario: Reading a category's owner
+
+- **WHEN** a category row's `user_id` points at an existing user
+- **THEN** `category.owner` returns that user and `category.decorate.the_owner` returns the
+  decorated user
+
+#### Scenario: Owner reflections are valid
+
+- **WHEN** the `owner` association of `Category`, `PostType`, `PostTag`, or `Widget::Main` is
+  accessed on a new record
+- **THEN** no `InverseOfAssociationNotFoundError` is raised
+
+### Requirement: Records loaded through site.nav_menu_items keep their real parent
+
+`NavMenuItem#parent` SHALL reference the item's `NavMenu` (via `parent_id`) even when the record
+was loaded through `Site#nav_menu_items` (which joins by `term_group`); the association load
+SHALL NOT overwrite `parent` with the `Site`. The admin nav-menu-item custom-fields form relies
+on this to show the menu's field groups rather than every group in the site.
+
+#### Scenario: Parent of a site-loaded menu item is its menu
+
+- **WHEN** a nav menu item is loaded via `site.nav_menu_items`
+- **THEN** `item.parent` is the item's `NavMenu`
+
+### Requirement: Drafts expose their author through owner and their post through parent
+
+`Post#drafts` SHALL set each draft's `parent` inverse to the owning post, and `draft.owner` SHALL
+remain the draft's author user — loading drafts through the association SHALL NOT retarget
+`owner` at the parent `Post`.
+
+#### Scenario: Draft author survives association loading
+
+- **WHEN** a draft is loaded via `post.drafts`
+- **THEN** `draft.owner` is the author user (or `nil`), never a `Post`
+- **AND** `draft.parent` is the owning post without an extra query

--- a/openspec/specs/sti-discriminator-compatibility/spec.md
+++ b/openspec/specs/sti-discriminator-compatibility/spec.md
@@ -1,0 +1,56 @@
+## Purpose
+
+Preserve the pre-STI tolerance of the `term_taxonomy.taxonomy` and `posts.post_class` discriminator columns: values that map to no known class instantiate the STI root instead of raising, on both read and write, while built-in values keep resolving to their subclasses.
+
+## Requirements
+
+### Requirement: Unknown discriminator values instantiate the STI root
+
+`CamaleonCms::TermTaxonomy.find_sti_class` and `CamaleonCms::PostDefault.find_sti_class` SHALL
+return the STI root (`base_class`) for a discriminator value that maps to no known class, instead
+of raising `ActiveRecord::SubclassNotFound`. This applies to both reading existing rows and
+creating new records with an explicit discriminator value, matching the pre-STI 2.9.2 behavior
+where `taxonomy` and `post_class` were plain string columns.
+
+#### Scenario: Reading an existing row with a custom taxonomy value
+
+- **WHEN** the `term_taxonomy` table holds a row whose `taxonomy` is `custom_tax` (written by a
+  plugin or by a 2.9.2-era install)
+- **THEN** `TermTaxonomy.find(id)` returns a `CamaleonCms::TermTaxonomy` instance with
+  `taxonomy == 'custom_tax'`
+- **AND** relation loads that include the row do not raise
+
+#### Scenario: Creating a record with a custom taxonomy value
+
+- **WHEN** code calls `CamaleonCms::TermTaxonomy.new(taxonomy: 'custom_tax', name: 'X')` and saves
+- **THEN** the row persists with `taxonomy == 'custom_tax'`
+
+#### Scenario: Reading a posts row with an unknown post_class
+
+- **WHEN** the `posts` table holds a row whose `post_class` names no resolvable class
+- **THEN** loading it returns a `CamaleonCms::PostDefault` instance with the column value
+  preserved
+
+### Requirement: Built-in discriminator values keep their subclasses
+
+The base-class fallback SHALL NOT change resolution for known values: built-in taxonomy values
+(`category`, `post_tag`, `post_type`, `nav_menu`, `nav_menu_item`, `site`, `theme`, `plugin`,
+`user_roles`, `widget`, `sidebar`) and post classes (`Post`, `Widget::Assigned`, legacy
+`CamaleonCms::`-prefixed names) SHALL continue to instantiate their subclasses.
+
+#### Scenario: A category row still loads as Category
+
+- **WHEN** a row with `taxonomy == 'category'` is loaded through `TermTaxonomy.find`
+- **THEN** the instance is a `CamaleonCms::Category`
+
+### Requirement: A discriminator resolving to a non-descendant class is treated as unknown
+
+If a discriminator value camelizes to the name of a class that is not a descendant of the STI
+root (e.g. a taxonomy value of `meta` resolving to `CamaleonCms::Meta`), the system SHALL treat
+the value as unknown and instantiate the STI root, rather than instantiating an unrelated class
+against the wrong table.
+
+#### Scenario: A taxonomy value naming an unrelated class loads as the root
+
+- **WHEN** a `term_taxonomy` row's `taxonomy` is `meta`
+- **THEN** loading it returns a `CamaleonCms::TermTaxonomy` instance, not `CamaleonCms::Meta`

--- a/openspec/specs/user-deletion-content-reassignment/spec.md
+++ b/openspec/specs/user-deletion-content-reassignment/spec.md
@@ -1,0 +1,52 @@
+## Purpose
+
+Define what happens to a deleted user's content: comments are reassigned to the site's anonymous user, widgets survive, posts move to a surviving admin or are detached, and comments orphaned by the post-2.9.2 regression render safely and are repairable by rake task.
+
+## Requirements
+
+### Requirement: A deleted user's comments are reassigned to the site's anonymous user
+
+When a user is destroyed, every comment they authored SHALL be reassigned to the owning site's
+anonymous user (created on demand by `Site#get_anonymous_user`) — never left with a `NULL`
+`user_id`. Comment rendering after the deletion SHALL keep working.
+
+#### Scenario: Comment survives its author's deletion
+
+- **WHEN** a user who commented on another user's post is destroyed
+- **THEN** the comment still exists and its `user_id` is the site's anonymous user's id
+- **AND** `the_author_name` on the decorated comment renders without error
+
+### Requirement: A deleted user's widgets survive
+
+Destroying a user SHALL NOT destroy the widgets they created; sidebar widgets keep rendering
+after their creator's account is removed, as on 2.9.2.
+
+#### Scenario: Widget survives its creator's deletion
+
+- **WHEN** a user who created a sidebar widget is destroyed
+- **THEN** the widget row still exists
+
+### Requirement: A deleted user's posts go to a surviving admin, else are detached
+
+`before_destroy` reassignment of the deleted user's posts (and the comments on them) to another
+admin of the same site SHALL be attempted first; posts with no surviving admin SHALL have
+`user_id` set to `NULL` rather than keeping a dangling id.
+
+#### Scenario: Posts move to the surviving admin
+
+- **WHEN** a site has a second admin and a post author is destroyed
+- **THEN** the author's posts belong to the surviving admin
+
+### Requirement: Comment rendering tolerates a missing author and orphans are repairable
+
+`PostCommentDecorator#the_user`, `#the_author_name`, and `#the_author_email` SHALL NOT raise when
+the comment's user is missing (rows orphaned while the regression was live).
+`rake camaleon_cms:reassign_orphaned_comments` SHALL reassign comments with a missing user to the
+owning site's anonymous user, and SHALL NOT modify comments whose user exists.
+
+#### Scenario: Orphaned comment renders and is repaired
+
+- **WHEN** a comment row's `user_id` is `NULL`
+- **THEN** `the_author_name` returns blank output instead of raising
+- **AND** after running `camaleon_cms:reassign_orphaned_comments` the comment's `user_id` is the
+  site's anonymous user's id

--- a/spec/lib/tasks/orphaned_comments_rake_spec.rb
+++ b/spec/lib/tasks/orphaned_comments_rake_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'orphaned_comments Rake task', type: :task do
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rails.application.load_tasks
+  end
+
+  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rake::Task['camaleon_cms:reassign_orphaned_comments'].clear
+  end
+
+  describe 'camaleon_cms:reassign_orphaned_comments' do
+    let(:task) { Rake::Task['camaleon_cms:reassign_orphaned_comments'] }
+    let(:site) { CamaleonCms::Site.first }
+    let(:post_type) { site.post_types.find_by(slug: 'post') }
+    let(:author) { create(:user) }
+    let(:post_record) do
+      post_type.add_post(title: 'Orphan fixture', slug: 'orphan-fixture-post', content: 'body',
+                         user_id: author.id)
+    end
+
+    before { task.reenable }
+
+    it 'reassigns comments with a missing user to the anonymous user' do
+      orphan = post_record.comments.create!(user_id: author.id, content: 'orphaned', approved: 'approved')
+      orphan.update_column(:user_id, nil) # rubocop:disable Rails/SkipsModelValidations
+
+      task.invoke
+
+      expect(orphan.reload.user_id).to eq(site.get_anonymous_user.id)
+    end
+
+    it 'leaves comments with an existing user untouched' do
+      kept = post_record.comments.create!(user_id: author.id, content: 'kept', approved: 'approved')
+
+      task.invoke
+
+      expect(kept.reload.user_id).to eq(author.id)
+    end
+  end
+end

--- a/spec/models/association_target_integrity_spec.rb
+++ b/spec/models/association_target_integrity_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Association target integrity', type: :model do
+  let(:site) { CamaleonCms::Site.first }
+  let(:post_type) { site.post_types.find_by(slug: 'post') }
+  let(:user) { create(:user) }
+
+  describe 'owner associations' do
+    it 'returns the owning user for a category' do
+      category = post_type.categories.create!(name: 'Owned category', slug: 'owned-category-x', user_id: user.id)
+
+      expect { category.owner }.not_to raise_error
+      expect(category.owner.id).to eq(user.id)
+      expect(category.decorate.the_owner).to be_present
+    end
+
+    it 'never raises InverseOfAssociationNotFoundError on any owner reader' do
+      [CamaleonCms::Category, CamaleonCms::PostType, CamaleonCms::PostTag, CamaleonCms::Widget::Main].each do |klass|
+        expect { klass.new.owner }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'site.nav_menu_items' do
+    # The inverse is applied when the collection is fully loaded (enumeration), which is
+    # where the wrong `inverse_of: :parent` overwrote each item's NavMenu with the Site.
+    it 'keeps the NavMenu as the parent of items loaded through the site' do
+      menu = site.nav_menus.create!(name: 'Integrity menu', slug: 'integrity-menu-x')
+      item = menu.append_menu_item(label: 'Item', link: '/item', type: 'custom', target: '')
+      item.update_column(:term_group, site.id) if item.term_group.blank? # rubocop:disable Rails/SkipsModelValidations
+
+      loaded = site.nav_menu_items.to_a.find { |i| i.id == item.id }
+
+      expect(loaded.parent).to eq(menu)
+      expect(loaded.parent).to be_a(CamaleonCms::NavMenu)
+    end
+  end
+
+  describe 'post.drafts' do
+    it 'wires the parent inverse and keeps the author as owner' do
+      parent = post_type.add_post(title: 'Draft parent', slug: 'draft-parent-x', content: 'body',
+                                  user_id: user.id)
+      post_type.posts.create!(title: 'Autosave', slug: 'draft-child-x', status: 'draft_child',
+                              post_parent: parent.id, user_id: user.id, content: 'draft body')
+
+      loaded_draft = CamaleonCms::Post.find(parent.id).drafts.to_a.first
+
+      expect(loaded_draft.owner).not_to be_a(CamaleonCms::Post)
+      expect(loaded_draft.owner.id).to eq(user.id)
+      expect(loaded_draft.association(:parent)).to be_loaded
+      expect(loaded_draft.parent.id).to eq(parent.id)
+    end
+  end
+end

--- a/spec/models/sti_discriminator_compatibility_spec.rb
+++ b/spec/models/sti_discriminator_compatibility_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'STI discriminator compatibility', type: :model do
+  let(:conn) { ActiveRecord::Base.connection }
+
+  def insert_row(table, columns)
+    now = conn.quote(Time.current)
+    cols = "#{columns.keys.join(', ')}, created_at, updated_at"
+    vals = "#{columns.values.map { |v| conn.quote(v) }.join(', ')}, #{now}, #{now}"
+    conn.execute("INSERT INTO #{table} (#{cols}) VALUES (#{vals})")
+    conn.select_value("SELECT MAX(id) FROM #{table}")
+  end
+
+  describe 'term_taxonomy discriminator' do
+    let(:table) { CamaleonCms::TermTaxonomy.table_name }
+
+    it 'reads an existing row with a custom taxonomy value as the STI root' do
+      id = insert_row(table, taxonomy: 'custom_tax', name: 'Custom Row')
+
+      record = CamaleonCms::TermTaxonomy.find(id)
+
+      expect(record).to be_instance_of(CamaleonCms::TermTaxonomy)
+      expect(record.taxonomy).to eq('custom_tax')
+    end
+
+    it 'loads relations that include custom-taxonomy rows' do
+      insert_row(table, taxonomy: 'custom_tax', name: 'Custom Relation Row')
+
+      expect { CamaleonCms::TermTaxonomy.where(name: 'Custom Relation Row').to_a }.not_to raise_error
+    end
+
+    it 'creates and persists a record with a custom taxonomy value' do
+      record = CamaleonCms::TermTaxonomy.new(taxonomy: 'custom_tax', name: 'Created Custom')
+      record.save!
+
+      expect(record.reload.taxonomy).to eq('custom_tax')
+    end
+
+    it 'still resolves built-in values to their subclasses' do
+      category = CamaleonCms::Category.first
+
+      expect(CamaleonCms::TermTaxonomy.find(category.id)).to be_instance_of(CamaleonCms::Category)
+    end
+
+    it 'treats a value resolving to a non-descendant class as unknown' do
+      id = insert_row(table, taxonomy: 'meta', name: 'Impostor Row')
+
+      expect(CamaleonCms::TermTaxonomy.find(id)).to be_instance_of(CamaleonCms::TermTaxonomy)
+    end
+  end
+
+  describe 'posts discriminator' do
+    let(:table) { CamaleonCms::PostDefault.table_name }
+
+    it 'reads a row with an unknown post_class as the STI root' do
+      id = insert_row(table, post_class: 'External::Unknown', title: 'Foreign Post', status: 'published')
+
+      record = CamaleonCms::PostDefault.find(id)
+
+      expect(record).to be_instance_of(CamaleonCms::PostDefault)
+      expect(record.post_class).to eq('External::Unknown')
+    end
+  end
+end

--- a/spec/models/user_deletion_spec.rb
+++ b/spec/models/user_deletion_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'User deletion content reassignment', type: :model do
+  let(:site) { CamaleonCms::Site.first }
+  let(:post_type) { site.post_types.find_by(slug: 'post') }
+  let(:author) { create(:user) }
+  let(:commenter) { create(:user) }
+  let(:post_record) do
+    post_type.add_post(title: 'Deletion fixture', slug: 'deletion-fixture-post', content: 'body',
+                       user_id: author.id)
+  end
+
+  it "reassigns the deleted user's comments to the site's anonymous user" do
+    comment = post_record.comments.create!(user_id: commenter.id, content: 'nice post', approved: 'approved')
+
+    commenter.destroy!
+
+    expect(comment.reload.user_id).to eq(site.get_anonymous_user.id)
+  end
+
+  it 'keeps comment rendering working after the author is deleted' do
+    comment = post_record.comments.create!(user_id: commenter.id, content: 'nice post', approved: 'approved')
+
+    commenter.destroy!
+
+    expect(comment.reload.decorate.the_author_name).to include('Anonymous')
+  end
+
+  it "does not destroy the deleted user's widgets" do
+    widget = site.widgets.create!(name: 'Deletion widget', slug: 'deletion-widget-x', user_id: commenter.id)
+
+    commenter.destroy!
+
+    expect(CamaleonCms::Widget::Main.exists?(widget.id)).to be(true)
+  end
+
+  it "moves the deleted user's posts to a surviving admin" do
+    admin = site.users.admin_scope.first
+    post_record
+
+    author.destroy!
+
+    expect(post_record.reload.user_id).to eq(admin.id)
+  end
+
+  describe 'orphan tolerance' do
+    it 'renders a blank author instead of raising when the user is missing' do
+      comment = post_record.comments.create!(user_id: commenter.id, content: 'orphan me', approved: 'approved')
+      comment.update_column(:user_id, nil) # rubocop:disable Rails/SkipsModelValidations
+
+      decorated = comment.reload.decorate
+
+      expect { decorated.the_author_name }.not_to raise_error
+      expect(decorated.the_user).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

The `2.9.2..master` regression audit identified PR #1173 (native Rails STI for taxonomies and posts, merged without a changelog entry) as the largest source of unresolved high-severity regressions. This PR fixes that cluster — audit items H8, H9, and the wrong `inverse_of` declarations — as planned in the `fix-1173-fallout-batch` OpenSpec change (archived on this branch). Every fix was demonstrated red→green by a spec reproducing the regression before the fix:

- **STI discriminator tolerance (H8)**: `find_sti_class` on `TermTaxonomy` and `PostDefault` falls back to the STI root for unknown discriminator values, so existing rows with custom `taxonomy`/`post_class` values — plugin-created or legacy — load and save again instead of raising `ActiveRecord::SubclassNotFound` (which fired on read, create, relation loads, and site-destroy sweeps). A value that resolves to a class outside the hierarchy (e.g. a taxonomy of `meta` naming `CamaleonCms::Meta`) is treated as unknown rather than instantiated against the wrong table. Built-in values keep resolving to their subclasses.
- **User deletion (H9)**: `dependent: :nullify` on `all_comments` ran before `after_destroy :reassign_comments` and emptied its working set, so deleted users' comments were orphaned instead of reassigned to the site's anonymous user, and comment rendering then crashed on the missing user; the user's widgets were also hard-destroyed. Both behaviors are restored to 2.9.2 semantics; `all_posts` keeps its nullify (it only affects the no-surviving-admin case, where 2.9.2 left dangling ids). `PostCommentDecorator` is now nil-safe for rows orphaned while the regression was live — which also fixes a pre-existing crash: its fallback called `User#full_name`, a method that has never existed (`fullname` is the real one), so any comment stored without an author string 500ed even with a live user. A new `rake camaleon_cms:reassign_orphaned_comments` repairs orphaned rows.
- **Association inverses**: `owner` on `TermTaxonomy`/`PostType`/`PostTag` named user-side associations that have never existed, so any `.owner` read raised `InverseOfAssociationNotFoundError` and `the_owner` silently returned nil; `owner` on `Widget::Main` was valid only for the built-in user model and raised for host apps with a custom `user_model`. These become `inverse_of: false`. `Site#nav_menu_items` joins by `term_group` (the site id) while `NavMenuItem#parent` reads `parent_id` (the menu id) — the inverse overwrote items' real menu parent with the Site on collection loads, so it also becomes `inverse_of: false`. `Post#drafts` had an inert, type-mismatched `inverse_of: :owner` and now carries the correct `inverse_of: :parent`.

Design decisions and alternatives are recorded in the archived change's `design.md`. The remaining audit highs (content sanitization scope, theme activation, upload rejections) are separate follow-ups.

## User-Visible Impact

Installs with custom taxonomy or post-class rows stop crashing; deleting a user no longer orphans their comments or deletes their widgets (operators who deleted users on a master-era build can run `rake camaleon_cms:reassign_orphaned_comments` once); and `owner`/`parent` association reads return the right records instead of raising or mislabeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)