### PR TITLE
Codify the security-capability-gating rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Docs:** Codified the security-capability-gating rule — a security-sensitive action is admin-only by
+  default and gated for non-admins by a dedicated, off-by-default, fail-closed role permission
+  (authorization, never a path/filename/flag proxy, and never fail-open). Adds the
+  `security-capability-gating` OpenSpec capability, a "The gating rule" section in
+  `docs/security/permissions.md` with a recipe for adding a new gated capability, and a
+  `docs/ai/criteria.md` checkpoint. No engine changes; the four existing permissions are cited as
+  templates. [#1231](https://github.com/owen2345/camaleon-cms/pull/1231).
+
 - **Docs:** Removed the defunct Autocomplete plugin (`gaelfokou/cama_autocomplete` — repository and
   gem no longer exist) from the README plugin list and the example Gemfile, and recorded the external
   plugin/theme binding surface as the `ecosystem-plugin-bindings` OpenSpec capability with a

--- a/docs/ai/criteria.md
+++ b/docs/ai/criteria.md
@@ -18,6 +18,7 @@ Before marking any task complete, evaluate against these criteria.
 - No `eval`, `instance_eval`, or `class_eval` with user input
 - SQL queries use parameterized forms
 - User input is sanitized appropriately
+- Security-sensitive actions follow the gating rule: admin-only by default, gated for non-admins by a dedicated, off-by-default, fail-closed permission — never a path/filename/flag proxy, never fail-open. See `docs/security/permissions.md` ("The gating rule") and the `security-capability-gating` spec.
 
 ## Rails Conventions
 

--- a/docs/security/permissions.md
+++ b/docs/security/permissions.md
@@ -10,6 +10,24 @@ Camaleon CMS defines role permissions in two families, both rendered in the User
 
 Users with the `admin` role satisfy every check through `can :manage, :all` in the Ability class, independently of role meta.
 
+## The gating rule
+
+Every permission on this page is an instance of one rule, and a new security-sensitive capability MUST follow it:
+
+1. **Administrators can do anything.** The `admin` role satisfies every check through `can :manage, :all`, before any role meta is read.
+2. **For every other role, an action that presents a security threat is allowed only through a dedicated permission that is off by default.** The permission is never seeded onto a non-admin role, so an existing install reads it as not-granted with no migration; and the check **fails closed** — with no `CurrentRequest` user or site (a background job, a rake task, the console), the caller is treated as untrusted.
+
+The gate is an **authorization** decision, never a proxy for one. A filesystem path, an output filename, a client-supplied flag or a network location can each be walked through by the caller; [#1228](https://github.com/owen2345/camaleon-cms/pull/1228) replaced exactly such a path-based upload exemption with `media_unfiltered_upload` for that reason. Where content can be substituted after the check — a `before_upload` handler rewriting the scanned bytes — the substituted content is re-checked, not trusted because the handler ran. A check that fails *open* (allowing the action when it cannot evaluate the permission) is the bug this rule exists to prevent.
+
+**Adding a new gated capability** — the four documented below are the templates:
+
+1. Add the key to `UserRole::ROLES[:manager]` (site-wide) or `ROLES[:post_type]` (per post type) with `color: 'danger'` and an i18n label/description.
+2. Gate the dangerous work behind a predicate that mirrors `Post#trusted_for_unfiltered_html?` or `CamaleonCms::UploaderContentSecurity#cama_trusted_for_unfiltered_upload?`: read `CurrentRequest.user` and `CurrentRequest.site`, return false if either is blank, otherwise ask `CamaleonCms::Ability`, and `rescue StandardError` to false. Check it *before* doing the work.
+3. Seed no non-admin role with the key. For a **post-type** permission, also add `next if key == '<key>'` to the Editor post-type seeding in `site_default_settings.rb`, which otherwise grants every post-type key.
+4. Ship a spec that reproduces the threat (per `AGENTS.md`) and covers the admin-allowed, non-admin-refused, granted-allowed and no-request-context-refused cases.
+
+The convention is specified as `openspec/specs/security-capability-gating/spec.md`.
+
 ## Manager permissions
 
 - `custom_fields` — Controls who can create/update Custom Field Groups and Custom Fields (write-time permission). This is a manager-level permission

--- a/openspec/changes/archive/2026-08-08-security-capability-gating/design.md
+++ b/openspec/changes/archive/2026-08-08-security-capability-gating/design.md
@@ -1,0 +1,43 @@
+# Design: security-capability-gating
+
+## Why a convention capability, not just docs
+
+A doc records the rule; a spec makes a proposal that violates it visible at review time. The
+`ecosystem-plugin-bindings` capability does the same for external contracts — a requirement a later
+change is measured against. Here the "conformant examples" are the four permissions that already
+implement the rule, and the governance requirement is what a new security-sensitive action is checked
+against before it merges.
+
+## The three parts of the rule
+
+**Admin bypass.** `Ability#initialize` answers `can :manage, :all` for the `admin` role before any
+role meta is read, so administrators satisfy every check without holding the permission. This is why a
+new permission needs no admin backfill and why the admin role's checkbox for it reads unchecked but
+effective.
+
+**Default-off for everyone else.** The permission lives in `UserRole::ROLES[:manager]` (site-wide) or
+`ROLES[:post_type]` (per type), with `color: 'danger'`. Role seeding writes manager/post-type metas
+only for the roles that should have them — never the new key onto a non-admin role — so an upgraded
+install reads the absent key as not-granted and needs no migration. The one wrinkle is the Editor
+post-type seeding, which grants every post-type key; a genuinely dangerous post-type permission needs
+an explicit `next if key == '<key>'` skip there, as `post_content_unfiltered_html` has.
+
+**Fail closed.** The predicate mirrors `Post#trusted_for_unfiltered_html?` and
+`UploaderContentSecurity#cama_trusted_for_unfiltered_upload?`: read `CurrentRequest.user` and
+`CurrentRequest.site`, return false if either is blank, otherwise ask `CamaleonCms::Ability`, and
+`rescue StandardError` to false. The blank-context branch is what makes rake tasks, jobs and the
+console untrusted by default; the rescue is what turns malformed role meta into a refusal, not a 500.
+
+## Authorization, not a proxy
+
+The requirement that the gate be an authorization check — not a filesystem path, an output filename, a
+client-supplied flag, or a network location — is the #1228 lesson stated as a rule. A path-based upload
+exemption was bypassable because the output name is caller-supplied; the fix was to ask *who*, not
+*where*. The same reasoning rejects "trust a `before_upload` handler by definition" for N2: a handler
+that swaps the scanned bytes is re-checked against the permission, not waved through because it ran.
+
+## What this does not do
+
+It does not change the four existing permissions, retrofit any check, or implement N2. It is the rule
+plus its enforcement seam. Retrofitting an existing ad-hoc, fail-open or proxy-gated check is a
+per-finding fix that cites this capability when it lands — starting with N2.

--- a/openspec/changes/archive/2026-08-08-security-capability-gating/proposal.md
+++ b/openspec/changes/archive/2026-08-08-security-capability-gating/proposal.md
@@ -1,0 +1,48 @@
+# Proposal: security-capability-gating
+
+## Why
+
+Camaleon already answers "may a non-admin do this dangerous thing?" with a role permission in four
+places — `post_content_unfiltered_html`, `contact_form_unfiltered_html`, `media_unfiltered_upload`,
+and `select_eval` — each held only by administrators by default and each failing closed when there is
+no request context. But the pattern is convention by repetition, not a stated rule. Nothing catches a
+new security-sensitive action shipped ungated, gated by a bypassable proxy (a filesystem path, an
+output filename, a client flag), or failing open.
+
+Both failure modes have already happened. [#1228](https://github.com/owen2345/camaleon-cms/pull/1228)
+was a correction after the fact: an upload exemption keyed on a source path that a caller-supplied
+output filename could walk through, replaced by a permission. And `cama_external_menu` in the surveyed
+ecosystem ships the opposite failure — an access check that fails *open*, so restricted menus become
+public if the hook stops running. State the rule once, as a checkable convention.
+
+## What Changes
+
+- A new `security-capability-gating` capability states the rule as requirements: the default-off
+  permission, admin-by-`can :manage, :all`, the fail-closed predicate, authorization rather than a
+  proxy signal, and a governance requirement that a new security-sensitive action conforms and cites
+  it.
+- `docs/security/permissions.md` gains a "The gating rule" section stating the principle and the
+  recipe for adding a new gated capability, ahead of the per-permission detail it already carries.
+- `docs/ai/criteria.md` gains a Security-section line pointing at the rule, so the pre-PR self-audit
+  checks it.
+- No engine code changes. The four existing permissions already conform and are cited as the
+  templates; they are not modified.
+
+## Capabilities
+
+### New Capabilities
+
+- `security-capability-gating`: a security-sensitive action is admin-only by default and gated for
+  non-admins by a dedicated, default-off, fail-closed role permission — authorization, never a proxy
+  signal, and never fail-open.
+
+## Impact
+
+- `openspec/specs/security-capability-gating/spec.md` (new)
+- `docs/security/permissions.md` (new section)
+- `docs/ai/criteria.md` (Security pointer)
+
+**Not in scope.** This codifies the rule; it does not retrofit existing ad-hoc checks beyond citing
+them, and it implements no specific fix. The first application under the codified rule is the N2 upload
+finding (re-scan the bytes a `before_upload` handler swaps in, for a caller without
+`media_unfiltered_upload`), which lands with its own change.

--- a/openspec/changes/archive/2026-08-08-security-capability-gating/specs/security-capability-gating/spec.md
+++ b/openspec/changes/archive/2026-08-08-security-capability-gating/specs/security-capability-gating/spec.md
@@ -1,0 +1,72 @@
+# security-capability-gating
+
+## ADDED Requirements
+
+### Requirement: Security-sensitive actions are gated by a default-off role permission
+Any action or method that presents a security threat SHALL be permitted for a non-administrator role
+only when that role holds a dedicated permission for it. The permission SHALL be off by default: it
+SHALL NOT be seeded onto any non-administrator role, so an existing installation reads it as
+not-granted without a migration. Administrators SHALL satisfy the check through `can :manage, :all`
+without the permission being present in role meta.
+
+Conformant examples: `post_content_unfiltered_html`, `contact_form_unfiltered_html`,
+`media_unfiltered_upload`, `select_eval`.
+
+#### Scenario: An administrator performs the action
+- **WHEN** a user with the `admin` role performs a gated security-sensitive action
+- **THEN** it SHALL be allowed without the permission being present in any role meta
+
+#### Scenario: A non-administrator without the permission
+- **WHEN** a non-administrator role that does not hold the permission attempts the action
+- **THEN** the restricted behavior SHALL apply — the action is refused, or its safe/sanitized path is
+  taken
+
+#### Scenario: A non-administrator granted the permission
+- **WHEN** the permission is granted to a non-administrator role
+- **THEN** that role SHALL be allowed to perform the action
+
+#### Scenario: An upgraded installation
+- **WHEN** a role's stored permission meta predates the new permission
+- **THEN** the absent key SHALL read as not-granted, with no migration required
+
+### Requirement: The permission check fails closed
+The gate SHALL read the acting user and site from `CurrentRequest` and SHALL treat the caller as
+untrusted when either is absent, so background jobs, rake tasks and the console get the restricted
+behavior by default. A failure while evaluating the permission — for example malformed role meta —
+SHALL resolve to untrusted rather than raising.
+
+#### Scenario: No request context
+- **WHEN** the action runs with no `CurrentRequest` user or site (a job, rake task, or console)
+- **THEN** the caller SHALL be treated as untrusted and the restricted behavior SHALL apply
+
+#### Scenario: Malformed permission data
+- **WHEN** evaluating the permission raises
+- **THEN** the gate SHALL resolve to untrusted rather than aborting the request
+
+### Requirement: Authorization decides, not a proxy signal
+The gate SHALL be an authorization check on the acting user. It SHALL NOT be decided by a filesystem
+path, an output filename, a client-supplied parameter, a network location, or the mere fact that a
+hook or handler ran. Where content or an action can be substituted after the check — such as a
+`before_upload` handler replacing the scanned bytes — the substituted content SHALL be re-checked
+against the permission rather than trusted.
+
+#### Scenario: The same action reached by a different path
+- **WHEN** the same bytes or action are presented under a different path or output filename
+- **THEN** the authorization outcome SHALL be the same
+
+#### Scenario: Content substituted after the check
+- **WHEN** a hook replaces the checked content after the gate ran, for a caller without the permission
+- **THEN** the substituted content SHALL be re-checked rather than accepted unscanned
+
+### Requirement: New security-sensitive capabilities conform to this rule
+When a change introduces an action or method that presents a security threat to non-administrator
+roles, it SHALL gate it per this capability and SHALL cite this capability. It SHALL NOT ship the
+action ungated, gate it by a non-authorization proxy, or let the check fail open.
+
+#### Scenario: A proposal adds a dangerous action
+- **WHEN** a proposal introduces a security-sensitive action available to non-administrators
+- **THEN** it SHALL add a default-off, fail-closed permission gating it and reference this capability
+
+#### Scenario: A proposal gates by a proxy signal
+- **WHEN** a proposal would gate such an action by a path, filename, or client flag
+- **THEN** it SHALL be revised to gate on the acting user's permission instead

--- a/openspec/changes/archive/2026-08-08-security-capability-gating/tasks.md
+++ b/openspec/changes/archive/2026-08-08-security-capability-gating/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: security-capability-gating
+
+## 1. Capability spec
+
+- [x] 1.1 Author `specs/security-capability-gating/spec.md` with the default-off, fail-closed,
+      authorization-not-proxy, and conform-new-capabilities requirements, citing the four existing
+      permissions as conformant examples.
+
+## 2. Docs
+
+- [x] 2.1 Add a "The gating rule" section to `docs/security/permissions.md` above the per-permission
+      detail: the rule, the admin bypass, default-off seeding, the fail-closed predicate, and the
+      recipe for adding a new gated capability.
+- [x] 2.2 Add a Security-section line to `docs/ai/criteria.md` pointing at the rule.
+
+## 3. Ship
+
+- [x] 3.1 `openspec validate --strict` on the new capability; `(cd spec/dummy && bin/rails zeitwerk:check)`
+      (no code changed). Lint and `bin/rspec` not applicable — docs + spec only.
+- [x] 3.2 Archive on the branch (syncs the capability into `openspec/specs/`).
+- [x] 3.3 Commit, push, open the PR, then add the changelog entry referencing it.

--- a/openspec/specs/security-capability-gating/spec.md
+++ b/openspec/specs/security-capability-gating/spec.md
@@ -1,0 +1,74 @@
+# security-capability-gating Specification
+
+## Purpose
+TBD - created by archiving change security-capability-gating. Update Purpose after archive.
+## Requirements
+### Requirement: Security-sensitive actions are gated by a default-off role permission
+Any action or method that presents a security threat SHALL be permitted for a non-administrator role
+only when that role holds a dedicated permission for it. The permission SHALL be off by default: it
+SHALL NOT be seeded onto any non-administrator role, so an existing installation reads it as
+not-granted without a migration. Administrators SHALL satisfy the check through `can :manage, :all`
+without the permission being present in role meta.
+
+Conformant examples: `post_content_unfiltered_html`, `contact_form_unfiltered_html`,
+`media_unfiltered_upload`, `select_eval`.
+
+#### Scenario: An administrator performs the action
+- **WHEN** a user with the `admin` role performs a gated security-sensitive action
+- **THEN** it SHALL be allowed without the permission being present in any role meta
+
+#### Scenario: A non-administrator without the permission
+- **WHEN** a non-administrator role that does not hold the permission attempts the action
+- **THEN** the restricted behavior SHALL apply — the action is refused, or its safe/sanitized path is
+  taken
+
+#### Scenario: A non-administrator granted the permission
+- **WHEN** the permission is granted to a non-administrator role
+- **THEN** that role SHALL be allowed to perform the action
+
+#### Scenario: An upgraded installation
+- **WHEN** a role's stored permission meta predates the new permission
+- **THEN** the absent key SHALL read as not-granted, with no migration required
+
+### Requirement: The permission check fails closed
+The gate SHALL read the acting user and site from `CurrentRequest` and SHALL treat the caller as
+untrusted when either is absent, so background jobs, rake tasks and the console get the restricted
+behavior by default. A failure while evaluating the permission — for example malformed role meta —
+SHALL resolve to untrusted rather than raising.
+
+#### Scenario: No request context
+- **WHEN** the action runs with no `CurrentRequest` user or site (a job, rake task, or console)
+- **THEN** the caller SHALL be treated as untrusted and the restricted behavior SHALL apply
+
+#### Scenario: Malformed permission data
+- **WHEN** evaluating the permission raises
+- **THEN** the gate SHALL resolve to untrusted rather than aborting the request
+
+### Requirement: Authorization decides, not a proxy signal
+The gate SHALL be an authorization check on the acting user. It SHALL NOT be decided by a filesystem
+path, an output filename, a client-supplied parameter, a network location, or the mere fact that a
+hook or handler ran. Where content or an action can be substituted after the check — such as a
+`before_upload` handler replacing the scanned bytes — the substituted content SHALL be re-checked
+against the permission rather than trusted.
+
+#### Scenario: The same action reached by a different path
+- **WHEN** the same bytes or action are presented under a different path or output filename
+- **THEN** the authorization outcome SHALL be the same
+
+#### Scenario: Content substituted after the check
+- **WHEN** a hook replaces the checked content after the gate ran, for a caller without the permission
+- **THEN** the substituted content SHALL be re-checked rather than accepted unscanned
+
+### Requirement: New security-sensitive capabilities conform to this rule
+When a change introduces an action or method that presents a security threat to non-administrator
+roles, it SHALL gate it per this capability and SHALL cite this capability. It SHALL NOT ship the
+action ungated, gate it by a non-authorization proxy, or let the check fail open.
+
+#### Scenario: A proposal adds a dangerous action
+- **WHEN** a proposal introduces a security-sensitive action available to non-administrators
+- **THEN** it SHALL add a default-off, fail-closed permission gating it and reference this capability
+
+#### Scenario: A proposal gates by a proxy signal
+- **WHEN** a proposal would gate such an action by a path, filename, or client flag
+- **THEN** it SHALL be revised to gate on the acting user's permission instead
+


### PR DESCRIPTION
## What and Why

Camaleon already answers "may a non-admin do this dangerous thing?" with a role permission in four places — `post_content_unfiltered_html`, `contact_form_unfiltered_html`, `media_unfiltered_upload`, and `select_eval` — each held only by administrators by default, each failing closed when there is no request context. But the pattern was convention by repetition, not a stated rule, so nothing catches a new security-sensitive action shipped ungated, gated by a bypassable proxy (a filesystem path, an output filename, a client flag), or failing open. Both failure modes have already occurred: [#1228](https://github.com/owen2345/camaleon-cms/pull/1228) was an after-the-fact correction of a path-based upload exemption that a caller-supplied output filename could walk through, and a surveyed ecosystem plugin ships an access check that fails *open*.

This states the rule once, as a checkable convention:

1. **Administrators can do anything** — they satisfy `can :manage, :all` before any role meta is read.
2. **For every other role, an action that presents a security threat is allowed only through a dedicated permission that is off by default**, is never seeded onto a non-admin role (so upgrades need no migration), and **fails closed** — no `CurrentRequest` user or site (a job, rake task, or the console) means untrusted.
3. **The gate is an authorization decision, never a proxy for one** — not a path, filename, client flag, or network location; and content substituted after the check (a `before_upload` handler swapping the scanned bytes) is re-checked, not trusted because the handler ran.

It ships as the `security-capability-gating` OpenSpec capability (four requirements, including a governance requirement that a new security-sensitive action conforms and cites it), a "The gating rule" section in `docs/security/permissions.md` with the recipe for adding a new gated capability, and a Security-section pointer in `docs/ai/criteria.md` so the pre-PR self-audit checks it. The four existing permissions are cited as the templates; none is modified.

**User-Visible Impact:** None — documentation and specification only; no engine code changes and no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
