### PR TITLE
Document the ecosystem plugin bindings in OpenSpec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,7 @@ All four must pass before pushing (CI parity).
 | Branching, vulnerability triage, refactoring protocol, commits, PRs, changelog | `docs/ai/workflows.md` |
 | Writing or running tests; reproducing vulnerabilities | `docs/ai/testing.md` |
 | Reading or writing app code: paths, namespacing, models, decorators, hooks, plugins, style idioms | `docs/ai/reference.md` |
+| Removing, renaming or hardening a public helper/hook/API that external plugins or themes may bind to | `docs/ai/ecosystem.md` |
 | Env files, keys, credentials | `docs/ai/secrets.md` |
 | Self-audit before opening a PR | `docs/ai/criteria.md` |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Docs:** Removed the defunct Autocomplete plugin (`gaelfokou/cama_autocomplete` — repository and
+  gem no longer exist) from the README plugin list and the example Gemfile, and recorded the external
+  plugin/theme binding surface as the `ecosystem-plugin-bindings` OpenSpec capability with a
+  `docs/ai/ecosystem.md` inventory. [#1229](https://github.com/owen2345/camaleon-cms/pull/1229).
+
 - **Security fix:** A user with only the `media` permission could upload an SVG the SVG ruleset
   accepted, then re-crop it under an `.html` name to have the identical bytes served as
   `text/html` from the site origin, unscanned — the re-scan exemption added in

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ https://camaleon.website/store/plugins
 * Image/iFrame Lazy Loader - https://github.com/brian-kephart/camaleon_lazy_loader
 * Import / Export - https://github.com/owen2345/camaleon_export_import
 * Lightbox - https://github.com/owen2345/CamaImageLightbox
-* Autocomplete - https://github.com/gaelfokou/cama_autocomplete
 * Permissions for External Menus - https://github.com/owen2345/cama_external_menu
 * TinyMCE Template Integration - https://github.com/owen2345/Camaleon-Tinymce-Templates
 * Download Manager - https://github.com/max2320/camaleon-download

--- a/docs/ai/ecosystem.md
+++ b/docs/ai/ecosystem.md
@@ -1,0 +1,101 @@
+# Ecosystem Inventory
+
+What external plugins, themes and host applications bind to in this engine. The contracts these
+bindings imply are specified in `openspec/specs/ecosystem-plugin-bindings/spec.md`; this file is the
+evidence behind them.
+
+**Surveyed 2026-08-05** against master `73141b88`: the sixteen plugins and four themes listed in
+`README.md` that have public repositories, plus two production host applications. Read-only survey —
+grep, file reads and `git log`, no execution of ecosystem code.
+
+**Staleness is the point.** Most of these repositories have not been touched in years and will not
+be updated to accommodate a breaking change. Two are unloadable as published. Treat the table as the
+*visible* surface: `AGENTS.md` notes that more consumers exist than this repo can enumerate.
+
+## How to use this
+
+Before removing, renaming or hardening a public API, search this file for it. Three outcomes:
+
+- **No consumer listed** — proceed on the engine's merits, cite this file in the proposal.
+- **A consumer listed** — name it and the disposition in the proposal (spec requirement
+  "Removed or renamed public APIs are recorded against their consumers").
+- **Hardening rather than removal** — check the "hardening hazards" section below first. The survey's
+  clearest lesson is that removals are cheap here and hardening is not.
+
+## Plugins
+
+| Repository | Declares `camaleon_cms` | Last activity | Binds to |
+|---|---|---|---|
+| `cama_contact_form` | Gemfile, unpinned | 2026-08 | `admin_menu_append_menu_item` with a pre-rendered `datas` string; `cama_tmp_upload` into `public/contact_form/<site_id>` with no `formats`, from an unauthenticated endpoint; `cama_send_email` with `attachments`/`extra_data`; own copies of the content-safety patterns |
+| `camaleon-cms-seo` (`cama_meta_tag`) | no | 2023-07 | `seo` hook reading `@cama_visited_post` and `is_page?`/`is_category?`/`is_post_type?`; `set_multiple_options(params[:options].permit!.to_h)` from six save hooks; `plugin_view` at both arities; runtime probe for Camaleon ≤ 2.3.6 |
+| `camaleon-ecommerce` | `>= 2.4` | 2024-08 | **Two-arg `post_type_list_taxonomy`** (live-broken on master); **HTML in an admin menu title** (`span`/`small` + order count); unvalidated `params[:return_to]` and `request.referer` into `login_user`; `email_late` writing a PDF to disk inline; `I18n.locale` mutated mid-request without `ensure`; meta scopes `currencies` and `_setting_ecommerce`; raw `object_class` string on `CamaleonCms::Meta` |
+| `camaleon_editor` | no | 2024-08 | **Unloadable as published** — includes `PluginCamaleonEditorPrivateHelper`, defined nowhere; all six declared hooks have no handler |
+| `cama_subscriber` | no | 2024-06 | `admin_menu_insert_menu_before` with nested `items`; three `cama_send_email` calls with `from`/`cc_to` (array)/`template`/`layout_name`; `CamaleonCms::Site.class_eval`; `CamaleonCms::Metas` on its own model; `all_locales` in a route constraint. Also calls `Rails.application.secrets`, removed in Rails 7.2 |
+| `camaleon_sitemap_customizer` | `~> 2.0` | 2022-01 | `on_render_sitemap` accumulating into all four skip lists and overriding `args[:render]` — matches the contract #1223 restored; six post/plugin hooks; ActiveJob ping |
+| `camaleon_image_optimizer` | `~> 2.0` | **2025-07** | `before_upload` only — rewrites the file in place and rebinds `settings[:uploaded_io]`, **after** the content scan; re-fires on the crop path's re-entry into `upload_file` |
+| `camaleon_lazy_loader` | `~> 2.0` | 2022-01 | Writes `response.body`; shares `@skip_lazy_loader` across hooks; reads `front_cache`'s private `@_plugin_do_cache`; binds `on_render_sitemap` with an arity-1 handler that ignores the payload |
+| `camaleon_export_import` | no gemspec (drop-in folder) | 2016-09 | Heaviest consumer found: seven `class_eval` patches from `app_before_load`; writes `content`, `content_filtered`, `user_id`, `post_class` from uploaded JSON; `cama_tmp_upload(params[:url])` with no options, path round-tripped to the client; hard-codes the `object_class` string grammar in five places; `posts.destroy_all`/`nav_menus.destroy_all` on client flags |
+| `camaleon-post-clone` | no | 2016-12 | `deep_clone` + `save!` of a core Post, copying `content` verbatim; `set_field_values(params[:field_options])` unfiltered; `add_custom_field_group`/`add_manual_field`; renders the core partial `camaleon_cms/admin/settings/custom_fields/render` |
+| `camaleon_post_created_at` | **`>= 2.3.5`** (only explicit constraint) | 2016-11 | Reads the controller ivar `@post` inside `new_post`/`edit_post`; appends raw HTML to `args[:extra_settings]`; injects `post[created_at]` into core strong params |
+| `camaleon-post-order-plugin` | no | 2019-12 | `list_post` hook calling `append_asset_libraries` + `cama_content_append`; `update_column('post_order')` direct on core posts; JS hard-coupled to the admin post-list DOM (`#posts-table-list`, `tr[data-id]`) |
+| `cama_external_menu` | no | 2018-10 | `on_external_menu` sets `args[:parsed_menu] = false` — the entire access check, and it **fails open**; calls bare `current_user` and `.role` |
+| `camaleon_oauth` | no | 2016-09 | Includes `SessionHelper`/`SiteHelper`/`HooksHelper` into `Object`; signs in via Doorkeeper `resource_owner_from_credentials` → `login_user_with_password` return value; identity read back through core's own `doorkeeper_token` branch. **Never assigns `@cama_current_user`** |
+| `camaleon-spree` | commented out in gemspec | 2017-10 | Reopens `CamaleonCms::SessionHelper` to replace `cama_current_user` and the login/register/logout path helpers; `class_eval` on `FrontendController`, `AdminController`, `User`; redefines `CamaleonCms::PostDecorator`; injects its admin menu via `cama_content_prepend` + DOM selectors; `add_after_reload_routes`; needs `user_model: Spree::User` |
+| `camaleon_admin_ajax` / `admin-ajax` | no | 2022-08 | **Unloadable as published** — `PluginCamaleonAdminAjaxPrivate` absent. Globally patches `ActionController::Redirecting#redirect_to`. Deep JS contract: `#admin_content[data-url]`, `#sidebar-menu`, `showLoading`/`hideLoading`, `I18n()`, and "response must not start with `<!DOCTYPE html>`". Calls `PluginRoutes.system_info_set`, absent from core |
+| `cama_tinymce_template` | no | 2017-03 | No Ruby coupling at all; one `admin_before_load` → `append_asset_libraries`. Entire contract is the JS globals `tinymce_global_settings["settings"]`/`["setups"]` and `open_modal(...)` — documented in its README as the extension point for theme authors |
+| `camaleon_cms_rating` | no | 2017-08 | `class_eval` `has_many :ratings` onto `CamaleonCms::Post`; own table, not metas; reads `static_system_info['user_model']` at load time. Ajax payload carries no `user_id` — rater derived server-side |
+| `camaleon-download` | no | 2019-01 | `admin_menu_insert_menu_after`; `shortcode_add` with unescaped attribute interpolation; calls `CamaleonCmsLocalUploader.private_file_path`, **absent from core**; `return_to` on the login path; PostgreSQL-only (`jsonb`) |
+| `cama_image_lightbox` | no | 2016-12 | `shortcode_add` from `app_before_load`; `append_asset_libraries` with `plugin_asset`; `String#cama_parse_image_version` |
+| `cama-stripe-donation` | no | 2024-08 | `CamaleonCmsLocalUploader.private_file_path` with a Base64-decoded request parameter, then `send_file`; `current_plugin.get_option` from a view; `@plugin.get_option` from controllers; reopens `CamaleonCms::Site` |
+| `camaleon-cms-language-editor` | no | 2020-09 | `plugin_asset_path` single-arg; reaches into `I18n.backend`'s private `translations` hash; writes to `params` from a view |
+
+## Themes
+
+| Repository | Last activity | Binds to |
+|---|---|---|
+| `cama-ecommerce-theme` (E Shop) | 2016-12 | `cama_menu_parse_items(nav_menu.children)` with implicit ordering; 48 `append_menu_item` calls on activation; `cama_current_user` decorated and undecorated; absolute `site_current_url` as `return_to`; JS globals `load_upload_image_field`, `cama_get_tinymce_settings` |
+| `camaleon-cms-efashion` | 2016-09 | Live `select_eval` field created on activation (**now raises under the permission gate**); unguarded `nav_menus.find_by_slug('main_menu').children`; same JS globals |
+| `camaleon-cms-shoppy` | 2016-07 | Live `select_eval`; `set_field_values(params[:field_options])` with no guard; 23 `current_theme.the_field` reads; assigns an ivar inside a view |
+
+## Host applications
+
+| Application | Camaleon | Shape | Notes |
+|---|---|---|---|
+| `camaleon_website` (camaleon.website) | 2.9.2 | **Wildcard-subdomain multisite**, 10 plugin gems pinned to git SHAs, 3 vendored plugins, 8 vendored themes | Runs `raise_on_open_redirects = false` with a comment waiting on a core `cama_site_check_existence` fix; `manifest.js` hard-codes gem asset logical paths, so asset renames break its build; four `class_eval` patches on `CamaleonCms::Site`/`User`; four `cama_send_email` call sites; a theme shortcode emitting a raw `<script>` |
+| `florsan` (florsan.md) | 2.9.2 | Single site, **three locales (en/md/ru)**, one vendored theme, no plugin gems | Zero `CamaleonCms::` references and zero monkey patches — the cleanest consumer surveyed. System-level `on_uploader`/`uploader_aws_before_upload` hooks that share `@suppress_content_type` across the pair; `on_render_sitemap` mutating `lookup_context.formats`; no YAML locale files, all translations in the database |
+
+## Hardening hazards
+
+Changes that look free from inside this repository and are not:
+
+- **Escaping admin menu titles** breaks `camaleon-ecommerce`'s Orders entry.
+- **Filtering the menu `datas` value** must tolerate a pre-rendered single-quoted attribute string —
+  the current filter truncates values at an embedded quote, which already breaks the engine's own
+  Menus tooltip.
+- **Requiring `cama_permitted_field_options`** breaks four plugins that pass raw params to
+  `set_field_values`.
+- **Restricting upload `formats` by default** breaks `cama_contact_form`'s file fields.
+- **Validating `cama_tmp_upload` paths against `public/`** breaks `cama_contact_form`'s redisplay URL.
+- **Making `hooks_run` dispatch off the controller** breaks seven plugins, one of them silently and
+  one of them open (`cama_external_menu`).
+- **Moving mail to a background job** breaks `camaleon-ecommerce`'s `email_late` PDF path and drops
+  its mid-request locale.
+- **Renaming gem-side assets** breaks `camaleon_website`'s production precompile.
+
+## APIs with no surveyed consumer
+
+Safe to change on the engine's own merits, citing this file: `update_or_create` / `update_or_create!`
+/ `assign_or_new` / `ActiveRecordExtras`; `find_by_key`; `unassign_category` / `assign_tags` /
+`unassign_tags`; `update_counters`; `cf_add_model`; `@_admin_menus`; `@cama_current_user` (no external
+writer); `on_translation`; `render prefixes:`; `Widget::Assigned` discriminator literals; `user_model`
+beyond the two read sites above; `SUSPICIOUS_PATTERNS` / `UNSAFE_EVENT_PATTERNS`; `post_type_list_taxonomy`
+at any arity other than two.
+
+## Engine APIs called but missing
+
+Consumers are already broken against master. Restoring any of these is a decision, not a bug fix:
+
+- `CamaleonCmsLocalUploader.private_file_path` — `camaleon-download`, `cama-stripe-donation`. The
+  latter passes a request-supplied path, so a naive restoration restores a traversal with it.
+- `PluginRoutes.system_info_set` — `camaleon_admin_ajax`.
+- `current_site.contact_forms` — `camaleon_oauth`; supplied by the `cama_contact_form` gem, not core.

--- a/docs/example_gemfile.rb
+++ b/docs/example_gemfile.rb
@@ -24,7 +24,6 @@ gem 'camaleon_sitemap_customizer', git: 'https://github.com/brian-kephart/camale
 gem 'camaleon_image_optimizer', git: 'https://github.com/brian-kephart/camaleon_image_optimizer'
 
 # gem 'cama_tinymce_template', git: 'https://github.com/owen2345/Camaleon-Tinymce-Templates'
-# gem 'cama_autocomplete', git: 'https://github.com/gaelfokou/cama_autocomplete.git'
 # gem 'cama_image_lightbox', git: 'https://github.com/owen2345/CamaImageLightbox'
 # gem 'camaleon_oauth', git: 'https://github.com/owen2345/camaleon_oauth'
 # gem 'camaleon_download', git: 'https://github.com/max2320/camaleon-download'

--- a/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/design.md
+++ b/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/design.md
@@ -1,0 +1,112 @@
+# Design: document-ecosystem-plugin-bindings
+
+## Why a capability rather than a document alone
+
+A markdown inventory rots without complaint. A requirement with a named consumer does not: when a
+later change proposes to escape admin menu titles, `openspec validate` and review surface the
+requirement that says `camaleon-ecommerce` renders HTML in one, and the decision gets made in the
+open. The inventory still exists — `docs/ai/ecosystem.md` — but it is the reference companion, not
+the contract. Facts that change every time a plugin releases (last commit, version constraint) live
+in the doc; contracts that the engine must honour live in the spec.
+
+## What counts as a binding worth specifying
+
+The survey found roughly 200 distinct call sites. Most are ordinary public API use that any Rails
+engine would preserve without being told (`current_site`, `the_title`, `link_to`). Three tests
+promote a binding into the spec:
+
+1. **A reasonable refactor would break it.** Hook dispatch moving off the controller instance is a
+   plausible next step of the `CurrentRequest` migration, and it would break seven plugins.
+2. **The breakage is silent.** `cama_external_menu`'s role check fails *open* — restricted menus
+   become publicly visible — which no test in this repository would catch.
+3. **The contract is not obvious from the method signature.** That `before_upload` may replace
+   `settings[:uploaded_io]` but must not change its `path` is invisible until you read the plugin
+   that depends on it.
+
+Bindings that fail all three are inventory, not requirements.
+
+## Hook dispatch is the load-bearing contract
+
+`hooks_run` → `_do_hook` → `send(hook, params)` on `self`. Every surveyed plugin assumes `self` is
+the controller. The dependency is not incidental — it is how the extension model works:
+
+- `camaleon_post_created_at` reads the controller ivar `@post` inside `new_post`/`edit_post` and
+  interpolates it into a string, so a nil `self` state raises rather than degrading.
+- `camaleon_lazy_loader` writes `response.body`, sets `@skip_lazy_loader` in one hook and reads it
+  in another on the same instance, and reads `@_plugin_do_cache` — a private ivar owned by the
+  bundled `front_cache` plugin.
+- `camaleon_admin_ajax` writes four different `flash` variants and reads `params`.
+- `cama_external_menu` calls `current_user` and suppresses a menu item by setting
+  `args[:parsed_menu] = false`.
+
+The spec therefore states the guarantee positively — hooks execute with the request's controller as
+receiver — instead of leaving it as an emergent property of `send`.
+
+## In-place mutation is the payload convention, not an accident
+
+Core seeds a hash, runs the hook, and reads the same object back. Plugins rely on `+=`, `<<` and
+`[]=` against pre-seeded keys. `camaleon_sitemap_customizer` does `args[:skip_post_ids] += …` on all
+four sitemap skip lists — which is exactly the contract [#1223](https://github.com/owen2345/camaleon-cms/pull/1223)
+restored when it fixed H4, and the survey confirms the plugin matches it key for key. A seeded key
+that arrives `nil`, frozen, or renamed breaks the consumer at the mutation, not at a boundary.
+
+`camaleon_lazy_loader` binds the same `on_render_sitemap` hook with an **arity-1 handler that ignores
+its argument**, which pins the call shape independently of the payload: `hooks_run` must keep passing
+exactly one argument.
+
+## Two engine defects the survey exposed — recorded, not fixed
+
+**`before_upload` runs after the content scan.** In `UploaderPipeline#upload_file` the scan gate sits
+at the top and `hooks_run('before_upload', settings)` fires afterwards; the file finally persisted is
+`settings[:uploaded_io]`, which a handler may have replaced. `camaleon_image_optimizer` does exactly
+that, and advertises SVGO support — so an SVG cleared by `SvgContentChecker` can be rewritten before
+storage. Whether the pipeline should re-scan when a hook swaps the handle, or whether `before_upload`
+handlers are trusted by definition, is a security decision that belongs in the upload capability with
+its own reproduction, not in a documentation change. Recorded here so the question is not lost.
+
+The same ordering is load-bearing in the other direction: `cached_name` and `settings[:filename]` are
+computed *before* the hook, so a handler that rebinds `uploaded_io` keeps the original filename only
+because of that ordering. The spec states the resulting rule — a handler may replace the IO object
+but must not change its `path`.
+
+**`CamaleonCmsLocalUploader.private_file_path` does not exist.** `camaleon-download` and
+`cama-stripe-donation` both call it, positionally, and feed the result to `send_file`. It is absent
+from `app/uploaders/`. Both plugins are already broken against master; `cama-stripe-donation` passes
+a Base64-decoded request parameter as the path, so restoring the method naively would restore a path
+traversal with it. Left as an open question with the traversal noted.
+
+## Where the survey contradicted the plan's assumptions
+
+Four defaults in the medium-fix plan were set from core-only reasoning and the evidence reversed
+them. They are recorded here because the reasoning, not just the conclusion, is what a later reader
+needs:
+
+| Question | Core-only guess | Evidence | Outcome |
+|---|---|---|---|
+| Escape admin menu titles? | Yes — hardening | `camaleon-ecommerce` ships an HTML title | Allowlist, not blanket escaping |
+| Honour `@cama_current_user`? | Yes — SSO plugins need it | The SSO plugin uses Doorkeeper; zero writers exist | Drop the ivar read; keep the method overridable |
+| Coerce the upload size limit at core read sites? | Sufficient | `cama_contact_form` reads the option itself and passes `maximum:` | Coerce in `cama_size_limit_error` instead |
+| Defer the asset precompile snapshot? | Needed | Neither host app appends `assets.paths` | Document the ordering; no code change |
+
+The pattern is worth naming: **the ecosystem constrains removals far less than expected and
+hardening far more.** Eleven of the surveyed API surfaces have no consumer at all
+(`update_or_create`, `find_by_key`, `unassign_category`, `cf_add_model`, `@_admin_menus`,
+`on_translation`, `render prefixes:`, and the rest), while three hardening changes that looked free
+would each have broken a shipped plugin. Restoration decisions can be made on the engine's own
+merits; escaping, validation and permission decisions need this spec consulted first.
+
+## Deliberately not specified
+
+**Version constraints as a compatibility gate.** Fifteen of the twenty surveyed repositories declare
+no `camaleon_cms` dependency at all, and the one explicit constraint is `>= 2.3.5`. Gating behaviour
+on the consumer's declared version would protect nobody.
+
+**Plugins that cannot load.** `camaleon_editor` and `camaleon_admin_ajax` both `include` a private
+module that is published nowhere; `camaleon_editor`'s six declared hooks have no handlers in the
+open-source tree. They are inventory entries, not contract sources — a core change cannot break what
+does not load, and their bindings cannot be verified.
+
+**The `select_eval` collateral.** `camaleon-cms-efashion` and `camaleon-cms-shoppy` create
+`field_key: "select_eval"` fields from their activation hooks, which now raise under the permission
+gate. That gate is an intentional capability decision; the themes are recorded as collateral so the
+next person to see the exception knows why, and nothing here proposes to loosen it.

--- a/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/proposal.md
+++ b/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/proposal.md
@@ -1,0 +1,62 @@
+# Proposal: document-ecosystem-plugin-bindings
+
+## Why
+
+`AGENTS.md` states that most plugins and themes live in separate gems and that "a public helper's
+return contract cannot be verified from this repo alone". That warning has no artifact behind it:
+nothing in the repository records *which* extension points external code actually binds to, so every
+compatibility decision is made blind. The 2026-08-03 regression audit's medium findings each carry a
+"restore, or document as intended?" question that cannot be answered from this repo.
+
+Twenty-two ecosystem repositories were surveyed for this change — the sixteen plugins and four
+themes named in `README.md` plus the two host applications that run them. The survey answers those
+questions with evidence, and several answers contradict what the repository would have guessed:
+
+- **`post_type_list_taxonomy` is live-broken.** `camaleon-ecommerce` calls the two-argument form in
+  its admin products index; on master those taxonomy columns render empty.
+- **Admin menu titles carry HTML in the wild.** `camaleon-ecommerce` renders an order count as
+  `<span><small class='label label-primary'>…`, so escaping titles unconditionally degrades a
+  shipped plugin's sidebar.
+- **`@cama_current_user` has no external writer.** The SSO plugin (`camaleon_oauth`) signs users in
+  through Doorkeeper and `login_user_with_password`, never through the ivar. What one plugin does
+  need is that `CamaleonCms::SessionHelper#cama_current_user` stay overridable by module reopening.
+- **`before_upload` runs after the content scan.** `camaleon_image_optimizer` rewrites the file and
+  rebinds `settings[:uploaded_io]` after `content_unsafe?` has already cleared the original bytes.
+
+None of this is derivable from the code in this repository, and all of it decays silently as the
+ecosystem moves. It belongs in OpenSpec, where a requirement can be checked.
+
+## What Changes
+
+- A new `ecosystem-plugin-bindings` capability records the extension surface external plugins and
+  themes bind to, as requirements with named consumers. Each requirement states a contract the
+  engine must keep and cites the repository that depends on it, so a future change that would break
+  one is caught while it is still a proposal.
+- The requirements cover: hook dispatch on the controller instance, in-place mutation of hook
+  payloads, the four admin-menu registration entry points, plugin asset helper arities, the
+  `PluginRoutes` read surface consumed at route-draw time, the uploader option and return-value
+  contract, `cama_send_email` option passthrough, and session-helper overridability.
+- `docs/ai/ecosystem.md` carries the survey inventory — every repository, its declared Camaleon
+  constraint, last activity, and what it binds — as the reference companion to the spec. `AGENTS.md`
+  gains a pointer to it in the per-task loading table.
+- No engine code changes. This change is documentation and specification only.
+
+## Capabilities
+
+### New Capabilities
+
+- `ecosystem-plugin-bindings`: the external extension contract — what plugins and themes bind to,
+  which consumer depends on each binding, and what the engine must therefore preserve.
+
+## Impact
+
+- `openspec/specs/ecosystem-plugin-bindings/spec.md` (new capability)
+- `docs/ai/ecosystem.md` (new reference inventory)
+- `AGENTS.md` (§5 loading table gains the ecosystem row)
+
+**Explicitly not in scope.** This change fixes nothing. The regression-audit medium findings whose
+disposition it informs — `post_type_list_taxonomy` (M23), admin menu title escaping (M22), the
+legacy-ivar reads (M16/M20/M21), the upload size limit (M26) — are fixed in their own changes. Two
+defects the survey found in the engine are recorded here as open questions rather than fixed:
+the `before_upload` scan-ordering seam, and the absence of `CamaleonCmsLocalUploader.private_file_path`
+that two plugins call.

--- a/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/specs/ecosystem-plugin-bindings/spec.md
+++ b/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/specs/ecosystem-plugin-bindings/spec.md
@@ -1,0 +1,203 @@
+# ecosystem-plugin-bindings
+
+## ADDED Requirements
+
+### Requirement: Hook handlers execute with the request controller as receiver
+`hooks_run` SHALL dispatch each handler on the object handling the current request, so that handlers
+can read and write controller state: `params`, `flash`, `session`, `response`, `redirect_to`,
+`render_to_string`, URL helpers, authorization helpers, and instance variables set earlier in the
+same request. A handler SHALL be able to set an instance variable in one hook and read it in another
+hook of the same request.
+
+Consumers: `camaleon_post_created_at` reads `@post` in `new_post`/`edit_post`; `camaleon_lazy_loader`
+writes `response.body` and shares `@skip_lazy_loader` across hooks; `camaleon_admin_ajax`,
+`camaleon-spree`, `camaleon-download`, `cama_subscriber` and `camaleon_export_import` write `flash`
+or read `params` from `admin_before_load`/`app_before_load`.
+
+#### Scenario: A hook handler reads a controller instance variable
+- **WHEN** a plugin registers an `edit_post` handler that reads `@post`
+- **THEN** the handler SHALL receive the post assigned by the posts controller for that request
+
+#### Scenario: A hook handler writes flash and asset state
+- **WHEN** a plugin registers an `admin_before_load` handler that sets `flash[:error]` and calls
+  `append_asset_libraries`
+- **THEN** the flash message SHALL render on that request and the registered assets SHALL be emitted
+  in that request's layout
+
+#### Scenario: State set in one hook is visible in another
+- **WHEN** a plugin sets an instance variable in an `on_render_sitemap` handler and reads it in a
+  `front_after_load` handler of the same request
+- **THEN** the value SHALL be the one written earlier in that request
+
+### Requirement: Hook payloads are mutated in place
+Where the engine passes a Hash to `hooks_run` and reads values back from it, the engine SHALL seed
+every key it will read, SHALL pass the same object to every handler, and SHALL read back the mutated
+object. Seeded collection values SHALL be non-nil and unfrozen so handlers can use `<<`, `+=` and
+`[]=` without a nil guard. `hooks_run` SHALL pass exactly one payload argument.
+
+Consumers: `camaleon_sitemap_customizer` accumulates into all four sitemap skip lists and overrides
+`args[:render]`; `cama_external_menu` suppresses a menu item with `args[:parsed_menu] = false`;
+`camaleon-spree` writes `args[:layout]` and `args[:custom_menus]`; `camaleon_post_created_at` and
+`camaleon-post-clone` append to `args[:extra_settings]`; `camaleon_lazy_loader` binds
+`on_render_sitemap` with a handler that ignores its argument.
+
+#### Scenario: A handler accumulates into a seeded collection
+- **WHEN** an `on_render_sitemap` handler appends ids to `args[:skip_post_ids]` and
+  `args[:skip_cat_ids]`
+- **THEN** the rendered sitemap SHALL omit exactly those records
+
+#### Scenario: A handler replaces a scalar the engine reads back
+- **WHEN** an `on_render_sitemap` handler assigns a different template name to `args[:render]`
+- **THEN** the engine SHALL render that template, and `args[:layout]` SHALL remain independently
+  overridable
+
+#### Scenario: A handler declares fewer parameters than the payload
+- **WHEN** a registered handler accepts one argument and ignores it
+- **THEN** the hook SHALL run without an argument-count error
+
+### Requirement: Admin menus are registrable through four entry points
+The engine SHALL accept admin menu registration through `admin_menu_append_menu_item`,
+`admin_menu_insert_menu_before`, `admin_menu_insert_menu_after`, and `admin_menu_add_menu`, callable
+from an `admin_before_load` handler. A menu entry SHALL accept `icon`, `title`, `url`, a nested
+`items` array of the same shape, and a `datas` value supplied as a pre-rendered attribute string.
+
+A menu `title` SHALL be permitted to contain inline presentational markup. The engine SHALL NOT
+render such a title as visible escaped text.
+
+Consumers: `cama_contact_form` uses `admin_menu_append_menu_item` with a `datas` string containing
+single-quoted `data-intro` and `data-position` attributes; `cama_subscriber` and `camaleon-download`
+use the insert forms with nested `items`; `camaleon-ecommerce` supplies a title containing `span`
+and `small` elements carrying a live order count.
+
+#### Scenario: A plugin registers a menu with nested items
+- **WHEN** a plugin calls `admin_menu_insert_menu_after` from `admin_before_load` with an entry
+  carrying an `items` array
+- **THEN** the parent entry and each child SHALL render in the admin sidebar
+
+#### Scenario: A menu title carries inline markup
+- **WHEN** a registered menu title contains `<span>` and `<small>` elements
+- **THEN** those elements SHALL render as markup rather than as literal text
+
+#### Scenario: A menu carries a pre-rendered datas string
+- **WHEN** a registered entry supplies `datas` as a string of single-quoted `data-*` attributes whose
+  values contain double quotes
+- **THEN** each attribute SHALL render with its value intact
+
+### Requirement: Plugin and theme asset helpers accept their published arities
+`plugin_asset_path` SHALL accept both a single asset name and an asset name with an explicit plugin
+key. `plugin_view` SHALL accept both a single view path and a view path with an explicit plugin key.
+`plugin_asset`, `plugin_gem_asset`, `append_asset_libraries` and `cama_load_custom_assets` SHALL
+remain available to plugin code, with `append_asset_libraries` accepting a nested hash of library
+name to `js`/`css` arrays.
+
+Consumers: `camaleon-cms-language-editor` calls `plugin_asset_path` with one argument and
+`camaleon_admin_ajax` with two; `cama_meta_tag` calls `plugin_view` with both arities; `cama_subscriber`,
+`cama_image_lightbox`, `camaleon-post-order-plugin` and `cama_tinymce_template` register assets
+through the library helpers.
+
+#### Scenario: An asset helper is called with an explicit plugin key
+- **WHEN** a plugin calls `plugin_asset_path('admin', 'camaleon_admin_ajax')`
+- **THEN** the helper SHALL resolve the asset for the named plugin
+
+#### Scenario: An asset helper is called without a plugin key
+- **WHEN** a plugin calls `plugin_asset_path('admin')` from its own helper
+- **THEN** the helper SHALL resolve the asset against the calling plugin
+
+### Requirement: PluginRoutes exposes a stable read surface at route-draw time
+`PluginRoutes.system_info`, `PluginRoutes.static_system_info`, `PluginRoutes.all_locales`,
+`PluginRoutes.migration_class` and `PluginRoutes.db_installed?` SHALL be callable while the host
+application draws routes and while plugin migrations load. `all_locales` SHALL return a value that
+interpolates into a route-constraint regular expression. `static_system_info['user_model']` SHALL
+remain readable, defaulting to `CamaleonCms::User`.
+
+The `PluginRoutes` constant SHALL tolerate being defined by the host application before the engine
+loads.
+
+Consumers: `cama_subscriber`, `cama_image_lightbox`, `cama-stripe-donation`, `camaleon_cms_rating`
+and `camaleon-download` interpolate `all_locales` into a `scope '(:locale)'` constraint;
+`camaleon_cms_rating` resolves `user_model` at class-definition time; `camaleon_oauth` reads
+`db_prefix` in migrations; both surveyed host applications define `PluginRoutes` in their own
+`lib/plugin_routes.rb` before bundling the gem.
+
+#### Scenario: A plugin constrains routes by locale
+- **WHEN** a plugin's `config/routes.rb` interpolates `PluginRoutes.all_locales` into a scope
+  constraint
+- **THEN** the application SHALL boot and the locale-scoped routes SHALL recognise each configured
+  locale
+
+#### Scenario: The host application predefines the constant
+- **WHEN** the host application requires its own file defining `PluginRoutes` from its `Gemfile`
+- **THEN** loading the engine SHALL NOT raise a constant conflict
+
+### Requirement: Uploader entry points keep their option and return contract
+`upload_file` and `cama_tmp_upload` SHALL accept an options hash carrying at least `maximum`, `path`,
+`folder`, `dimension`, `formats`, `name` and `remove_source`, and SHALL remain callable with no
+options. The returned value SHALL expose `file_path`, `url` and `error` under indifferent access.
+
+A `before_upload` handler SHALL be permitted to replace `settings[:uploaded_io]`, provided the
+replacement reports the same `path`. The engine SHALL compute the stored filename before running the
+handler.
+
+Consumers: `cama_contact_form` passes `maximum`, `path` and `name` from an unauthenticated endpoint;
+`camaleon_export_import` calls `cama_tmp_upload` with no options and reads `file_path`;
+`camaleon_website`'s store plugin reads both `res['url']` and `res[:error]` from the same result;
+`camaleon_image_optimizer` rewrites the file in place and rebinds `settings[:uploaded_io]`.
+
+#### Scenario: A caller reads the result with either key type
+- **WHEN** a plugin reads `result['url']` and `result[:error]` from an `upload_file` result
+- **THEN** both SHALL resolve
+
+#### Scenario: A before_upload handler replaces the IO object
+- **WHEN** a handler optimises the file in place and assigns a new `File` to `settings[:uploaded_io]`
+- **THEN** the stored file SHALL keep the filename derived before the handler ran
+
+### Requirement: Mail helpers pass plugin-defined options through
+`cama_send_email` and `cama_send_mail_to_admin` SHALL accept an options hash and SHALL NOT reject
+keys they do not recognise. `cc_to` SHALL accept an array as well as a string.
+
+Consumers: `cama_contact_form` passes `attachments` and `extra_data`; `camaleon-ecommerce` passes
+`files`, `template_name` and a plugin-specific `ecommerce_invoice`; `cama_subscriber` passes `from`,
+`template`, `layout_name` and an array `cc_to`; `camaleon_website`'s store plugin passes `attachs`
+and a string `cc_to`.
+
+#### Scenario: A caller supplies an unrecognised option key
+- **WHEN** a plugin calls `cama_send_email` with an option key the engine does not read
+- **THEN** the mail SHALL be sent and the key SHALL be available to `email_late` handlers
+
+#### Scenario: A caller supplies multiple carbon-copy recipients
+- **WHEN** `cc_to` is an array of addresses
+- **THEN** each address SHALL receive the message
+
+### Requirement: Session and site helpers remain overridable by module reopening
+`CamaleonCms::SessionHelper` and `CamaleonCms::SiteHelper` SHALL define their public helpers —
+including `cama_current_user`, the admin login, register and logout path helpers, and `current_site`
+— as ordinary instance methods on the module, so that a host application or plugin can replace one by
+reopening the module. `login_user_with_password` SHALL return the authenticated user without
+redirecting or writing a session cookie as a side effect. `cama_current_user` SHALL continue to
+resolve an API identity from an OAuth access token when one is present.
+
+Consumers: `camaleon-spree` reopens `CamaleonCms::SessionHelper` to delegate `cama_current_user` and
+the three path helpers to Spree; `camaleon_oauth` includes `SessionHelper`, `SiteHelper` and
+`HooksHelper` into `Object` and calls `login_user_with_password` from a Doorkeeper credentials block.
+
+#### Scenario: A plugin replaces the current-user resolver
+- **WHEN** a plugin reopens `CamaleonCms::SessionHelper` in a `to_prepare` block and redefines
+  `cama_current_user`
+- **THEN** engine controllers SHALL call the redefined method
+
+#### Scenario: An API client authenticates by access token
+- **WHEN** a request carries a valid OAuth access token and no session cookie
+- **THEN** `cama_current_user` SHALL resolve the token's resource owner
+
+### Requirement: Removed or renamed public APIs are recorded against their consumers
+Where an engine change removes, renames or narrows a public helper, model method or constant that
+`docs/ai/ecosystem.md` records as bound, the change SHALL state the affected consumer and the chosen
+disposition — restore, alias, or document as withdrawn — in its proposal.
+
+#### Scenario: A change removes a bound API
+- **WHEN** a proposal removes a method that the ecosystem inventory records as bound
+- **THEN** the proposal SHALL name the consuming repository and state the disposition
+
+#### Scenario: A change removes an unbound API
+- **WHEN** a proposal removes a method with no recorded consumer
+- **THEN** the inventory SHALL be cited as the basis and no compatibility shim is required

--- a/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/tasks.md
+++ b/openspec/changes/archive/2026-08-05-document-ecosystem-plugin-bindings/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: document-ecosystem-plugin-bindings
+
+## 1. Capability spec
+
+- [x] 1.1 Add `openspec/specs/ecosystem-plugin-bindings/spec.md` via the change delta — the nine
+      binding requirements, each with named consumers and scenarios.
+- [x] 1.2 `openspec validate 2026-08-05-document-ecosystem-plugin-bindings --strict` passes.
+
+## 2. Reference inventory
+
+- [x] 2.1 Add `docs/ai/ecosystem.md`: the 22-repository table, hardening hazards, the no-consumer
+      list, and the missing-API list.
+- [x] 2.2 Add the `ecosystem-plugin-bindings` / `docs/ai/ecosystem.md` row to the `AGENTS.md` §5
+      loading table.
+
+## 3. Fold the survey back into the audit
+
+- [x] 3.1 In `REGRESSION-AUDIT-2026-08-03.md`, mark M23 as ecosystem-confirmed (live consumer:
+      `camaleon-ecommerce`), and record the four reversed dispositions (M22 escape→sanitize,
+      M16 ivar dropped, M26 coercion site, M29 document-only) with the evidence.
+- [x] 3.2 Add the survey-found engine defects as new audit candidates (N2 `before_upload` post-scan
+      seam, N3 `dependent: :delete_all` on custom fields, N4 missing `private_file_path`).
+
+## 4. Ship
+
+- [x] 4.1 `(cd spec/dummy && bin/rails zeitwerk:check)` — no code changed, tree loads clean. Lint
+      not applicable (no `.rb` touched); `bin/rspec` unaffected (no behaviour change).
+- [x] 4.2 Archive this change on the branch (syncs the capability into `openspec/specs/`).
+- [x] 4.3 Commit, push, open the PR, then add the changelog entry referencing it.

--- a/openspec/specs/ecosystem-plugin-bindings/spec.md
+++ b/openspec/specs/ecosystem-plugin-bindings/spec.md
@@ -1,0 +1,205 @@
+# ecosystem-plugin-bindings Specification
+
+## Purpose
+TBD - created by archiving change 2026-08-05-document-ecosystem-plugin-bindings. Update Purpose after archive.
+## Requirements
+### Requirement: Hook handlers execute with the request controller as receiver
+`hooks_run` SHALL dispatch each handler on the object handling the current request, so that handlers
+can read and write controller state: `params`, `flash`, `session`, `response`, `redirect_to`,
+`render_to_string`, URL helpers, authorization helpers, and instance variables set earlier in the
+same request. A handler SHALL be able to set an instance variable in one hook and read it in another
+hook of the same request.
+
+Consumers: `camaleon_post_created_at` reads `@post` in `new_post`/`edit_post`; `camaleon_lazy_loader`
+writes `response.body` and shares `@skip_lazy_loader` across hooks; `camaleon_admin_ajax`,
+`camaleon-spree`, `camaleon-download`, `cama_subscriber` and `camaleon_export_import` write `flash`
+or read `params` from `admin_before_load`/`app_before_load`.
+
+#### Scenario: A hook handler reads a controller instance variable
+- **WHEN** a plugin registers an `edit_post` handler that reads `@post`
+- **THEN** the handler SHALL receive the post assigned by the posts controller for that request
+
+#### Scenario: A hook handler writes flash and asset state
+- **WHEN** a plugin registers an `admin_before_load` handler that sets `flash[:error]` and calls
+  `append_asset_libraries`
+- **THEN** the flash message SHALL render on that request and the registered assets SHALL be emitted
+  in that request's layout
+
+#### Scenario: State set in one hook is visible in another
+- **WHEN** a plugin sets an instance variable in an `on_render_sitemap` handler and reads it in a
+  `front_after_load` handler of the same request
+- **THEN** the value SHALL be the one written earlier in that request
+
+### Requirement: Hook payloads are mutated in place
+Where the engine passes a Hash to `hooks_run` and reads values back from it, the engine SHALL seed
+every key it will read, SHALL pass the same object to every handler, and SHALL read back the mutated
+object. Seeded collection values SHALL be non-nil and unfrozen so handlers can use `<<`, `+=` and
+`[]=` without a nil guard. `hooks_run` SHALL pass exactly one payload argument.
+
+Consumers: `camaleon_sitemap_customizer` accumulates into all four sitemap skip lists and overrides
+`args[:render]`; `cama_external_menu` suppresses a menu item with `args[:parsed_menu] = false`;
+`camaleon-spree` writes `args[:layout]` and `args[:custom_menus]`; `camaleon_post_created_at` and
+`camaleon-post-clone` append to `args[:extra_settings]`; `camaleon_lazy_loader` binds
+`on_render_sitemap` with a handler that ignores its argument.
+
+#### Scenario: A handler accumulates into a seeded collection
+- **WHEN** an `on_render_sitemap` handler appends ids to `args[:skip_post_ids]` and
+  `args[:skip_cat_ids]`
+- **THEN** the rendered sitemap SHALL omit exactly those records
+
+#### Scenario: A handler replaces a scalar the engine reads back
+- **WHEN** an `on_render_sitemap` handler assigns a different template name to `args[:render]`
+- **THEN** the engine SHALL render that template, and `args[:layout]` SHALL remain independently
+  overridable
+
+#### Scenario: A handler declares fewer parameters than the payload
+- **WHEN** a registered handler accepts one argument and ignores it
+- **THEN** the hook SHALL run without an argument-count error
+
+### Requirement: Admin menus are registrable through four entry points
+The engine SHALL accept admin menu registration through `admin_menu_append_menu_item`,
+`admin_menu_insert_menu_before`, `admin_menu_insert_menu_after`, and `admin_menu_add_menu`, callable
+from an `admin_before_load` handler. A menu entry SHALL accept `icon`, `title`, `url`, a nested
+`items` array of the same shape, and a `datas` value supplied as a pre-rendered attribute string.
+
+A menu `title` SHALL be permitted to contain inline presentational markup. The engine SHALL NOT
+render such a title as visible escaped text.
+
+Consumers: `cama_contact_form` uses `admin_menu_append_menu_item` with a `datas` string containing
+single-quoted `data-intro` and `data-position` attributes; `cama_subscriber` and `camaleon-download`
+use the insert forms with nested `items`; `camaleon-ecommerce` supplies a title containing `span`
+and `small` elements carrying a live order count.
+
+#### Scenario: A plugin registers a menu with nested items
+- **WHEN** a plugin calls `admin_menu_insert_menu_after` from `admin_before_load` with an entry
+  carrying an `items` array
+- **THEN** the parent entry and each child SHALL render in the admin sidebar
+
+#### Scenario: A menu title carries inline markup
+- **WHEN** a registered menu title contains `<span>` and `<small>` elements
+- **THEN** those elements SHALL render as markup rather than as literal text
+
+#### Scenario: A menu carries a pre-rendered datas string
+- **WHEN** a registered entry supplies `datas` as a string of single-quoted `data-*` attributes whose
+  values contain double quotes
+- **THEN** each attribute SHALL render with its value intact
+
+### Requirement: Plugin and theme asset helpers accept their published arities
+`plugin_asset_path` SHALL accept both a single asset name and an asset name with an explicit plugin
+key. `plugin_view` SHALL accept both a single view path and a view path with an explicit plugin key.
+`plugin_asset`, `plugin_gem_asset`, `append_asset_libraries` and `cama_load_custom_assets` SHALL
+remain available to plugin code, with `append_asset_libraries` accepting a nested hash of library
+name to `js`/`css` arrays.
+
+Consumers: `camaleon-cms-language-editor` calls `plugin_asset_path` with one argument and
+`camaleon_admin_ajax` with two; `cama_meta_tag` calls `plugin_view` with both arities; `cama_subscriber`,
+`cama_image_lightbox`, `camaleon-post-order-plugin` and `cama_tinymce_template` register assets
+through the library helpers.
+
+#### Scenario: An asset helper is called with an explicit plugin key
+- **WHEN** a plugin calls `plugin_asset_path('admin', 'camaleon_admin_ajax')`
+- **THEN** the helper SHALL resolve the asset for the named plugin
+
+#### Scenario: An asset helper is called without a plugin key
+- **WHEN** a plugin calls `plugin_asset_path('admin')` from its own helper
+- **THEN** the helper SHALL resolve the asset against the calling plugin
+
+### Requirement: PluginRoutes exposes a stable read surface at route-draw time
+`PluginRoutes.system_info`, `PluginRoutes.static_system_info`, `PluginRoutes.all_locales`,
+`PluginRoutes.migration_class` and `PluginRoutes.db_installed?` SHALL be callable while the host
+application draws routes and while plugin migrations load. `all_locales` SHALL return a value that
+interpolates into a route-constraint regular expression. `static_system_info['user_model']` SHALL
+remain readable, defaulting to `CamaleonCms::User`.
+
+The `PluginRoutes` constant SHALL tolerate being defined by the host application before the engine
+loads.
+
+Consumers: `cama_subscriber`, `cama_image_lightbox`, `cama-stripe-donation`, `camaleon_cms_rating`
+and `camaleon-download` interpolate `all_locales` into a `scope '(:locale)'` constraint;
+`camaleon_cms_rating` resolves `user_model` at class-definition time; `camaleon_oauth` reads
+`db_prefix` in migrations; both surveyed host applications define `PluginRoutes` in their own
+`lib/plugin_routes.rb` before bundling the gem.
+
+#### Scenario: A plugin constrains routes by locale
+- **WHEN** a plugin's `config/routes.rb` interpolates `PluginRoutes.all_locales` into a scope
+  constraint
+- **THEN** the application SHALL boot and the locale-scoped routes SHALL recognise each configured
+  locale
+
+#### Scenario: The host application predefines the constant
+- **WHEN** the host application requires its own file defining `PluginRoutes` from its `Gemfile`
+- **THEN** loading the engine SHALL NOT raise a constant conflict
+
+### Requirement: Uploader entry points keep their option and return contract
+`upload_file` and `cama_tmp_upload` SHALL accept an options hash carrying at least `maximum`, `path`,
+`folder`, `dimension`, `formats`, `name` and `remove_source`, and SHALL remain callable with no
+options. The returned value SHALL expose `file_path`, `url` and `error` under indifferent access.
+
+A `before_upload` handler SHALL be permitted to replace `settings[:uploaded_io]`, provided the
+replacement reports the same `path`. The engine SHALL compute the stored filename before running the
+handler.
+
+Consumers: `cama_contact_form` passes `maximum`, `path` and `name` from an unauthenticated endpoint;
+`camaleon_export_import` calls `cama_tmp_upload` with no options and reads `file_path`;
+`camaleon_website`'s store plugin reads both `res['url']` and `res[:error]` from the same result;
+`camaleon_image_optimizer` rewrites the file in place and rebinds `settings[:uploaded_io]`.
+
+#### Scenario: A caller reads the result with either key type
+- **WHEN** a plugin reads `result['url']` and `result[:error]` from an `upload_file` result
+- **THEN** both SHALL resolve
+
+#### Scenario: A before_upload handler replaces the IO object
+- **WHEN** a handler optimises the file in place and assigns a new `File` to `settings[:uploaded_io]`
+- **THEN** the stored file SHALL keep the filename derived before the handler ran
+
+### Requirement: Mail helpers pass plugin-defined options through
+`cama_send_email` and `cama_send_mail_to_admin` SHALL accept an options hash and SHALL NOT reject
+keys they do not recognise. `cc_to` SHALL accept an array as well as a string.
+
+Consumers: `cama_contact_form` passes `attachments` and `extra_data`; `camaleon-ecommerce` passes
+`files`, `template_name` and a plugin-specific `ecommerce_invoice`; `cama_subscriber` passes `from`,
+`template`, `layout_name` and an array `cc_to`; `camaleon_website`'s store plugin passes `attachs`
+and a string `cc_to`.
+
+#### Scenario: A caller supplies an unrecognised option key
+- **WHEN** a plugin calls `cama_send_email` with an option key the engine does not read
+- **THEN** the mail SHALL be sent and the key SHALL be available to `email_late` handlers
+
+#### Scenario: A caller supplies multiple carbon-copy recipients
+- **WHEN** `cc_to` is an array of addresses
+- **THEN** each address SHALL receive the message
+
+### Requirement: Session and site helpers remain overridable by module reopening
+`CamaleonCms::SessionHelper` and `CamaleonCms::SiteHelper` SHALL define their public helpers —
+including `cama_current_user`, the admin login, register and logout path helpers, and `current_site`
+— as ordinary instance methods on the module, so that a host application or plugin can replace one by
+reopening the module. `login_user_with_password` SHALL return the authenticated user without
+redirecting or writing a session cookie as a side effect. `cama_current_user` SHALL continue to
+resolve an API identity from an OAuth access token when one is present.
+
+Consumers: `camaleon-spree` reopens `CamaleonCms::SessionHelper` to delegate `cama_current_user` and
+the three path helpers to Spree; `camaleon_oauth` includes `SessionHelper`, `SiteHelper` and
+`HooksHelper` into `Object` and calls `login_user_with_password` from a Doorkeeper credentials block.
+
+#### Scenario: A plugin replaces the current-user resolver
+- **WHEN** a plugin reopens `CamaleonCms::SessionHelper` in a `to_prepare` block and redefines
+  `cama_current_user`
+- **THEN** engine controllers SHALL call the redefined method
+
+#### Scenario: An API client authenticates by access token
+- **WHEN** a request carries a valid OAuth access token and no session cookie
+- **THEN** `cama_current_user` SHALL resolve the token's resource owner
+
+### Requirement: Removed or renamed public APIs are recorded against their consumers
+Where an engine change removes, renames or narrows a public helper, model method or constant that
+`docs/ai/ecosystem.md` records as bound, the change SHALL state the affected consumer and the chosen
+disposition — restore, alias, or document as withdrawn — in its proposal.
+
+#### Scenario: A change removes a bound API
+- **WHEN** a proposal removes a method that the ecosystem inventory records as bound
+- **THEN** the proposal SHALL name the consuming repository and state the disposition
+
+#### Scenario: A change removes an unbound API
+- **WHEN** a proposal removes a method with no recorded consumer
+- **THEN** the inventory SHALL be cited as the basis and no compatibility shim is required
+


### PR DESCRIPTION
## What and Why

`AGENTS.md` warns that most plugins and themes live in separate gems and that a public helper's return contract "cannot be verified from this repo alone" — but nothing behind that warning recorded *which* extension points external code actually binds to. Every compatibility decision was therefore made blind, and the regression audit's medium findings each carried a "restore, or document as intended?" question this repo could not answer.

This surveys the 22 public ecosystem repositories named in `README.md` — 16 plugins, 4 themes, and the two production host applications that run them — against `master`, and captures what they bind to as an OpenSpec capability, `ecosystem-plugin-bindings`. Each of its nine requirements names the consumer that depends on it (hook dispatch on the controller instance, in-place hook-payload mutation, the four admin-menu entry points, plugin asset helper arities, the `PluginRoutes` read surface, the uploader option/return contract, `cama_send_email` option passthrough, session-helper overridability), so a future change that would break one is caught while it is still a proposal. `docs/ai/ecosystem.md` is the reference inventory behind the spec — the repository table, the hardening hazards, the APIs with no surveyed consumer, and three APIs plugins call that are already missing from core — and `AGENTS.md` §5 gains a pointer to it.

The survey overturned several assumptions that had been made from core-only reasoning: the SSO plugin never assigns `@cama_current_user` (it signs in through Doorkeeper), admin menu titles carry HTML in a shipped plugin, `post_type_list_taxonomy`'s two-argument form has a live consumer, and `before_upload` runs after the content scan. Those are recorded for the fixes that will act on them; this change itself touches no engine code.

A second commit removes the defunct `gaelfokou/cama_autocomplete` plugin (repository gone, no gem published) from the README plugin list and the example Gemfile.

**User-Visible Impact:** None — documentation and specification only; the sole runtime-adjacent edit removes a dead plugin link from the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
