### PR TITLE
Restore caller-set @current_site so multisite mail sends (M21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Fix:** On multisite installs, background and cross-site email (password reset, email confirmation,
+  admin notifications) raised `NameError` during delivery and sent nothing — `SiteHelper#current_site`
+  stopped honoring the `@current_site` that `HtmlMailer` sets, so a delivery with no request fell
+  through to a request-only branch. Restored; single-site installs were unaffected.
+  [#1233](https://github.com/owen2345/camaleon-cms/pull/1233).
+
 - **Docs:** Codified the security-capability-gating rule — a security-sensitive action is admin-only by
   default and gated for non-admins by a dedicated, off-by-default, fail-closed role permission
   (authorization, never a path/filename/flag proxy, and never fail-open). Adds the

--- a/app/helpers/camaleon_cms/site_helper.rb
+++ b/app/helpers/camaleon_cms/site_helper.rb
@@ -13,6 +13,17 @@ module CamaleonCms
         return $current_site
       end
 
+      # Honor a caller-set @current_site (HtmlMailer and other background senders assign it) before the
+      # memoized CurrentRequest.site, so a delivery for another site resolves against that site rather
+      # than the request's. Restores 2.9.2; without it, multisite/background mail resolves the wrong site
+      # or raises NameError on `request` in a job. See regression audit M21. Read via
+      # instance_variable_get to match #current_theme and avoid Rails/HelperInstanceVariable.
+      caller_site = (instance_variable_get(:@current_site) if instance_variable_defined?(:@current_site))
+      if caller_site.present?
+        CurrentRequest.site = caller_site
+        return caller_site
+      end
+
       return CurrentRequest.site if CurrentRequest.site.present?
 
       if PluginRoutes.get_sites.size == 1

--- a/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/design.md
+++ b/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/design.md
@@ -1,0 +1,40 @@
+# Design: restore-caller-site-resolution
+
+## The resolution order
+
+`SiteHelper#current_site` resolves in precedence order, each winner short-circuiting:
+
+1. an explicit `site` argument;
+2. the `$current_site` global;
+3. **a caller-set `@current_site` instance variable** — restored here;
+4. the memoized `CurrentRequest.site`;
+5. otherwise compute from `PluginRoutes.get_sites` (single-site) or the request host (multisite), then
+   memoize into `CurrentRequest.site`.
+
+Step 3 is what #1177 dropped. Its placement between 2 and 4 is load-bearing: a background sender assigns
+`@current_site` for the site it is mailing about, and that must win over whatever site the current
+request (if any) already memoized into `CurrentRequest.site`. Putting it after step 4 would let an
+in-request `deliver_now` for site B resolve against the request's site A.
+
+## Why the ivar, not only CurrentRequest
+
+`HtmlMailer` (and other senders) assign `@current_site` directly — that is the seam they already use, and
+`CurrentRequest.site` is deliberately left blank in a job so per-request state does not leak across
+deliveries. Reading the ivar honors the existing contract without asking every sender to learn a new one.
+The check uses `instance_variable_defined?(:@current_site)` — matching `current_theme`'s existing
+`instance_variable_defined?(:@_current_theme)` guard — so an object that never set it is untouched.
+
+The branch writes `CurrentRequest.site = @current_site` before returning, keeping the memo consistent for
+any later `current_site` call in the same delivery.
+
+## Why a plain method still
+
+`ecosystem-plugin-bindings` records that `camaleon-spree` reopens `CamaleonCms::SiteHelper` to replace
+`current_site` (delegating to Spree). The fix stays an ordinary instance-method edit so that override
+keeps winning; it does not move resolution into a prepended module or an `ActiveSupport::CurrentAttributes`
+reader.
+
+## Scope
+
+One branch restored in one method. No change to the single-site path, the compute-from-request path, or
+the `current_site(site)` setter. The finding is a straight regression; the reproducer is the fix's proof.

--- a/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/proposal.md
+++ b/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/proposal.md
@@ -1,0 +1,37 @@
+# Proposal: restore-caller-site-resolution
+
+## Why
+
+On a multisite install, sending mail is broken. `HtmlMailer#sender` sets `@current_site` and then runs
+`hooks_run('email_late', …)`, which calls `current_theme` → `SiteHelper#current_site`. At 2.9.2
+`current_site` honored a caller-set `@current_site`; [#1177](https://github.com/owen2345/camaleon-cms/pull/1177)
+replaced that branch with `return CurrentRequest.site if CurrentRequest.site.present?`. In a delivery
+with no request-scoped site — a mailer, a background job, `deliver_later` — `CurrentRequest.site` is
+blank, so resolution falls through to the branch that dereferences `request`, and a mailer has no
+`request`: it raises `NameError`. On single-site installs the earlier `get_sites.size == 1` branch
+returns `Site.first` and hides the bug; on multisite, password-reset, confirmation and admin-notification
+mail all fail. This is finding **M21** in the 2.9.2→master regression audit, and it is a release blocker.
+
+## What Changes
+
+- `SiteHelper#current_site` honors a caller-set `@current_site` again — after the `$current_site` global
+  and before the memoized `CurrentRequest.site` — writing it through to `CurrentRequest.site` and
+  returning it. This restores 2.9.2 behavior and lets a background sender resolve hooks and theme against
+  the site it set, without a request.
+- Placed *before* the `CurrentRequest.site` check on purpose: an in-request `deliver_now` for another
+  site must resolve against the caller's `@current_site`, not the request's memoized site.
+
+## Capabilities
+
+### New Capabilities
+
+- `site-resolution-order`: the precedence `SiteHelper#current_site` follows and its no-request safety.
+
+## Impact
+
+- `app/helpers/camaleon_cms/site_helper.rb` (restore the `@current_site` branch)
+- `spec/helpers/camaleon_cms/site_helper_spec.rb` (new — resolution order, no-request safety, and a
+  multisite mailer reproducer)
+
+`current_site` stays a plain overridable instance method — `camaleon-spree` reopens `SiteHelper` to
+delegate it (`ecosystem-plugin-bindings`), so the fix must not move it to a prepend or `CurrentAttributes`.

--- a/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/specs/site-resolution-order/spec.md
+++ b/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/specs/site-resolution-order/spec.md
@@ -1,0 +1,27 @@
+# site-resolution-order
+
+## ADDED Requirements
+
+### Requirement: current_site honors a caller-set @current_site before the memoized site
+`SiteHelper#current_site` SHALL resolve the current site in precedence order: an explicit `site`
+argument, then the `$current_site` global, then a caller-set `@current_site` instance variable, then the
+memoized `CurrentRequest.site`, and only otherwise compute it from the installed sites or the request
+host. A caller-set `@current_site` SHALL be returned and written through to `CurrentRequest.site`, and
+SHALL take precedence over an already-memoized `CurrentRequest.site`.
+
+#### Scenario: A background sender sets @current_site with no request
+- **WHEN** `current_site` is called on a multisite install with `CurrentRequest.site` blank, no request
+  available, and `@current_site` assigned
+- **THEN** it SHALL return the assigned site without raising, and set `CurrentRequest.site` to it
+
+#### Scenario: @current_site overrides the memoized site
+- **WHEN** `@current_site` is set for one site while `CurrentRequest.site` already holds another
+- **THEN** `current_site` SHALL return the `@current_site` site
+
+### Requirement: Multisite mail sends without a request
+Sending mail through `HtmlMailer` SHALL resolve its site from the `current_site` passed to `sender`,
+without requiring a request, so background and multisite deliveries do not raise.
+
+#### Scenario: HtmlMailer builds on a multisite install
+- **WHEN** `HtmlMailer.sender` is called with a `current_site` on a multisite install and no request
+- **THEN** the message SHALL build without raising and resolve its theme and hooks against that site

--- a/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/tasks.md
+++ b/openspec/changes/archive/2026-08-08-restore-caller-site-resolution/tasks.md
@@ -1,0 +1,21 @@
+# Tasks: restore-caller-site-resolution
+
+## 1. Reproduce
+
+- [x] 1.1 Add `spec/helpers/camaleon_cms/site_helper_spec.rb`: with `PluginRoutes.get_sites` stubbed to a
+      multisite size and `CurrentRequest.site` blank, a caller-set `@current_site` and no request must
+      resolve without raising; confirm it fails on master with `NameError`.
+
+## 2. Fix
+
+- [x] 2.1 In `SiteHelper#current_site`, restore the `@current_site` branch after `$current_site` and
+      before `CurrentRequest.site`, writing through to `CurrentRequest.site`.
+- [x] 2.2 Cover the precedence (`@current_site` over a memoized `CurrentRequest.site`) and the
+      no-request mailer reproducer (`HtmlMailer.sender(..., current_site:)` builds without raising).
+
+## 3. Ship
+
+- [x] 3.1 `bin/rspec` (new spec + `spec/mailers`), `bin/rubocop` on touched files, `bin/brakeman --no-pager`,
+      `(cd spec/dummy && bin/rails zeitwerk:check)`.
+- [x] 3.2 Archive on the branch (syncs `site-resolution-order` into `openspec/specs/`).
+- [x] 3.3 Commit, push, open the PR, then add the changelog entry referencing it.

--- a/openspec/specs/site-resolution-order/spec.md
+++ b/openspec/specs/site-resolution-order/spec.md
@@ -1,0 +1,29 @@
+# site-resolution-order Specification
+
+## Purpose
+TBD - created by archiving change restore-caller-site-resolution. Update Purpose after archive.
+## Requirements
+### Requirement: current_site honors a caller-set @current_site before the memoized site
+`SiteHelper#current_site` SHALL resolve the current site in precedence order: an explicit `site`
+argument, then the `$current_site` global, then a caller-set `@current_site` instance variable, then the
+memoized `CurrentRequest.site`, and only otherwise compute it from the installed sites or the request
+host. A caller-set `@current_site` SHALL be returned and written through to `CurrentRequest.site`, and
+SHALL take precedence over an already-memoized `CurrentRequest.site`.
+
+#### Scenario: A background sender sets @current_site with no request
+- **WHEN** `current_site` is called on a multisite install with `CurrentRequest.site` blank, no request
+  available, and `@current_site` assigned
+- **THEN** it SHALL return the assigned site without raising, and set `CurrentRequest.site` to it
+
+#### Scenario: @current_site overrides the memoized site
+- **WHEN** `@current_site` is set for one site while `CurrentRequest.site` already holds another
+- **THEN** `current_site` SHALL return the `@current_site` site
+
+### Requirement: Multisite mail sends without a request
+Sending mail through `HtmlMailer` SHALL resolve its site from the `current_site` passed to `sender`,
+without requiring a request, so background and multisite deliveries do not raise.
+
+#### Scenario: HtmlMailer builds on a multisite install
+- **WHEN** `HtmlMailer.sender` is called with a `current_site` on a multisite install and no request
+- **THEN** the message SHALL build without raising and resolve its theme and hooks against that site
+

--- a/spec/helpers/camaleon_cms/site_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/site_helper_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+# Regression audit M21: #1177 dropped the caller-set @current_site branch from
+# SiteHelper#current_site. Background senders (HtmlMailer, jobs) assign @current_site but had it
+# ignored; on a multisite install, resolution then fell through to the request-based branch and
+# raised NameError (no request in a mailer/job), so no mail was sent. These pin the restored
+# precedence and the multisite mailer symptom.
+describe CamaleonCms::SiteHelper do
+  subject(:helper_object) { Class.new { include CamaleonCms::SiteHelper }.new }
+
+  let(:site) { CamaleonCms::Site.first.decorate }
+
+  before do
+    CurrentRequest.reset
+    # Force the multisite branch of #current_site (get_sites.size != 1), where the un-fixed code
+    # dereferences `request`. No second DB row needed.
+    allow(PluginRoutes).to receive(:get_sites).and_return([site, site])
+  end
+
+  after { CurrentRequest.reset }
+
+  describe '#current_site with a caller-set @current_site and no request' do
+    before { helper_object.instance_variable_set(:@current_site, site) }
+
+    it 'returns the caller-set site instead of raising NameError on `request`' do
+      expect { helper_object.current_site }.not_to raise_error
+      expect(helper_object.current_site).to eq(site)
+    end
+
+    it 'writes it through to CurrentRequest.site' do
+      helper_object.current_site
+      expect(CurrentRequest.site).to eq(site)
+    end
+  end
+
+  describe '#current_site precedence' do
+    it 'prefers a caller-set @current_site over an already-memoized CurrentRequest.site' do
+      # so an in-request deliver_now for another site resolves against @current_site, not the request's
+      CurrentRequest.site = instance_double(CamaleonCms::SiteDecorator).as_null_object
+      helper_object.instance_variable_set(:@current_site, site)
+      expect(helper_object.current_site).to eq(site)
+    end
+  end
+
+  describe 'HtmlMailer on a multisite install (real-world M21 symptom)' do
+    it 'builds the message without raising when there is no request' do
+      mail = CamaleonCms::HtmlMailer.sender('test@gmail.com', 'test', current_site: site.id,
+                                                                      content: 'hi there')
+      expect { mail.subject }.not_to raise_error
+      expect(mail.subject).to eq('test')
+      expect(mail.body.encoded).to match('hi there')
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

On a multisite install, sending mail is broken. `HtmlMailer#sender` assigns `@current_site` and then runs `hooks_run('email_late', …)`, which resolves `current_theme` → `SiteHelper#current_site`. At 2.9.2 `current_site` honored a caller-set `@current_site`; [#1177](https://github.com/owen2345/camaleon-cms/pull/1177) replaced that branch with `return CurrentRequest.site if CurrentRequest.site.present?`. In a delivery with no request-scoped site — a mailer, a background job, `deliver_later` — `CurrentRequest.site` is blank, so resolution falls through to the branch that dereferences `request`; a mailer has no `request`, so it raises `NameError` and nothing is sent. Single-site installs return `Site.first` from the earlier `get_sites.size == 1` branch and never hit it, which is why the bug is multisite-only.

The fix restores the `@current_site` branch in `current_site`, placed after the `$current_site` global and **before** the memoized `CurrentRequest.site` — so an in-request `deliver_now` for another site resolves against the caller's site, not the request's. The ivar is read through `instance_variable_get`, matching the existing `current_theme` guard so `Rails/HelperInstanceVariable` stays satisfied. `current_site` remains a plain, overridable instance method (an ecosystem plugin reopens `SiteHelper` to replace it), so the change doesn't move it to a prepend or `CurrentAttributes`.

This is finding **M21** in the 2.9.2→master regression audit — a release blocker. The behavior and its precedence are pinned by the new `site-resolution-order` OpenSpec capability and a spec that reproduces the `NameError` through the mailer.

**User-Visible Impact:** On multisite installs, background and cross-site email — password reset, email confirmation, admin notifications — sends again; previously it raised `NameError` during delivery and no mail was sent. Single-site installs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
