### PR TITLE
Fix content-sanitization scope (H7) and camaleon_first theme activation (H10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+- **Fix:** Save-time post-content sanitization ([#1206](https://github.com/owen2345/camaleon-cms/pull/1206))
+  destroyed legitimate markup for untrusted authors — the default allowlist has no table or figure
+  elements and drops `id`/`style`/`target`/`rel` — and sanitized every programmatic save with no
+  opt-out. Untrusted `Post#content` now keeps structural, non-executable markup (tables, figures,
+  `u`/`s`/`hr`, and `id`/`style`/`target`/`rel`/`colspan`/`rowspan`) while still stripping scripts,
+  iframes, event handlers, and `javascript:`/style-expression payloads. Also restores activation of
+  the bundled `camaleon_first` theme, which 500'd on a `helper.capture` call in controller context.
+  [#1225](https://github.com/owen2345/camaleon-cms/pull/1225).
+
+  **Notes for upgraders**
+
+  - **Trusted server-side code can bypass sanitization per record** with
+    `post.unfiltered_content!` before save (imports, seeds, plugin pipelines). It has no `=`
+    writer, so it is not mass-assignable and request parameters cannot set it.
+  - Role gating is unchanged: admins and roles holding `post_content_unfiltered_html` still store
+    raw HTML; the Editor default is still excluded. Content stripped before this release is not
+    restored — re-add it and it now persists.
+
 - **Fix:** Fallout from the native-STI conversion ([#1173](https://github.com/owen2345/camaleon-cms/pull/1173),
   which shipped with no changelog entry): rows with custom `taxonomy`/`post_class` values raised
   `SubclassNotFound` on read and create — they load and save as the base class again; deleting a

--- a/app/apps/themes/camaleon_first/main_helper.rb
+++ b/app/apps/themes/camaleon_first/main_helper.rb
@@ -32,31 +32,14 @@ module Themes
         group.add_field(
           { 'name' => 'Column Center', 'slug' => 'footer_center' },
           { field_key: 'editor', translate: true,
-            default_value: helper.capture do
-              helper.safe_join([
-                                 helper.content_tag(:h4, 'My Links'),
-                                 helper.content_tag(:p) do
-                                   helper.safe_join([
-                                                      helper.link_to('Dribbble', '#'), helper.tag(:br), ' ',
-                                                      helper.link_to('Twitter', '#'), helper.tag(:br), ' ',
-                                                      helper.link_to('Facebook', '#')
-                                                    ])
-                                 end
-                               ])
-            end }
+            default_value: "<h4>My Links</h4> <p><a href='#'>Dribbble</a><br> " \
+                           "<a href='#'>Twitter</a><br> <a href='#'>Facebook</a></p>" }
         )
         group.add_field(
           { 'name' => 'Column Right', 'slug' => 'footer_right' },
           { field_key: 'editor', translate: true,
-            default_value: helper.capture do
-              helper.safe_join([
-                                 helper.content_tag(:h4, 'About Theme'),
-                                 helper.content_tag(
-                                   :p,
-                                   'This cute theme was created to showcase your work in a simple way. Use it wisely.'
-                                 )
-                               ])
-            end }
+            default_value: '<h4>About Theme</h4><p>This cute theme was created to showcase your work ' \
+                           'in a simple way. Use it wisely.</p>' }
         )
       end
 

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -2,6 +2,27 @@ module CamaleonCms
   class Post < CamaleonCms::PostDefault
     include CamaleonCms::CategoriesTagsForPosts
 
+    # Structural, non-executable markup that long-form post content legitimately uses but the
+    # sanitizer default drops. Superset of the default so upstream security additions are inherited.
+    SANITIZE_EXTRA_TAGS = %w[table thead tbody tfoot tr td th caption col colgroup
+                             figure figcaption u s hr].freeze
+    SANITIZE_EXTRA_ATTRIBUTES = %w[id style target rel colspan rowspan].freeze
+    CONTENT_ALLOWED_TAGS = (ActionController::Base.helpers.sanitizer_vendor.safe_list_sanitizer
+                              .allowed_tags.to_a + SANITIZE_EXTRA_TAGS).uniq.freeze
+    CONTENT_ALLOWED_ATTRIBUTES = (ActionController::Base.helpers.sanitizer_vendor.safe_list_sanitizer
+                                    .allowed_attributes.to_a + SANITIZE_EXTRA_ATTRIBUTES).uniq.freeze
+
+    # Opt-out for trusted server-side pipelines (imports, seeds, plugin code) that would otherwise
+    # be sanitized by the fail-closed default. Exposed as a reader plus a bang enabler and NO
+    # `unfiltered_content=` writer, so `assign_attributes`/mass assignment cannot reach it — only
+    # explicit server-side code calling `post.unfiltered_content!` can.
+    attr_reader :unfiltered_content
+
+    def unfiltered_content!
+      @unfiltered_content = true
+      self
+    end
+
     alias_attribute :post_type_id, :taxonomy_id
     default_scope -> { where(post_class: 'Post').order(post_order: :asc, created_at: :desc) }
 
@@ -270,11 +291,15 @@ module CamaleonCms
     def sanitize_content
       return unless new_record? || attribute_changed?(:content)
       return if content.blank?
+      # The explicit pipeline opt-out short-circuits before the Ability lookup below.
+      return if unfiltered_content
       # Check trust only once we know there is content to sanitize, so unchanged/blank updates never pay for
       # building an Ability (a role-meta DB lookup) on every save.
       return if trusted_for_unfiltered_html?
 
-      self.content = CamaleonRecord.cama_sanitize_translatable(content)
+      self.content = CamaleonRecord.cama_sanitize_translatable(
+        content, tags: CONTENT_ALLOWED_TAGS, attributes: CONTENT_ALLOWED_ATTRIBUTES
+      )
     end
 
     # calculate a post order when it is empty

--- a/app/models/camaleon_record.rb
+++ b/app/models/camaleon_record.rb
@@ -26,12 +26,16 @@ class CamaleonRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRec
 
   # Sanitize a value with ActionController's sanitize() while preserving translation locale markers
   # (<!--:xx-->). Shared by Post#sanitize_content and the NormalizeAttrs concern so the transform lives in
-  # one place. Returns nil unchanged.
-  def self.cama_sanitize_translatable(value)
+  # one place. Returns nil unchanged. `tags:`/`attributes:` default to nil, i.e. the sanitizer's own
+  # allowlist, so NormalizeAttrs and other callers are unaffected; Post#content passes a widened list.
+  def self.cama_sanitize_translatable(value, tags: nil, attributes: nil)
     return value if value.nil?
 
+    options = {}
+    options[:tags] = tags if tags
+    options[:attributes] = attributes if attributes
     ActionController::Base.helpers.sanitize(
-      value.to_s.gsub(TRANSLATION_TAG_HIDE_REGEX, TRANSLATION_TAG_HIDE_MAP)
+      value.to_s.gsub(TRANSLATION_TAG_HIDE_REGEX, TRANSLATION_TAG_HIDE_MAP), **options
     ).gsub(TRANSLATION_TAG_RESTORE_REGEX, TRANSLATION_TAG_RESTORE_MAP)
   end
 

--- a/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/design.md
+++ b/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/design.md
@@ -1,0 +1,83 @@
+# Design: fix-content-sanitization-scope
+
+## Context
+
+#1206 added `Post#before_validation :sanitize_content` using
+`ActionController::Base.helpers.sanitize` with no allowlist argument, i.e. the Rails default
+(`Rails::HTML5::SafeListSanitizer` defaults). The audit (H7) confirmed two collateral problems:
+the default allowlist has no table/figure elements and drops `id`/`style`/`target`/`rel`, so
+untrusted authors lose legitimate structure on every save; and the fail-closed rule sanitizes all
+saves without a `CurrentRequest.user`, so developer-controlled pipelines are mutated with no
+escape hatch. The security goal — no stored executable content from untrusted authors — is not in
+question and is preserved unchanged. H10 (theme activation) ships in the same branch as a
+one-line restoration; it has no capability of its own.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Stop destroying legitimate structural markup on untrusted post saves.
+- Give trusted server-side code an explicit, non-mass-assignable opt-out.
+- Keep the executable-content posture byte-for-byte as strict as today.
+
+**Non-Goals:**
+
+- Backfilling `post_content_unfiltered_html` onto existing Editor/custom roles — that is a
+  deliberate security default (documented in the capability), and widening the allowlist already
+  removes the day-to-day pain (tables/embeds-by-attribute) without granting script capability.
+- Allowing `iframe`/`video`/`audio`/`embed` for untrusted authors — those remain admin-only via
+  the existing permission; YouTube-style embeds are exactly the trusted-role case.
+- Touching `NormalizeAttrs` (descriptions, `NavMenuItem#name`) — their strict defaults are correct
+  for short plain-text-ish fields.
+
+## Decisions
+
+- **D1 — Widen the allowlist as a superset of the sanitizer default, not a hand-rolled list:**
+  the constants are `Rails::HTML5::SafeListSanitizer.allowed_tags + EXTRA_TAGS` and the attribute
+  equivalent, so upstream security fixes to the base list are inherited and we only ever add.
+  Rejected: a fixed literal list (drifts from upstream), or switching sanitizer backends
+  (needless blast radius).
+- **D2 — `style` is allowed but relies on the sanitizer's own CSS scrubber:** loofah/rails-html
+  strips `expression()`, `url(javascript:…)`, and behaviour properties from `style` values, so
+  allowing the attribute restores inline layout without opening a script vector. The requirement
+  states "scrubbed", and a spec asserts a script-bearing style is neutralized while a plain one
+  survives.
+- **D3 — Opt-out via a reader + `unfiltered_content!` bang enabler with no `=` writer, checked
+  first in `sanitize_content`:** a plain `attr_accessor` is in fact mass-assignable at the model
+  level — `Post.new(unfiltered_content: true)` would set it, since strong parameters only guard
+  the controller. Exposing a reader plus a bang method and no `unfiltered_content=` writer means
+  `assign_attributes` has nothing to call, so mass assignment raises `UnknownAttributeError`
+  instead of silently flipping a security-sensitive flag. `sanitize_content` returns early when
+  the flag is set. Rejected: a plain accessor (mass-assignable, the bug this avoids); a private
+  writer (`respond_to?` is false, so mass assignment still raises, but the intent reads less
+  clearly than a named bang); a thread/CurrentAttributes flag (leaks across records). Ordering:
+  the opt-out check comes before the trust check so it also short-circuits the Ability lookup.
+- **D4 — `cama_sanitize_translatable` gains optional `tags:`/`attributes:` keyword args
+  defaulting to `nil`:** when nil it behaves exactly as today (sanitizer default), so
+  `NormalizeAttrs` and every other caller are untouched; `Post#sanitize_content` passes the
+  widened lists explicitly. Keeps the translation-marker hide/restore logic in one place.
+- **D5 — H10 restores plain string literals** (the 2.9.2 form) for the two footer field defaults,
+  rather than swapping `helper.` for `helpers.`: the values are static HTML, so a literal is
+  simplest and removes the controller-context dependency entirely. A feature spec activates the
+  bundled theme end-to-end so the hook actually runs.
+
+## Risks / Trade-offs
+
+- [A theme/plugin matching on the exact old sanitized output of untrusted content sees more tags
+  now] → the change only *adds* preserved tags; nothing previously stripped-and-relied-upon
+  changes, and trusted output was never sanitized. Acceptably low.
+- [`style` retention depends on the sanitizer's CSS scrubber being sound] → it is the same
+  scrubber the framework ships for all `sanitize` calls; if it has a hole, every Rails app shares
+  it. A spec pins the script-in-style case.
+- [Opt-out misuse could re-introduce stored XSS if a developer sets it on request-derived
+  content] → it is server-only and non-mass-assignable by design; the requirement and a spec
+  enforce that params cannot set it.
+
+## Migration Plan
+
+No schema or data migration. Content stripped before this change is not restored (the original
+input is gone); authors re-adding tables/embeds simply keep them now. Operators need do nothing.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/proposal.md
+++ b/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/proposal.md
@@ -1,0 +1,49 @@
+# Proposal: fix-content-sanitization-scope
+
+## Why
+
+The `2.9.2..master` regression audit (H7) confirmed that #1206's save-time sanitization destroys
+legitimate content far beyond its security intent: the Rails default allowlist silently strips
+tables, figures, and common attributes (`style`, `id`, `target`, `rel`) from every untrusted
+save, and the fail-closed rule sanitizes *all* out-of-request saves — rake imports, seeds, and
+plugin pipelines mutate developer-controlled content with no way to opt out. The audit also
+confirmed H10: activating the bundled `camaleon_first` theme 500s mid-activation because a
+Rubocop line-length rewrite introduced `helper.capture` calls into a hook that runs in controller
+context (fixed in the same branch as a trivial restoration, outside this change's capability
+scope).
+
+## What Changes
+
+- Untrusted post saves keep structural, non-executable markup: table elements
+  (`table thead tbody tfoot tr td th caption col colgroup`), `figure`/`figcaption`, `u`, `s`,
+  `hr`, and the attributes `id`, `style` (CSS-scrubbed by the sanitizer), `target`, `rel`,
+  `colspan`, `rowspan`. Scripts, iframes, event handlers, and `javascript:` URLs stay stripped;
+  the security posture for executable content is unchanged. The widened lists apply to
+  `Post#content` only — `NormalizeAttrs` consumers (descriptions, `NavMenuItem#name`) keep the
+  strict defaults.
+- Developer-controlled pipelines get an explicit opt-out: calling `post.unfiltered_content!`
+  before save stores content unchanged. It is exposed with no `=` writer, so it is not
+  mass-assignable; without it, out-of-request saves keep failing closed exactly as specified
+  today.
+- No change to role gating: admins bypass via `manage :all`, the `post_content_unfiltered_html`
+  grant works per post type, and the Editor exclusion stays (deliberately not backfilled).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `post-content-sanitization`: the untrusted-save requirement gains the structural-markup
+  preservation contract, and the no-user-context requirement gains the explicit
+  `unfiltered_content` opt-out for developer-controlled saves.
+
+## Impact
+
+- `app/models/camaleon_cms/post.rb` (allowlist constants, opt-out accessor, sanitize call)
+- `app/models/camaleon_record.rb` (`cama_sanitize_translatable` accepts optional
+  `tags:`/`attributes:`; callers without arguments are unaffected)
+- `app/apps/themes/camaleon_first/main_helper.rb` (H10: string literals restore activation)
+- `spec/models/post_content_sanitization_spec.rb`, `spec/features/admin/themes_spec.rb`

--- a/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/specs/post-content-sanitization/spec.md
+++ b/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/specs/post-content-sanitization/spec.md
@@ -1,9 +1,5 @@
-# post-content-sanitization
+## MODIFIED Requirements
 
-## Purpose
-
-Prevent stored XSS via post content by applying server-side HTML sanitization at save time for untrusted users, while preserving raw HTML capability for trusted roles (admins and roles with the `post_content_unfiltered_html` permission). This closes the gap where post content is rendered with `raw @post.the_content` in templates without any server-side filtering.
-## Requirements
 ### Requirement: Untrusted users' post content is sanitized at save time
 The system SHALL apply server-side HTML sanitization to `Post#content` when the current user lacks the `post_content_unfiltered_html` permission for the associated post type. Dangerous tags and attributes (including `<script>`, `<iframe>`, event handlers like `onerror`/`onload`, and `javascript:` URLs) MUST be stripped before persistence.
 
@@ -38,17 +34,6 @@ The allowlist SHALL preserve the structural, non-executable markup that long-for
 - **THEN** the persisted content SHALL retain `id`, the scrubbed `style`, `target`, and `rel`
 - **AND** the `onclick` attribute SHALL be removed
 
-### Requirement: Trusted users' post content bypasses sanitization
-The system SHALL store post content unchanged (no sanitization) when the current user has the `post_content_unfiltered_html` permission for the associated post type. This preserves backward compatibility for administrators and trusted editors who need raw HTML capabilities.
-
-#### Scenario: Admin saves post with embedded content
-- **WHEN** an admin (who has `can :manage, :all` or explicit `post_content_unfiltered_html` permission) saves a post with content containing `<iframe src="https://example.com/embed"></iframe>`
-- **THEN** the persisted content SHALL contain the `<iframe>` element unchanged
-
-#### Scenario: Editor with unfiltered_html permission saves script
-- **WHEN** a user with the `editor` role that has `post_content_unfiltered_html` enabled on the post type saves post content with `<script>validAppCode()</script>`
-- **THEN** the persisted content SHALL contain the `<script>` element unchanged
-
 ### Requirement: Content sanitization does not apply when user context is absent
 The system SHALL apply strict sanitization (same as untrusted user) when no user context is available (background jobs, rake tasks, console operations) to ensure security by default.
 
@@ -68,27 +53,3 @@ The system SHALL also expose an explicit per-record opt-out for developer-contro
 #### Scenario: The opt-out has no mass-assignment writer
 - **WHEN** `unfiltered_content` is supplied in a request-style attributes hash to a new post
 - **THEN** no `unfiltered_content=` writer SHALL exist to receive it (mass assignment raises `UnknownAttributeError` rather than enabling the opt-out)
-
-### Requirement: post_content_unfiltered_html permission key exists in the role system
-The system SHALL define a `post_content_unfiltered_html` key in `UserRole::ROLES[:post_type]` that can be assigned per post type per role. The key MUST be surfaced in the admin UI alongside existing post-type permission keys.
-
-The key name SHALL state its subject. It governs `Post#content` only, and is distinct from the manager-family key `contact_form_unfiltered_html`, which governs contact-form content under `contact-form-output-escaping`. Holding either SHALL NOT imply the other. The permission is checked as `can?(:post_content_unfiltered_html, post_type)`; the ability name and the role-meta key are deliberately identical, matching how manager-family keys resolve through `Ability#define_manage_rules`.
-
-The two capabilities also differ in remedy, and the difference is deliberate: post content is sanitized on save, while a contact-form save is refused outright. Post content is long-form prose where silently dropping a disallowed tag is a reasonable trade; a contact-form definition is configuration, where the author needs to know their change did not take effect.
-
-#### Scenario: Admin can grant unfiltered HTML permission to a role
-- **WHEN** an admin edits a role's post-type permissions in the admin panel
-- **THEN** a `post_content_unfiltered_html` checkbox or toggle SHALL be present for each post type
-- **AND** enabling it SHALL persist the setting for that role and post type
-
-#### Scenario: Default admin role has unfiltered HTML permission
-- **WHEN** a new site is created with default roles (seeded via `SiteDefaultSettings`)
-- **THEN** the admin role SHALL have `post_content_unfiltered_html` enabled (via `can :manage, :all`)
-- **AND** the editor role SHALL NOT have `post_content_unfiltered_html` enabled by default — it is explicitly skipped during seed to prevent non-admin editors from storing raw scripts
-- **AND** the contributor role SHALL NOT have `post_content_unfiltered_html` enabled
-
-#### Scenario: Holding the post-content grant does not widen contact-form trust
-- **WHEN** a user holds `post_content_unfiltered_html` on every post type but not `:manage, :contact_form_unfiltered_html`
-- **AND** that user saves a contact form whose `previous_html` contains `<script>alert(1)</script>`
-- **THEN** the save SHALL be refused and nothing SHALL be persisted
-

--- a/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/tasks.md
+++ b/openspec/changes/archive/2026-08-03-fix-content-sanitization-scope/tasks.md
@@ -1,0 +1,26 @@
+# Tasks: fix-content-sanitization-scope
+
+## 1. Red specs
+
+- [x] 1.1 Sanitization scope specs: untrusted table markup + `colspan` preserved;
+  `id`/`style`/`target`/`rel` preserved while `onclick`/script-in-style neutralized
+- [x] 1.2 Opt-out specs: `unfiltered_content!` stores raw content with no user context;
+  no `unfiltered_content=` writer exists (mass assignment raises `UnknownAttributeError`)
+- [x] 1.3 H10 feature spec: activating the bundled `camaleon_first` theme succeeds
+
+## 2. Implementation
+
+- [x] 2.1 Add `CONTENT_ALLOWED_TAGS`/`CONTENT_ALLOWED_ATTRIBUTES` (superset of the sanitizer
+  default) and pass them from `Post#sanitize_content`; add the reader + `unfiltered_content!`
+  bang enabler (no `=` writer) and early-return on it
+- [x] 2.2 `cama_sanitize_translatable` accepts optional `tags:`/`attributes:` (default nil =
+  current behavior)
+- [x] 2.3 H10: replace the two `helper.capture` footer defaults in `camaleon_first/main_helper.rb`
+  with the static HTML string literals
+
+## 3. Verification and close-out
+
+- [x] 3.1 Red→green; full gates (`bin/rspec`, `bin/rubocop`, `bin/brakeman --no-pager`,
+  `(cd spec/dummy && bin/rails zeitwerk:check)`)
+- [x] 3.2 PR + changelog entry (allowlist widening + opt-out + theme-activation fix)
+- [x] 3.3 Archive this change on the branch as part of the PR

--- a/spec/dummy/app/apps/themes/camaleon_first/main_helper.rb
+++ b/spec/dummy/app/apps/themes/camaleon_first/main_helper.rb
@@ -32,31 +32,14 @@ module Themes
         group.add_field(
           { 'name' => 'Column Center', 'slug' => 'footer_center' },
           { field_key: 'editor', translate: true,
-            default_value: helper.capture do
-              helper.safe_join([
-                                 helper.content_tag(:h4, 'My Links'),
-                                 helper.content_tag(:p) do
-                                   helper.safe_join([
-                                                      helper.link_to('Dribbble', '#'), helper.tag(:br), ' ',
-                                                      helper.link_to('Twitter', '#'), helper.tag(:br), ' ',
-                                                      helper.link_to('Facebook', '#')
-                                                    ])
-                                 end
-                               ])
-            end }
+            default_value: "<h4>My Links</h4> <p><a href='#'>Dribbble</a><br> " \
+                           "<a href='#'>Twitter</a><br> <a href='#'>Facebook</a></p>" }
         )
         group.add_field(
           { 'name' => 'Column Right', 'slug' => 'footer_right' },
           { field_key: 'editor', translate: true,
-            default_value: helper.capture do
-              helper.safe_join([
-                                 helper.content_tag(:h4, 'About Theme'),
-                                 helper.content_tag(
-                                   :p,
-                                   'This cute theme was created to showcase your work in a simple way. Use it wisely.'
-                                 )
-                               ])
-            end }
+            default_value: '<h4>About Theme</h4><p>This cute theme was created to showcase your work ' \
+                           'in a simple way. Use it wisely.</p>' }
         )
       end
 

--- a/spec/features/admin/themes_spec.rb
+++ b/spec/features/admin/themes_spec.rb
@@ -17,4 +17,14 @@ describe 'the Themes', :js do
     #   page.should have_selector 'body'
     # end
   end
+
+  # Activating camaleon_first runs its on_active hook in controller context, where the
+  # helper.capture-based field defaults raised NoMethodError after already switching the theme.
+  it 'activates the bundled camaleon_first theme without error' do
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/appearances/themes?set=camaleon_first"
+
+    expect(page).to have_css('#themes_page')
+    expect(CamaleonCms::Site.first.get_option('_theme')).to eq('camaleon_first')
+  end
 end

--- a/spec/models/post_content_sanitization_spec.rb
+++ b/spec/models/post_content_sanitization_spec.rb
@@ -178,5 +178,61 @@ RSpec.describe CamaleonCms::Post, type: :model do
         expect(post.content).to include('<p>Text</p>')
       end
     end
+
+    context 'when an untrusted user saves structural markup' do
+      it 'preserves table elements and colspan' do
+        assign_current_user(contributor)
+
+        post = create(:post, post_type: post_type, owner: contributor,
+                             content: '<table><thead><tr><th>H</th></tr></thead>' \
+                                      '<tbody><tr><td colspan="2">cell</td></tr></tbody></table>')
+
+        %w[<table> <thead> <tbody> <tr> <th> <td].each { |tag| expect(post.content).to include(tag) }
+        expect(post.content).to include('colspan="2"')
+      end
+
+      it 'keeps layout attributes while removing script vectors' do
+        assign_current_user(contributor)
+
+        post = create(:post, post_type: post_type, owner: contributor,
+                             content: '<p id="lead" style="color:red" onclick="alert(1)">t</p>' \
+                                      '<a href="/x" target="_blank" rel="noopener">l</a>')
+
+        expect(post.content).to include('id="lead"')
+        expect(post.content).to include('target="_blank"')
+        expect(post.content).to include('rel="noopener"')
+        expect(post.content).to include('color:red')
+        expect(post.content).not_to include('onclick')
+      end
+
+      it 'neutralizes a script payload hidden in a style attribute' do
+        assign_current_user(contributor)
+
+        post = create(:post, post_type: post_type, owner: contributor,
+                             content: '<p style="width: expression(alert(1))">t</p>')
+
+        expect(post.content).not_to include('expression(')
+      end
+    end
+
+    context 'with the developer opt-out' do
+      it 'stores raw content when unfiltered_content! is set and no user context exists' do
+        CurrentRequest.user = nil
+        CurrentRequest.site = nil
+
+        post = build(:post, post_type: post_type, content: '<p>seed</p><script>seed()</script>')
+        post.unfiltered_content!
+        post.save!
+
+        expect(post.content).to include('<script>seed()</script>')
+      end
+
+      it 'has no mass-assignment writer, so request-style attributes cannot enable it' do
+        expect(described_class.new).not_to respond_to(:unfiltered_content=)
+        expect do
+          described_class.new(unfiltered_content: true)
+        end.to raise_error(ActiveModel::UnknownAttributeError)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What and Why

Two more highs from the `2.9.2..master` regression audit. H7 is planned in the `fix-content-sanitization-scope` OpenSpec change (archived on this branch, modifying the `post-content-sanitization` capability); H10 is a one-line restoration. Both were demonstrated red→green by specs reproducing the regression first.

**H7 — sanitization destroyed legitimate content.** [#1206](https://github.com/owen2345/camaleon-cms/pull/1206) added save-time sanitization for untrusted post authors using the Rails default allowlist, which has no table/figure elements and drops `id`/`style`/`target`/`rel`. So a contributor saving a table, a figure, or styled/anchored markup silently lost it on every save; and because the rule fails closed when there is no request user, every programmatic save (imports, seeds, plugin pipelines) was sanitized with no escape hatch.

- Untrusted `Post#content` now preserves structural, non-executable markup — the table family (`table thead tbody tfoot tr td th caption col colgroup`), `figure`/`figcaption`, `u`/`s`/`hr`, and the attributes `id style target rel colspan rowspan` — by allowing a **superset of the sanitizer's own default list**, so future upstream security additions are still inherited. Scripts, iframes, event handlers, `javascript:` URLs, and script-bearing `style` values remain stripped; the executable-content posture is unchanged.
- `post.unfiltered_content!` opts a single record out of sanitization for trusted server-side code. It is exposed as a reader plus a bang enabler with **no `unfiltered_content=` writer**, so `assign_attributes`/mass assignment cannot reach it — a plain `attr_accessor` would have been mass-assignable at the model level, since strong parameters only guard the controller.
- Role gating is unchanged: admins bypass via `manage :all`, the `post_content_unfiltered_html` grant works per post type, and the Editor exclusion stays (deliberately not backfilled — widening the allowlist removes the day-to-day pain without granting script capability).

**H10 — activating the bundled `camaleon_first` theme 500'd.** A Rubocop line-length rewrite turned two footer field defaults into `helper.capture` blocks, but the theme's `on_active` hook runs in controller context where the instance method `helper` does not exist, so activation raised `NoMethodError` after the site's `_theme` option had already switched (a partial activation). Both defaults are static HTML and go back to plain string literals.

Design decisions — including why the opt-out is a bang method rather than an accessor, and why `style` is safe to allow — are in the archived change's `design.md`. The remaining audit highs (H11/H12, upload rejections and path roots) are the last follow-up.

## User-Visible Impact

Contributors keep tables, figures, and layout attributes in post content instead of having them silently stripped; trusted server-side pipelines can opt a record out of sanitization; and activating the bundled `camaleon_first` theme works again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)