### PR TITLE
Skip CI on fully-docs PRs while master is unprotected

### DIFF
--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -60,18 +60,20 @@ If YES, you MUST format the commit message as:
 
 **⚠️ The marker is per-push, not per-commit.** GitHub evaluates it against the **head commit of the push**, so a `[skip ci]` commit at the tip suppresses every workflow for that push — including the `pull_request` event when the PR is opened at that tip. Push three commits ending on a docs-only one and *nothing* runs, for any of them.
 
-**Decide the marker per push, not per commit, by answering one question:**
+**First: is the *entire PR* docs-only?** If every commit on the branch touches only documentation, specs (`openspec/`), `CHANGELOG.md`, or config with no code paths, mark **every** commit `[skip ci]` — including the first — so the PR runs no CI at all. Such a tree gives the code matrix nothing to validate, and `master` carries **no branch protection** (no required status checks), so a PR with zero runs still merges. This is the primary path for a documentation-, spec-, or changelog-only PR, and it overrides the one-run rule below. *(It depends on `master` staying unprotected: if a required-status-check rule is ever added, a PR with no run would be unmergeable and this carve-out must be revisited — re-check with `gh api repos/owen2345/camaleon-cms/branches/master --jq '.protected'`.)*
+
+**Otherwise** — the PR includes a code change in some commit — decide the marker per push, not per commit, by answering one question:
 
 > Has this PR already had a full check run on an earlier push?
 
-- **No** — omit the marker, *even on a docs-only push*, and say why in the message. Every PR must get one full check run, and a push whose head carries the marker produces none. This is the case when the branch has no PR yet, or when every push so far has been docs-only.
+- **No** — omit the marker on that push, *even if the push itself is docs-only*, and say why in the message. A mixed PR must get one full check run over its code, and a push whose head carries the marker produces none. This is the case when the branch has no PR yet, or when every push so far has been docs-only.
 - **Yes** — include the marker. A second run on a docs-only change revalidates nothing. CI validates the tree at the head commit, and a `CHANGELOG.md` edit does not change any tree the earlier run already covered.
 
 **The Phase 4 changelog commit is normally in the "Yes" branch.** It lands after the PR exists, which means an earlier push already opened the PR and triggered CI. Omitting the marker there duplicates the entire matrix to validate a Markdown edit. Do not read "the changelog commit lands last" as a reason to omit the marker — *lands last* is not the condition; *no run yet* is.
 
 Other consequences to plan for:
 
-- **Including the marker moves the PR head without triggering a run.** The passing checks stay attached to the previous SHA. Before merge, check whether branch protection requires checks on the head commit, and re-trigger only if it does.
+- **Including the marker moves the PR head without triggering a run.** The passing checks stay attached to the previous SHA. Before merge, check whether branch protection requires checks on the head commit, and re-trigger only if it does — `master` currently has none, so no re-trigger is needed.
 - **If you have already pushed a docs-only commit without the marker**, cancel the now-stale runs on the *previous* SHA, not the new ones. The PR head has moved, so the new runs are the ones that count for merge.
 - **The marker matches anywhere in the message, including the body.** A commit that merely *explains* the directive will skip CI too. Write "skip-ci directive" in prose rather than the literal token — unless you are actually invoking it, in which case it belongs on its own line as shown above.
 


### PR DESCRIPTION
## What and Why

`docs/ai/workflows.md` Phase 3 previously required every PR to get one full CI run — the first push omitted `[skip ci]` even when the push was docs-only — on the reasoning that "every PR must get one full check run." That reasoning was really about satisfying required status checks, and `master` has **no branch protection** (`branches/master.protected` is `false`; the protection endpoint 404s; no rulesets), so nothing requires a check to merge.

Phase 3 now short-circuits before the per-push logic: when the **entire PR** touches only documentation, specs (`openspec/`), `CHANGELOG.md`, or config with no code paths, every commit is marked `[skip ci]` — including the first — so the PR runs no CI at all. A tree with no code gives the matrix nothing to validate, and a zero-run PR still merges while `master` is unprotected. Mixed PRs (any commit with code) keep the existing one-run rule unchanged. The carve-out documents its dependence on `master` staying unprotected and how to re-check it, and the "re-trigger" note now records that `master` currently has no required checks.

This PR is itself docs-only and is the first to follow the new rule — **no CI is expected to run on it.**

**User-Visible Impact:** None — internal agent-workflow guidance only; no gem code, no behavior change. (No changelog entry: the change has no upgrader relevance, which is the changelog's stated audience.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
