### PR TITLE
Do not memoize String#translations on a frozen receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Fix:** Validating a post without an explicit slug raised `FrozenError` instead of reporting
+  `Slug can't be blank`, so creating posts programmatically (imports, seeds, jobs, console) was
+  impossible. `String#translations` memoized its parsed locales in an instance variable on the
+  receiver, which Ruby 3.4's frozen `nil.to_s` cannot carry; frozen strings now parse without
+  memoizing. Long-standing, not a regression.
+  [#1227](https://github.com/owen2345/camaleon-cms/pull/1227).
+
 - **Fix:** The upload hardening in [#1198](https://github.com/owen2345/camaleon-cms/pull/1198)–[#1211](https://github.com/owen2345/camaleon-cms/pull/1211)
   rejected legitimate work: uploads staged outside `public/` or the system temp dir failed with
   `Invalid file path`, animated SVGs and re-crops of already-stored files were refused as

--- a/lib/ext/translator.rb
+++ b/lib/ext/translator.rb
@@ -34,6 +34,13 @@ class String
   # return hash of translations for this string
   # sample: {es: "hola mundo", en: "Hello World"}
   def translations
+    # A frozen receiver cannot carry the memo: Ruby 3.4's nil.to_s returns a frozen —
+    # and process-wide shared — empty string, and every literal in a file with the
+    # frozen_string_literal magic comment is frozen too. Parse without memoizing for
+    # those rather than raising FrozenError (memoizing on a shared instance would be
+    # wrong even where it is permitted).
+    return split_locales if frozen?
+
     @translations ||= split_locales
   end
 

--- a/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-03

--- a/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/design.md
+++ b/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/design.md
@@ -1,0 +1,68 @@
+# Design: add-multilingual-content-translation-spec
+
+## Context
+
+The inline locale-marker mechanism predates every existing capability in `openspec/specs/` and is
+implemented as monkey-patches in `lib/ext/translator.rb` (`String#translate`,
+`String#translations`, `String#translations_array`, `Hash#to_translate`, `Array#translate`) plus
+the sanitization sentinels in `app/models/camaleon_record.rb`. Two capabilities already lean on it
+without stating it — `post-content-sanitization` (markers must survive sanitization) and
+`escaped-title-composition` (transformations on translatable names). Writing it down was prompted
+by a defect this PR fixes: parsing memoized onto the receiver, so a frozen receiver raised
+`FrozenError`, and nothing recorded that parsing must not mutate what it reads.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Record the format and the resolution rules as they behave today, so future changes have
+  something to be checked against.
+- State the one property whose violation caused the defect: parsing must not depend on mutating
+  the receiver.
+
+**Non-Goals:**
+
+- Changing any behavior. This change adds no code; the accompanying fix is scoped to the frozen
+  receiver.
+- Specifying the admin editing UI, the language-switcher, or `I18n` message translation
+  (`ct`/`cama_t`/`on_translation`) — that is a different mechanism which happens to share the word
+  "translation", and is already partly covered by `uploader-implementation-parity`.
+- Enshrining incidental artifacts of the current parser (see D3).
+
+## Decisions
+
+- **D1 — Every scenario was derived by executing the implementation, not by reading it.** The
+  resolution order, the empty-string case, the `translations_array` fallback, regional locale
+  codes, multiline content, the sanitization round-trip and the `nil` element behavior were each
+  confirmed against the running code before being written down. A spec asserted from a reading of
+  the source would risk codifying what the author assumed rather than what ships.
+- **D2 — The empty-string result is documented as deliberate, not as a quirk.** When a value
+  carries translations but for neither the requested nor the default locale, `translate` returns
+  `''`. That is a real product decision — render nothing rather than serve the reader a language
+  they did not ask for — and stating it prevents a future "fix" from falling back to an arbitrary
+  available locale.
+- **D3 — Incidental parser artifacts are deliberately left unspecified.** Text sitting outside any
+  marker is currently retained in the output (`"  \n<!--:en-->Hi<!--:-->"` translates to
+  `"  \nHi"`). It is observable, but it reads as an artifact of the `gsub`-based extraction rather
+  than intended behavior, so it is described nowhere in the requirements. Specifying it would make
+  a future cleanup a spec violation.
+- **D4 — Caching is permitted but must not be load-bearing.** The requirement says an
+  implementation MAY cache on a mutable receiver but SHALL NOT make correctness depend on it. This
+  keeps the current memoization legal (it is a real hot path: `translate` consults `translations`
+  up to three times per call) while forbidding the shape that caused the defect.
+
+## Risks / Trade-offs
+
+- [Documenting current behavior can freeze a latent bug in place] → mitigated by D3: only rules
+  that read as intended are stated, and the one known artifact is explicitly excluded.
+- [The marker format is a public, on-disk contract that themes and plugins parse themselves] →
+  that is precisely the argument for writing it down; the spec makes the contract explicit rather
+  than creating it.
+
+## Migration Plan
+
+None. No code or data changes.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/proposal.md
+++ b/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/proposal.md
@@ -1,0 +1,59 @@
+# Proposal: add-multilingual-content-translation-spec
+
+## Why
+
+Camaleon stores multilingual content inline, as HTML-comment locale markers
+(`<!--:en-->Hello<!--:-->`) inside a single column, and resolves them at render time through
+monkey-patches on `String`, `Hash` and `Array`. This mechanism is load-bearing across the
+codebase — post titles and content, slugs, taxonomy names, custom field values, metas and site
+options all pass through it, and slug-uniqueness validation parses it — yet it has no capability
+of its own. Adjacent specs already depend on it without stating it: `post-content-sanitization`
+requires markers to survive sanitization, and `escaped-title-composition` reasons about
+transformations applied to translatable names.
+
+The gap has cost something concrete. `String#translations` memoized its parsed result in an
+instance variable on the receiver, which Ruby 3.4's frozen `nil.to_s` cannot carry, so validating
+a post without a slug raised `FrozenError` instead of reporting `Slug can't be blank` — a defect
+that stood since before 2.9.2 with nothing recording that parsing must not mutate its receiver.
+
+## What Changes
+
+This is a **documentation-only** change: it records behavior that already exists, verified by
+executing the current implementation rather than by reading it. No application code changes as
+part of this change.
+
+The one requirement not purely historical is that parsing must not depend on mutating the
+receiver, which the accompanying fix in this PR makes true for frozen strings.
+
+Captured behavior:
+
+- Marker syntax and the locale-code shape the parser accepts.
+- Resolution order for `String#translate`: requested locale, then `I18n.default_locale`, then an
+  empty string when the value carries translations for neither, then the value itself when it
+  carries none.
+- Pass-through for untagged content, so a plain string is never damaged by being translated.
+- The `String#translations` / `String#translations_array` contracts, including the
+  `translations_array` fallback to the receiver.
+- `Hash#to_translate` composition and its round-trip with `String#translations`.
+- `Array#translate` element-wise mapping.
+- Marker survival through `CamaleonRecord.cama_sanitize_translatable`, and the guarantee that
+  user-typed `!--` / `--!` text is not promoted into marker delimiters.
+- Parsing does not mutate the receiver, so frozen strings are safe.
+
+## Capabilities
+
+### New Capabilities
+
+- `multilingual-content-translation`: the inline locale-marker format and the resolution rules
+  that read it.
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+No code impact. Documents `lib/ext/translator.rb`, the translation sentinels in
+`app/models/camaleon_record.rb`, and the behavior relied on by decorators, validators and
+`post-content-sanitization`. Existing regression coverage lives in
+`spec/lib/ext/translator_spec.rb`.

--- a/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/specs/multilingual-content-translation/spec.md
+++ b/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/specs/multilingual-content-translation/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: Translatable values carry their locales inline as comment markers
+
+A single stored value MAY hold content for several locales at once, delimited by HTML-comment
+markers of the form `<!--:<locale>-->content<!--:-->`. The locale code SHALL be 2 to 5 characters
+drawn from word characters and `-`, so both plain (`en`) and regional (`pt-BR`) codes are
+accepted. A value is treated as translatable when it starts with `<!--` after whitespace is
+squished, so leading whitespace does not disable translation.
+
+#### Scenario: A two-locale value exposes both locales
+- **WHEN** a value is `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->`
+- **THEN** `translations` returns `{ en: 'Hello', es: 'Hola' }`
+
+#### Scenario: A regional locale code is accepted
+- **WHEN** a value is `<!--:pt-BR-->Ola<!--:-->`
+- **THEN** `translations` contains the key `:'pt-BR'` with value `Ola`
+
+#### Scenario: Content spanning several lines is preserved
+- **WHEN** a locale's content contains newlines
+- **THEN** the whole content, including the newlines, is returned for that locale
+
+### Requirement: Translation resolves to the requested locale, then the default, then empty
+
+`String#translate(locale = nil)` SHALL resolve against `I18n.locale` when no locale is given, and
+otherwise in this order: the requested locale if the value carries it; else `I18n.default_locale`
+if the value carries it; else an empty string when the value carries translations for other
+locales; else the value itself.
+
+The empty-string case is deliberate: a value that has been translated but not into any locale the
+reader can be served renders as nothing rather than leaking another language's text.
+
+#### Scenario: The requested locale is present
+- **WHEN** `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->` is translated to `:es`
+- **THEN** the result is `Hola`
+
+#### Scenario: The requested locale is absent and the default is present
+- **WHEN** the same value is translated to `:fr`
+- **AND** `I18n.default_locale` is `:en`
+- **THEN** the result is `Hello`
+
+#### Scenario: Neither the requested nor the default locale is present
+- **WHEN** `<!--:es-->Hola<!--:-->` is translated to `:fr` and `I18n.default_locale` is `:en`
+- **THEN** the result is an empty string
+
+### Requirement: Untagged content passes through translation unchanged
+
+A value carrying no locale markers SHALL be returned unchanged by `translate`, for any locale, and
+SHALL report no translations. Translation is therefore safe to apply to values that were never
+multilingual, which is what lets decorators call it unconditionally.
+
+#### Scenario: A plain string survives translation
+- **WHEN** `Just a title` is translated to `:es`
+- **THEN** the result is `Just a title`
+- **AND** `translations` returns an empty hash
+
+#### Scenario: A blank value translates to itself
+- **WHEN** an empty string is translated
+- **THEN** the result is an empty string
+
+### Requirement: The translations array falls back to the whole value
+
+`String#translations_array` SHALL return the content of every locale the value carries, and SHALL
+fall back to a single-element array holding the value itself when it carries none. Callers that
+must inspect every stored variant — slug-uniqueness validation among them — can therefore treat
+translated and untranslated values alike.
+
+#### Scenario: A multilingual value yields one entry per locale
+- **WHEN** `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->` is asked for its translations array
+- **THEN** the result contains `Hello` and `Hola`
+
+#### Scenario: An untranslated value yields itself
+- **WHEN** `Just a title` is asked for its translations array
+- **THEN** the result is `['Just a title']`
+
+### Requirement: Parsing does not mutate the receiver
+
+Reading translations SHALL NOT require mutating the value being read, so frozen strings — Ruby's
+shared frozen `nil.to_s`, and every literal in a file with the `frozen_string_literal` magic
+comment — can be translated like any other value. An implementation MAY cache the parse on a
+mutable receiver, but SHALL NOT make correctness depend on being able to do so.
+
+#### Scenario: A frozen value is translatable
+- **WHEN** `translate`, `translations`, or `translations_array` is called on a frozen string
+- **THEN** the call returns the same result it would for an equal mutable string
+- **AND** no `FrozenError` is raised
+
+#### Scenario: Validating a record whose translatable column is unset
+- **WHEN** a post with no slug is validated, so slug parsing receives `nil.to_s`
+- **THEN** validation completes and reports its own errors, such as `Slug can't be blank`
+
+### Requirement: Locale markers survive sanitization, and comment-like text is never promoted
+
+`CamaleonRecord.cama_sanitize_translatable` SHALL preserve locale markers through HTML
+sanitization while still stripping dangerous markup from the content between them. Text a user
+typed that merely resembles a marker delimiter SHALL NOT be converted into one.
+
+#### Scenario: Markers survive while script inside them does not
+- **WHEN** `<!--:en--><script>x</script>Hi<!--:-->` is sanitized
+- **THEN** the locale markers are still present and parse back to the `:en` locale
+- **AND** the `<script>` element is gone
+
+#### Scenario: User-typed comment-like text stays literal
+- **WHEN** a user writes `Sale !-- 50% --!` in translatable content
+- **THEN** the stored value still reads `Sale !-- 50% --!`
+- **AND** no `<!--` or `-->` delimiter is introduced
+
+### Requirement: Translatable values can be composed and mapped
+
+`Hash#to_translate` SHALL compose a locale-keyed hash into the marker format, round-tripping with
+`String#translations`. `Array#translate` SHALL translate each element, coercing non-strings, so a
+collection of translatable values can be resolved in one call.
+
+#### Scenario: A hash composes into markers and parses back
+- **WHEN** `{ es: 'Hola', en: 'Hello' }` is composed with `to_translate`
+- **THEN** the result is `<!--:es-->Hola<!--:--><!--:en-->Hello<!--:-->`
+- **AND** parsing that result returns the original pairs
+
+#### Scenario: An array translates element-wise
+- **WHEN** `['<!--:es-->Hola<!--:-->', 'plain']` is translated to `:es`
+- **THEN** the result is `['Hola', 'plain']`
+
+#### Scenario: A nil element translates to an empty string
+- **WHEN** an array containing `nil` is translated
+- **THEN** that element resolves to an empty string rather than raising

--- a/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/tasks.md
+++ b/openspec/changes/archive/2026-08-03-add-multilingual-content-translation-spec/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: add-multilingual-content-translation-spec
+
+## 1. Establish ground truth
+
+- [x] 1.1 Execute the current implementation to confirm resolution order, the empty-string case,
+  the `translations_array` fallback, regional locale codes, multiline content, `to_translate`
+  round-trip, `Array#translate` coercion, and the sanitization round-trip
+
+## 2. Author the capability
+
+- [x] 2.1 Write the `multilingual-content-translation` delta covering format, resolution,
+  pass-through, array contract, frozen-receiver safety, sanitization survival, and composition
+- [x] 2.2 Record in `design.md` why the empty-string case is deliberate and why the
+  outside-marker retention artifact is left unspecified
+
+## 3. Close-out
+
+- [x] 3.1 `openspec validate --strict` passes; existing regression coverage
+  (`spec/lib/ext/translator_spec.rb`) already exercises the frozen-receiver requirement
+- [x] 3.2 Archive this change on the branch as part of the PR

--- a/openspec/specs/multilingual-content-translation/spec.md
+++ b/openspec/specs/multilingual-content-translation/spec.md
@@ -1,0 +1,129 @@
+## Purpose
+
+Define Camaleon's inline multilingual content format — locale markers of the form `<!--:en-->…<!--:-->` stored within a single column — and the rules that resolve it at render time. This mechanism underlies post titles and content, slugs, taxonomy names, custom field values, metas and site options, and is depended on by `post-content-sanitization` (markers must survive sanitization) and `escaped-title-composition`. It is distinct from `I18n` message translation (`ct`/`cama_t`/`on_translation`), which shares the word but not the mechanism.
+
+## Requirements
+
+### Requirement: Translatable values carry their locales inline as comment markers
+
+A single stored value MAY hold content for several locales at once, delimited by HTML-comment
+markers of the form `<!--:<locale>-->content<!--:-->`. The locale code SHALL be 2 to 5 characters
+drawn from word characters and `-`, so both plain (`en`) and regional (`pt-BR`) codes are
+accepted. A value is treated as translatable when it starts with `<!--` after whitespace is
+squished, so leading whitespace does not disable translation.
+
+#### Scenario: A two-locale value exposes both locales
+- **WHEN** a value is `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->`
+- **THEN** `translations` returns `{ en: 'Hello', es: 'Hola' }`
+
+#### Scenario: A regional locale code is accepted
+- **WHEN** a value is `<!--:pt-BR-->Ola<!--:-->`
+- **THEN** `translations` contains the key `:'pt-BR'` with value `Ola`
+
+#### Scenario: Content spanning several lines is preserved
+- **WHEN** a locale's content contains newlines
+- **THEN** the whole content, including the newlines, is returned for that locale
+
+### Requirement: Translation resolves to the requested locale, then the default, then empty
+
+`String#translate(locale = nil)` SHALL resolve against `I18n.locale` when no locale is given, and
+otherwise in this order: the requested locale if the value carries it; else `I18n.default_locale`
+if the value carries it; else an empty string when the value carries translations for other
+locales; else the value itself.
+
+The empty-string case is deliberate: a value that has been translated but not into any locale the
+reader can be served renders as nothing rather than leaking another language's text.
+
+#### Scenario: The requested locale is present
+- **WHEN** `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->` is translated to `:es`
+- **THEN** the result is `Hola`
+
+#### Scenario: The requested locale is absent and the default is present
+- **WHEN** the same value is translated to `:fr`
+- **AND** `I18n.default_locale` is `:en`
+- **THEN** the result is `Hello`
+
+#### Scenario: Neither the requested nor the default locale is present
+- **WHEN** `<!--:es-->Hola<!--:-->` is translated to `:fr` and `I18n.default_locale` is `:en`
+- **THEN** the result is an empty string
+
+### Requirement: Untagged content passes through translation unchanged
+
+A value carrying no locale markers SHALL be returned unchanged by `translate`, for any locale, and
+SHALL report no translations. Translation is therefore safe to apply to values that were never
+multilingual, which is what lets decorators call it unconditionally.
+
+#### Scenario: A plain string survives translation
+- **WHEN** `Just a title` is translated to `:es`
+- **THEN** the result is `Just a title`
+- **AND** `translations` returns an empty hash
+
+#### Scenario: A blank value translates to itself
+- **WHEN** an empty string is translated
+- **THEN** the result is an empty string
+
+### Requirement: The translations array falls back to the whole value
+
+`String#translations_array` SHALL return the content of every locale the value carries, and SHALL
+fall back to a single-element array holding the value itself when it carries none. Callers that
+must inspect every stored variant — slug-uniqueness validation among them — can therefore treat
+translated and untranslated values alike.
+
+#### Scenario: A multilingual value yields one entry per locale
+- **WHEN** `<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->` is asked for its translations array
+- **THEN** the result contains `Hello` and `Hola`
+
+#### Scenario: An untranslated value yields itself
+- **WHEN** `Just a title` is asked for its translations array
+- **THEN** the result is `['Just a title']`
+
+### Requirement: Parsing does not mutate the receiver
+
+Reading translations SHALL NOT require mutating the value being read, so frozen strings — Ruby's
+shared frozen `nil.to_s`, and every literal in a file with the `frozen_string_literal` magic
+comment — can be translated like any other value. An implementation MAY cache the parse on a
+mutable receiver, but SHALL NOT make correctness depend on being able to do so.
+
+#### Scenario: A frozen value is translatable
+- **WHEN** `translate`, `translations`, or `translations_array` is called on a frozen string
+- **THEN** the call returns the same result it would for an equal mutable string
+- **AND** no `FrozenError` is raised
+
+#### Scenario: Validating a record whose translatable column is unset
+- **WHEN** a post with no slug is validated, so slug parsing receives `nil.to_s`
+- **THEN** validation completes and reports its own errors, such as `Slug can't be blank`
+
+### Requirement: Locale markers survive sanitization, and comment-like text is never promoted
+
+`CamaleonRecord.cama_sanitize_translatable` SHALL preserve locale markers through HTML
+sanitization while still stripping dangerous markup from the content between them. Text a user
+typed that merely resembles a marker delimiter SHALL NOT be converted into one.
+
+#### Scenario: Markers survive while script inside them does not
+- **WHEN** `<!--:en--><script>x</script>Hi<!--:-->` is sanitized
+- **THEN** the locale markers are still present and parse back to the `:en` locale
+- **AND** the `<script>` element is gone
+
+#### Scenario: User-typed comment-like text stays literal
+- **WHEN** a user writes `Sale !-- 50% --!` in translatable content
+- **THEN** the stored value still reads `Sale !-- 50% --!`
+- **AND** no `<!--` or `-->` delimiter is introduced
+
+### Requirement: Translatable values can be composed and mapped
+
+`Hash#to_translate` SHALL compose a locale-keyed hash into the marker format, round-tripping with
+`String#translations`. `Array#translate` SHALL translate each element, coercing non-strings, so a
+collection of translatable values can be resolved in one call.
+
+#### Scenario: A hash composes into markers and parses back
+- **WHEN** `{ es: 'Hola', en: 'Hello' }` is composed with `to_translate`
+- **THEN** the result is `<!--:es-->Hola<!--:--><!--:en-->Hello<!--:-->`
+- **AND** parsing that result returns the original pairs
+
+#### Scenario: An array translates element-wise
+- **WHEN** `['<!--:es-->Hola<!--:-->', 'plain']` is translated to `:es`
+- **THEN** the result is `['Hola', 'plain']`
+
+#### Scenario: A nil element translates to an empty string
+- **WHEN** an array containing `nil` is translated
+- **THEN** that element resolves to an empty string rather than raising

--- a/spec/lib/ext/translator_spec.rb
+++ b/spec/lib/ext/translator_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe String do
+  describe '#translations' do
+    # Ruby 3.4's nil.to_s returns a frozen (and globally shared) empty string, and every
+    # string literal in a `frozen_string_literal: true` file is frozen too. Memoizing the
+    # parsed translations in an ivar on the receiver therefore raised FrozenError for any
+    # such string instead of returning its (empty) translation set.
+    it 'does not raise for a frozen receiver' do
+      expect { nil.to_s.translations }.not_to raise_error
+    end
+
+    it 'returns an empty set for a frozen blank string' do
+      expect(nil.to_s.translations).to eq({})
+    end
+
+    it 'parses locale markers on a frozen string' do
+      frozen = (+'<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->').freeze
+
+      expect(frozen.translations).to eq({ en: 'Hello', es: 'Hola' })
+    end
+
+    it 'still parses locale markers on a mutable string' do
+      expect((+'<!--:en-->Hello<!--:-->').translations).to eq({ en: 'Hello' })
+    end
+  end
+
+  describe '#translations_array' do
+    it 'does not raise for a frozen receiver' do
+      expect { nil.to_s.translations_array }.not_to raise_error
+    end
+
+    it 'returns the receiver itself when it carries no locale markers' do
+      expect(nil.to_s.translations_array).to eq([''])
+    end
+  end
+
+  describe '#translate' do
+    it 'does not raise for a frozen receiver' do
+      expect { nil.to_s.translate(:en) }.not_to raise_error
+    end
+
+    it 'translates a frozen multilingual string' do
+      frozen = (+'<!--:en-->Hello<!--:--><!--:es-->Hola<!--:-->').freeze
+
+      expect(frozen.translate(:es)).to eq('Hola')
+    end
+  end
+end

--- a/spec/models/post_blank_slug_validation_spec.rb
+++ b/spec/models/post_blank_slug_validation_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Post, type: :model do
+  describe 'validating a post with no slug' do
+    let(:post_type) { CamaleonCms::Site.first.post_types.find_by(slug: 'post') }
+
+    # PostUniqValidator calls record.slug.to_s.translations_array; with no slug that
+    # receiver is Ruby 3.4's frozen shared empty string, which raised FrozenError before
+    # the validator could report anything.
+    it 'reports validation results instead of raising' do
+      record = described_class.new(title: 'No slug', post_type: post_type)
+
+      expect { record.valid? }.not_to raise_error
+    end
+
+    it 'does not raise when saved through a post type' do
+      expect { post_type.posts.new(title: 'No slug').valid? }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

`String#translations` memoized the parsed locale hash in an ivar on the receiver:

```ruby
@translations ||= split_locales
```

Ruby 3.4's `nil.to_s` returns a frozen — and process-wide shared — empty string, so a caller reaching `translations` through it raised `FrozenError: can't modify frozen String: ""` instead of getting a result. The same applies to any string literal in a file carrying the `frozen_string_literal` magic comment.

`PostUniqValidator` does exactly that: it calls `record.slug.to_s.translations_array`. So validating a post with no slug crashed inside the validator, before the model's own presence validation could report `Slug can't be blank`. Since slug auto-generation in `PostDefault#before_validating` is commented out, nothing filled the slug in first — which made creating a post programmatically without an explicit slug impossible:

```ruby
CamaleonCms::Post.new(title: 'x').valid?   # => FrozenError
```

Frozen receivers now parse without memoizing; mutable strings keep the memo, so no hot path changes behaviour or cost. Fixing it in `translations` rather than guarding the one validator means every caller is covered — the crash was reachable from `translate` and `translations_array` too, not just from slug validation.

Worth noting independently of the crash: memoizing on `nil.to_s` would have been wrong even where Ruby permitted it, because that instance is shared process-wide and the memo would outlive any individual caller.

**This is pre-existing, not a regression.** The identical code and behaviour are present at tag `2.9.2` on this Ruby; [#1222](https://github.com/owen2345/camaleon-cms/pull/1222) changed only how the validator registers its error, not this path. It is filed as a normal bug fix rather than a release blocker.

## User-Visible Impact

Creating or validating a post without an explicit slug now returns the `Slug can't be blank` validation error instead of raising `FrozenError`, which unblocks programmatic post creation from imports, seeds, jobs and the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
