### PR TITLE
Restore admin and frontend runtime-compatibility surfaces (M16, M18–M20, M22, M23)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,7 +53,7 @@ Metrics/MethodLength:
 # Offense count: 18
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 326
+  Max: 332
 
 # Offense count: 15
 # Configuration parameters: CountKeywordArgs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Fix:** Restores seven admin and frontend runtime-compatibility contracts broken by the
+  `CurrentRequest` and admin-menu refactors: the 2-arg `post_type_list_taxonomy` (which rendered empty
+  taxonomy columns in overridden admin posts-index views), signed-out `cama_current_user` memoization,
+  quote-safe admin menu `data-*` attributes (the admin Menus tooltip), inline formatting in plugin menu
+  titles, `cf_add_model`'s placement-dropdown models, the `@_admin_menus.delete` menu-removal idiom, and
+  the frontend legacy-ivar read fallback for `the_title`/`is_home?`/SEO helpers. Regression audit
+  M16/M18–M20/M22/M23. [#1234](https://github.com/owen2345/camaleon-cms/pull/1234).
+
 - **Fix:** On multisite installs, background and cross-site email (password reset, email confirmation,
   admin notifications) raised `NameError` during delivery and sent nothing — `SiteHelper#current_site`
   stopped honoring the `@current_site` that `HtmlMailer` sets, so a delivery with no request fell

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -79,7 +79,10 @@ module CamaleonCms
     # initialize all vars and methods for admin panel
     def admin_init_actions
       I18n.locale = current_site.get_admin_language
-      @_admin_menus = {}
+      # Alias the legacy @_admin_menus ivar onto the live menu store so a hook using the WordPress-style
+      # `@_admin_menus.delete('comments')` removal idiom mutates the same hash admin_menu_draw reads. The
+      # menu-insert methods mutate in place (.replace), so this reference stays valid. Regression M19.
+      @_admin_menus = CurrentRequest.admin_menu_items = {}
       @_admin_breadcrumb = []
       @_extra_models_for_fields = []
       # Cache the site's frontend language for decorators and plugins that still

--- a/app/controllers/concerns/camaleon_cms/runtime_admin_menu_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_admin_menu_concern.rb
@@ -210,7 +210,7 @@ module CamaleonCms
         hsh[key_menu] = menu if key == key_target
         hsh[key] = val
       end
-      CurrentRequest.admin_menu_items = res
+      CurrentRequest.admin_menu_items.replace(res) # mutate in place so @_admin_menus stays a live alias (M19)
     end
 
     def admin_menu_insert_menu_after(key_target, key_menu, menu)
@@ -219,7 +219,7 @@ module CamaleonCms
         hsh[key] = val
         hsh[key_menu] = menu if key == key_target
       end
-      CurrentRequest.admin_menu_items = res
+      CurrentRequest.admin_menu_items.replace(res) # mutate in place so @_admin_menus stays a live alias (M19)
     end
 
     def cama_comments_get_common_data

--- a/app/helpers/camaleon_cms/admin/custom_fields_helper.rb
+++ b/app/helpers/camaleon_cms/admin/custom_fields_helper.rb
@@ -344,6 +344,17 @@ module CamaleonCms
         CurrentRequest.extra_models_for_fields ||= []
         CurrentRequest.extra_models_for_fields << model_class
       end
+
+      # Models offered in the field-group placement dropdown: those registered via cf_add_model plus any
+      # a custom_field_custom_models hook appends. Seeded from the legacy @_extra_models_for_fields ivar
+      # so a controller still assigning it keeps working. The dropdown used to read that ivar while
+      # cf_add_model wrote CurrentRequest, so registered models never appeared. Regression M18.
+      def cf_extra_models_for_fields
+        CurrentRequest.extra_models_for_fields ||= instance_variable_get(:@_extra_models_for_fields) || []
+        f_args = { models: CurrentRequest.extra_models_for_fields }
+        hooks_run('custom_field_custom_models', f_args)
+        f_args[:models]
+      end
     end
   end
 end

--- a/app/helpers/camaleon_cms/admin/custom_fields_helper.rb
+++ b/app/helpers/camaleon_cms/admin/custom_fields_helper.rb
@@ -349,9 +349,11 @@ module CamaleonCms
       # a custom_field_custom_models hook appends. Seeded from the legacy @_extra_models_for_fields ivar
       # so a controller still assigning it keeps working. The dropdown used to read that ivar while
       # cf_add_model wrote CurrentRequest, so registered models never appeared. Regression M18.
+      # The seed and the hook payload are copies: hook appends must reach only this read, not
+      # accumulate in the request store or leak into the controller ivar.
       def cf_extra_models_for_fields
-        CurrentRequest.extra_models_for_fields ||= instance_variable_get(:@_extra_models_for_fields) || []
-        f_args = { models: CurrentRequest.extra_models_for_fields }
+        CurrentRequest.extra_models_for_fields ||= (instance_variable_get(:@_extra_models_for_fields) || []).dup
+        f_args = { models: CurrentRequest.extra_models_for_fields.dup }
         hooks_run('custom_field_custom_models', f_args)
         f_args[:models]
       end

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -360,8 +360,11 @@ module CamaleonCms
         return {} if datas_string.blank?
 
         result = {}
-        datas_string.scan(/data-(\w+)=['"]([^'"]*)['"]/).each do |key, value|
-          result[key.to_sym] = value
+        # Match single- or double-quoted values so a value may contain the other quote character. The
+        # old /['"]([^'"]*)['"]/ stopped at the first quote of either kind, truncating data-intro
+        # strings that carry HTML (e.g. the Menus tooltip's <img ... style="...">). Regression M22.
+        datas_string.scan(/data-([\w-]+)=(?:'([^']*)'|"([^"]*)")/).each do |key, single, double|
+          result[key.to_sym] = single || double
         end
         result
       end

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -265,7 +265,7 @@ module CamaleonCms
                 safe_join([
                   content_tag(:i, nil, class: "fa fa-#{menu[:icon]}"),
                   ' ',
-                  content_tag(:span, menu[:title]),
+                  content_tag(:span, cama_admin_menu_title(menu[:title])),
                   (content_tag(:i, nil, class: 'fa fa-angle-left pull-right') if menu.key?(:items))
                 ].compact)
               end,
@@ -345,7 +345,7 @@ module CamaleonCms
                   safe_join([
                     content_tag(:i, nil, class: "fa fa-#{item[:icon]}"),
                     ' ',
-                    item[:title],
+                    cama_admin_menu_title(item[:title]),
                     (content_tag(:i, nil, class: 'fa fa-angle-left pull-right') if item.key?(:items))
                   ].compact)
                 end,
@@ -354,6 +354,16 @@ module CamaleonCms
             end
           end)
         end
+      end
+
+      # Menu titles may carry inline formatting (e.g. camaleon-ecommerce's count badge). Core builds its
+      # titles as SafeBuffers via safe_join/content_tag and those pass through untouched; a plain-String
+      # title from a plugin is sanitized to a safe inline subset — the badge renders, scripts and event
+      # handlers are stripped — rather than escaped whole. Regression M22.
+      def cama_admin_menu_title(title)
+        return title if title.is_a?(ActiveSupport::SafeBuffer)
+
+        sanitize(title.to_s, tags: %w[span small i b strong em], attributes: %w[class])
       end
 
       def parse_datas(datas_string)

--- a/app/helpers/camaleon_cms/admin/menus_helper.rb
+++ b/app/helpers/camaleon_cms/admin/menus_helper.rb
@@ -230,7 +230,7 @@ module CamaleonCms
           hsh[key_menu] = menu if key == key_target
           hsh[key] = val
         end
-        CurrentRequest.admin_menu_items = res
+        CurrentRequest.admin_menu_items.replace(res) # mutate in place so @_admin_menus stays a live alias (M19)
       end
 
       # add menu after menu with key = key_target
@@ -242,7 +242,7 @@ module CamaleonCms
           hsh[key] = val
           hsh[key_menu] = menu if key == key_target
         end
-        CurrentRequest.admin_menu_items = res
+        CurrentRequest.admin_menu_items.replace(res) # mutate in place so @_admin_menus stays a live alias (M19)
       end
 
       # draw admin menu as html

--- a/app/helpers/camaleon_cms/admin/post_type_helper.rb
+++ b/app/helpers/camaleon_cms/admin/post_type_helper.rb
@@ -16,6 +16,9 @@ module CamaleonCms
 
       # taxonomies ->  (categories || post_tags)
       def post_type_list_taxonomy(taxonomies, color = 'primary', post_type = nil)
+        # Legacy 2-arg call sites (e.g. overridden admin posts-index views, camaleon-ecommerce) omit
+        # post_type and expect the controller's @post_type. Restored from #1178; see regression M23.
+        post_type ||= controller.instance_variable_get(:@post_type) if respond_to?(:controller)
         return safe_join([]) if post_type.blank?
 
         safe_join(taxonomies.decorate.map do |f|

--- a/app/helpers/camaleon_cms/frontend/content_select_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/content_select_helper.rb
@@ -163,7 +163,8 @@ module CamaleonCms
       private
 
       def camaleon_frontend_object
-        CurrentRequest.frontend_object
+        # Fall back to a plugin-set @object ivar; core writes CurrentRequest.frontend_object. Regression M20.
+        CurrentRequest.frontend_object || (instance_variable_get(:@object) if instance_variable_defined?(:@object))
       end
     end
   end

--- a/app/helpers/camaleon_cms/frontend/seo_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/seo_helper.rb
@@ -10,6 +10,7 @@ module CamaleonCms
         visited_tag = camaleon_frontend_visited_state(:frontend_visited_tag)
         visited_category = camaleon_frontend_visited_state(:frontend_visited_category)
         visited_user = CurrentRequest.frontend_user
+        visited_user ||= instance_variable_get(:@user) if instance_variable_defined?(:@user) # legacy @user (M20)
 
         data2 = if is_home?
                   {}

--- a/app/helpers/camaleon_cms/frontend/site_helper.rb
+++ b/app/helpers/camaleon_cms/frontend/site_helper.rb
@@ -76,7 +76,13 @@ module CamaleonCms
       private
 
       def camaleon_frontend_visited_state(current_request_attr)
-        CurrentRequest.public_send(current_request_attr)
+        value = CurrentRequest.public_send(current_request_attr)
+        return value unless value.nil?
+
+        # Fall back to a legacy @cama_visited_* ivar a plugin front controller may have set directly;
+        # core writes both stores, so stock flows never reach here. Regression M20.
+        legacy_ivar = CamaleonCms::FrontendVisitedStateConcern::LEGACY_VISITED_IVAR_BY_ATTR[current_request_attr]
+        instance_variable_get(legacy_ivar) if legacy_ivar && instance_variable_defined?(legacy_ivar)
       end
     end
   end

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -107,6 +107,7 @@ module CamaleonCms
       c_data[:domain] = :all if PluginRoutes.system_info['users_share_sites'].present? && CamaleonCms::Site.count > 1
       cookies[:auth_token] = c_data
       CurrentRequest.user = nil
+      CurrentRequest.user_resolved = true # the cookie is gone; don't re-resolve to a stale user
       redirect_to safe_redirect_url(params[:return_to]) || cama_admin_login_path,
                   notice: t('camaleon_cms.admin.logout.message.closed')
     end
@@ -126,16 +127,16 @@ module CamaleonCms
 
     # return the current user logged in
     def cama_current_user
-      return CurrentRequest.user if CurrentRequest.user
+      # Honor an externally-set user, and memoize a nil resolution via user_resolved so a signed-out
+      # request (or a present-but-stale auth cookie) is not re-resolved on every call (regression M16).
+      return CurrentRequest.user if CurrentRequest.user || CurrentRequest.user_resolved
 
-      # api current user...
-      current_user = cama_calc_api_current_user
-      return CurrentRequest.user = current_user if current_user
-
-      return nil unless cookie_auth_token_complete?
-
-      users = current_site.users_include_admins
-      CurrentRequest.user = users.find_by(auth_token: user_auth_token_from_cookie).try(:decorate)
+      CurrentRequest.user_resolved = true
+      user = cama_calc_api_current_user # api current user...
+      if user.nil? && cookie_auth_token_complete?
+        user = current_site.users_include_admins.find_by(auth_token: user_auth_token_from_cookie).try(:decorate)
+      end
+      CurrentRequest.user = user
     end
 
     def cookie_auth_token_complete?

--- a/app/models/current_request.rb
+++ b/app/models/current_request.rb
@@ -12,7 +12,8 @@
 # Note: Rails automatically resets CurrentAttributes between requests, ensuring no leakage.
 # In specs, call CurrentRequest.reset in before/after hooks to avoid cross-test pollution.
 class CurrentRequest < ActiveSupport::CurrentAttributes
-  attribute :user, :site, :content_helper_state, :hooks_helper_state, :html_helper_state, :theme_helper_state,
+  attribute :user, :user_resolved, :site, :content_helper_state, :hooks_helper_state, :html_helper_state,
+            :theme_helper_state,
             :frontend_object, :frontend_seo_settings, :frontend_current_theme, :frontend_site_current_path,
             :frontend_visited_home, :frontend_visited_post, :frontend_visited_ajax, :frontend_visited_search,
             :frontend_visited_post_type, :frontend_visited_tag, :frontend_visited_category,

--- a/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
@@ -68,9 +68,9 @@
                                     <option value="<%= value %>" data-help="<%= t('camaleon_cms.admin.settings.tooltip.add_custom_field_users') %>"><%= t('camaleon_cms.admin.sidebar.users') %></option>
                                     <% value = "Site,#{current_site.id}" %>
                                     <option value="<%= value %>" data-help="<%= t('camaleon_cms.admin.settings.tooltip.add_custom_field_sites') %>"><%= t('camaleon_cms.admin.sidebar.site_settings') %></option>
-                                    <% f_args={models: @_extra_models_for_fields || []}; hooks_run('custom_field_custom_models', f_args); f_args[:models].each do |model| %>
+                                    <% cf_extra_models_for_fields.each do |model| %>
                                         <% value = "#{model.name},#{current_site.id}" %>
-                                        <option value="<%= value %>" data-help=""><%= model.name %></option><%= model.name %>
+                                        <option value="<%= value %>" data-help=""><%= model.name %></option>
                                     <% end %>
                                 </optgroup>
 

--- a/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/design.md
+++ b/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/design.md
@@ -1,0 +1,54 @@
+# Design: restore-runtime-compat-surfaces
+
+## Scope decisions from the ecosystem survey
+
+The survey (`docs/ai/ecosystem.md`) trimmed the batch the audit first proposed:
+
+- **Dropped the `@cama_current_user` ivar-read (M16).** Its justification was external SSO plugins
+  assigning the ivar; the actual SSO plugin (`camaleon_oauth`) signs in through Doorkeeper and
+  `login_user_with_password`, and no surveyed repo writes the ivar. Only the nil-memoization half is
+  kept.
+- **Dropped restoring `include Admin::ApplicationHelper` on `AdminController`.** No hook or controller
+  calls `cf_add_model`, `do_shortcode` or the admin view helpers from controller context, so M18/M19/M23
+  work without it.
+- **M22b is `sanitize`, not escape.** `camaleon-ecommerce` ships an Orders-menu title carrying
+  `<span><small class='label'>`; escaping shows literal markup. Neither `escaped-title-composition` nor
+  `generated-markup-escaping` governs admin menu titles, so there is no hard requirement to violate.
+
+## M16 — memoize the nil, keep the external set
+
+`cama_current_user` guarded on a truthy `CurrentRequest.user`, so a signed-out request re-ran the API
+lookup and an auth-token `find_by` every call. A `user_resolved` flag on `CurrentRequest` memoizes the
+outcome; the guard becomes `CurrentRequest.user || CurrentRequest.user_resolved`, so an externally-set
+user (the spec helpers, admin controller) is still returned, and logout marks resolved so nothing
+re-resolves against a deleted cookie.
+
+## M22 — quote-aware datas, SafeBuffer-aware titles
+
+`parse_datas` now matches `'…'` or `"…"` so a value may contain the other quote. For titles, core builds
+SafeBuffers via `safe_join`/`content_tag` and those pass through `cama_admin_menu_title` untouched; a
+plain-String plugin title is sanitized to `span/small/i/b/strong/em` + `class`. Master already escaped
+titles, so this is not a security regression — it is strictly safer than 2.9.2 (which rendered them raw)
+and less breaking than master.
+
+## M19 — object identity is the contract
+
+The `@_admin_menus.delete('comments')` idiom needs the ivar to alias the same hash `admin_menu_draw`
+reads. `admin_menu_add_menu`/`append`/`prepend` already mutate in place; only
+`admin_menu_insert_menu_before`/`after` reassigned `CurrentRequest.admin_menu_items` to a fresh hash.
+Both copies (controller concern and view helper) now `.replace` in place, and `admin_init_actions`
+aliases `@_admin_menus` onto the store, so a reference taken at init stays valid through menu building.
+
+## M20 — read fallback only, write side unchanged
+
+Core already writes both `CurrentRequest.<attr>` and the legacy `@cama_visited_*` ivar (with a
+deprecation warning) — the break was read-only. `camaleon_frontend_visited_state`,
+`camaleon_frontend_object` and the SEO `frontend_user` read now fall back to the legacy ivar (read via
+`instance_variable_get`) when `CurrentRequest` is unset. The two specs #1183 added to assert the removed
+fallback are inverted to assert it, matching `docs/ai/reference.md`'s claim that the ivars remain
+assigned for ecosystem compatibility.
+
+## Testing
+
+One repro per finding, red before the fix. Auth (230), admin (143) and frontend (45) request/helper
+specs plus the full suite (1196) confirm no cross-cutting regression.

--- a/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/proposal.md
+++ b/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/proposal.md
@@ -1,0 +1,52 @@
+# Proposal: restore-runtime-compat-surfaces
+
+## Why
+
+The `CurrentRequest` refactors (#1178, #1182, #1183 Phase 6C) and the admin-menu rewrite moved runtime
+state off controller instance variables and rebuilt the admin menu and helper surfaces. In doing so
+they silently broke a set of contracts that plugins, themes and overridden admin views depend on, all
+medium-severity findings in the 2.9.2→master regression audit:
+
+- **M23** — `post_type_list_taxonomy` lost its 2-arg form's `@post_type` fallback, so overridden admin
+  posts-index views (and `camaleon-ecommerce`'s products index) render empty taxonomy columns.
+- **M16** — `cama_current_user` stopped memoizing a signed-out resolution, re-querying on every call.
+- **M22** — `parse_datas` truncated a `data-*` value at the first quote (breaking core's own Menus
+  tooltip), and menu titles were escaped whole, so a plugin's inline badge (`camaleon-ecommerce`)
+  rendered as literal markup.
+- **M18** — `cf_add_model` wrote `CurrentRequest` while the placement dropdown read the legacy ivar, so
+  registered models never appeared.
+- **M19** — the `@_admin_menus.delete('key')` removal idiom no-oped because the ivar was unsynced and
+  the insert methods reassigned the store.
+- **M20** — the frontend readers ignored the legacy `@object` / `@cama_visited_*` / `@user` ivars, so a
+  plugin front controller setting them got nil-backed `the_title` / `is_home?` / SEO helpers.
+
+## What Changes
+
+Each finding is restored to its 2.9.2 contract (or, for M22b, to a safer superset), one commit per
+finding, and pinned by a spec that reproduced the regression first. Grounded in the ecosystem survey
+(`docs/ai/ecosystem.md`): M23 and M22b have live consumers; the `@cama_current_user` ivar-read half of
+M16 and the `AdminController` `ApplicationHelper` include were **dropped** because no consumer needs
+them.
+
+- M23 restores the controller `@post_type` fallback.
+- M16 memoizes the nil resolution via a `CurrentRequest.user_resolved` flag; an externally-set user is
+  still honoured.
+- M22a makes `parse_datas` quote-aware; M22b sanitizes a plain-String menu title to a safe inline
+  subset (SafeBuffer titles pass through untouched) instead of escaping it.
+- M18 shares one `CurrentRequest` store between `cf_add_model` and the dropdown.
+- M19 aliases `@_admin_menus` onto the live store and makes the insert methods mutate in place.
+- M20 restores the read-side legacy-ivar fallback in the frontend readers.
+
+## Capabilities
+
+### New Capabilities
+
+- `runtime-compat-surfaces`: the admin and frontend runtime contracts these findings restore.
+
+## Impact
+
+- `app/helpers/camaleon_cms/admin/post_type_helper.rb`, `session_helper.rb`, `admin/menus_helper.rb`,
+  `admin/custom_fields_helper.rb`, `frontend/{site,seo,content_select}_helper.rb`
+- `app/controllers/camaleon_cms/admin_controller.rb`, `concerns/.../runtime_admin_menu_concern.rb`
+- `app/models/current_request.rb`, `app/views/.../custom_fields/form.html.erb`
+- Specs under `spec/helpers/`; `.rubocop_todo.yml` (ModuleLength ceiling for the M18 helper)

--- a/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/specs/runtime-compat-surfaces/spec.md
+++ b/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/specs/runtime-compat-surfaces/spec.md
@@ -1,0 +1,80 @@
+# runtime-compat-surfaces
+
+## ADDED Requirements
+
+### Requirement: Legacy 2-argument taxonomy-list calls resolve the post type from the controller
+`post_type_list_taxonomy` SHALL accept its legacy 2-argument form (`taxonomies`, `color`) and resolve
+the post type from the controller's `@post_type` when the third argument is omitted, so overridden
+admin posts-index views render taxonomy links rather than empty output.
+
+#### Scenario: A 2-argument call renders the taxonomy links
+- **WHEN** `post_type_list_taxonomy(taxonomies, 'primary')` is called while the controller has assigned
+  `@post_type`
+- **THEN** it SHALL render the taxonomy label links for that post type
+
+### Requirement: A signed-out current user is resolved once per request
+`cama_current_user` SHALL memoize a nil resolution so a signed-out request, or one carrying a stale
+auth cookie, is not re-resolved on every call. An externally-assigned `CurrentRequest.user` SHALL still
+be returned without re-resolving.
+
+#### Scenario: The nil resolution is not repeated
+- **WHEN** `cama_current_user` is called twice on a request with no resolvable user
+- **THEN** the API/token resolution SHALL run only once
+
+#### Scenario: An externally set user is honoured
+- **WHEN** `CurrentRequest.user` is assigned before `cama_current_user` is called
+- **THEN** that user SHALL be returned and no resolution SHALL run
+
+### Requirement: Admin menu data attributes preserve quoted values
+`parse_datas` SHALL parse a `data-*` attribute value that is single- or double-quoted, so a value may
+contain the other quote character without being truncated.
+
+#### Scenario: A single-quoted value containing double quotes survives
+- **WHEN** a `datas` string contains `data-intro='<img style="…" />'`
+- **THEN** the parsed `intro` value SHALL retain the full markup including the double quotes
+
+### Requirement: Admin menu titles keep safe inline markup
+An admin menu title SHALL render its inline formatting rather than as escaped text. A title that is
+already an `ActiveSupport::SafeBuffer` (as core builds them) SHALL pass through unchanged; a plain-String
+title SHALL be sanitized to a safe inline subset (`span`, `small`, `i`, `b`, `strong`, `em`, and `class`),
+so scripts and event handlers are removed.
+
+#### Scenario: A plugin's inline badge renders
+- **WHEN** a menu title is the plain String `Orders <small class='label'>3</small>`
+- **THEN** the rendered menu SHALL contain the `<small>` element, not escaped text
+
+#### Scenario: A script or handler in a title is stripped
+- **WHEN** a menu title contains a `<script>` element or an `on*` handler attribute
+- **THEN** the rendered menu SHALL contain neither
+
+### Requirement: Models registered via cf_add_model reach the placement dropdown
+A model registered through `cf_add_model`, plus any a `custom_field_custom_models` hook appends, SHALL
+appear in the custom-field-group placement dropdown. The writer and the dropdown SHALL read the same
+`CurrentRequest` store.
+
+#### Scenario: A registered model is offered for placement
+- **WHEN** `cf_add_model(SomeModel)` is called before the custom-fields form renders
+- **THEN** `SomeModel` SHALL be among the models the placement dropdown lists
+
+### Requirement: The admin menu store supports in-place removal held across menu building
+The admin menu store SHALL keep the same object identity across all menu operations, and `@_admin_menus`
+SHALL alias it, so the `@_admin_menus.delete('key')` removal idiom in an `admin_before_load` hook removes
+a menu that `admin_menu_draw` then omits.
+
+#### Scenario: A reference held before an insert can still remove a menu
+- **WHEN** a reference to the store is taken, a menu is inserted, and the reference then deletes a key
+- **THEN** the store `admin_menu_draw` reads SHALL no longer contain that key
+
+### Requirement: Frontend readers honour legacy compatibility ivars
+When `CurrentRequest` state is unset, the frontend readers SHALL fall back to the legacy
+`@object` / `@cama_visited_*` / `@user` instance variables a plugin front controller may have set, so
+`the_title`, `is_home?`, menu-active and SEO helpers reflect that state. When `CurrentRequest` state is
+present it SHALL take precedence.
+
+#### Scenario: A plugin-set @object backs the frontend helpers
+- **WHEN** a front controller assigns `@object` and no `CurrentRequest.frontend_object` is set
+- **THEN** `the_title` SHALL return that object's title
+
+#### Scenario: CurrentRequest takes precedence over the legacy ivar
+- **WHEN** both `CurrentRequest.frontend_visited_post` and `@cama_visited_post` are set
+- **THEN** the reader SHALL return the `CurrentRequest` value

--- a/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/tasks.md
+++ b/openspec/changes/archive/2026-08-08-restore-runtime-compat-surfaces/tasks.md
@@ -1,0 +1,25 @@
+# Tasks: restore-runtime-compat-surfaces
+
+## 1. Admin helper/menu surfaces
+
+- [x] 1.1 M23 — restore the `@post_type` fallback in `post_type_list_taxonomy`; spec the 2-arg call.
+- [x] 1.2 M22a — quote-aware `parse_datas`; spec single/double-quoted values.
+- [x] 1.3 M22b — `sanitize` plain-String menu titles to a safe inline subset, SafeBuffer pass-through;
+      spec that inline HTML renders and scripts/handlers are stripped.
+- [x] 1.4 M18 — share one `CurrentRequest` store between `cf_add_model` and the placement dropdown;
+      spec `cf_extra_models_for_fields`.
+- [x] 1.5 M19 — alias `@_admin_menus` onto the store, `.replace` in the insert methods (both copies);
+      spec store identity through an insert.
+
+## 2. Session + frontend
+
+- [x] 2.1 M16 — memoize a nil `cama_current_user` via `CurrentRequest.user_resolved`; keep external set;
+      spec the single-resolution.
+- [x] 2.2 M20 — restore the legacy-ivar read fallback in the frontend readers; invert the two specs that
+      pinned its removal.
+
+## 3. Ship
+
+- [x] 3.1 Full `bin/rspec` (1196/0), `bin/rubocop` (429 files clean), `bin/brakeman` (0), zeitwerk.
+- [x] 3.2 Archive on the branch (syncs `runtime-compat-surfaces` into `openspec/specs/`).
+- [x] 3.3 Commit, push, open the PR, then add the changelog entry referencing it.

--- a/openspec/specs/runtime-compat-surfaces/spec.md
+++ b/openspec/specs/runtime-compat-surfaces/spec.md
@@ -58,11 +58,18 @@ so scripts and event handlers are removed.
 ### Requirement: Models registered via cf_add_model reach the placement dropdown
 A model registered through `cf_add_model`, plus any a `custom_field_custom_models` hook appends, SHALL
 appear in the custom-field-group placement dropdown. The writer and the dropdown SHALL read the same
-`CurrentRequest` store.
+`CurrentRequest` store. The hook SHALL receive a copy of the store, so its appends reach only that
+read — they SHALL NOT accumulate in the store or mutate a controller-assigned legacy ivar.
 
 #### Scenario: A registered model is offered for placement
 - **WHEN** `cf_add_model(SomeModel)` is called before the custom-fields form renders
 - **THEN** `SomeModel` SHALL be among the models the placement dropdown lists
+
+#### Scenario: Hook-appended models do not accumulate across repeated reads
+- **WHEN** a `custom_field_custom_models` hook appends a model and the list is read more than once in
+  a request
+- **THEN** each read SHALL include the hook's model once, and the `CurrentRequest` store SHALL retain
+  only the registered models
 
 ### Requirement: The admin menu store supports in-place removal held across menu building
 The admin menu store SHALL keep the same object identity across all menu operations, and `@_admin_menus`

--- a/openspec/specs/runtime-compat-surfaces/spec.md
+++ b/openspec/specs/runtime-compat-surfaces/spec.md
@@ -1,7 +1,14 @@
 # runtime-compat-surfaces Specification
 
 ## Purpose
-TBD - created by archiving change restore-runtime-compat-surfaces. Update Purpose after archive.
+
+Preserve the admin and frontend runtime contracts that plugins, themes and overridden views from the
+2.9.2 era bind to, across the `CurrentRequest` and admin-menu refactors: the legacy 2-argument
+`post_type_list_taxonomy` form, single-resolution `cama_current_user`, quote-safe admin menu `data-*`
+attributes, inline formatting in menu titles, `cf_add_model`'s placement-dropdown listing, the
+`@_admin_menus` removal idiom, and the legacy-ivar read fallbacks behind `the_title` / `is_home?` /
+SEO helpers.
+
 ## Requirements
 ### Requirement: Legacy 2-argument taxonomy-list calls resolve the post type from the controller
 `post_type_list_taxonomy` SHALL accept its legacy 2-argument form (`taxonomies`, `color`) and resolve

--- a/openspec/specs/runtime-compat-surfaces/spec.md
+++ b/openspec/specs/runtime-compat-surfaces/spec.md
@@ -1,0 +1,82 @@
+# runtime-compat-surfaces Specification
+
+## Purpose
+TBD - created by archiving change restore-runtime-compat-surfaces. Update Purpose after archive.
+## Requirements
+### Requirement: Legacy 2-argument taxonomy-list calls resolve the post type from the controller
+`post_type_list_taxonomy` SHALL accept its legacy 2-argument form (`taxonomies`, `color`) and resolve
+the post type from the controller's `@post_type` when the third argument is omitted, so overridden
+admin posts-index views render taxonomy links rather than empty output.
+
+#### Scenario: A 2-argument call renders the taxonomy links
+- **WHEN** `post_type_list_taxonomy(taxonomies, 'primary')` is called while the controller has assigned
+  `@post_type`
+- **THEN** it SHALL render the taxonomy label links for that post type
+
+### Requirement: A signed-out current user is resolved once per request
+`cama_current_user` SHALL memoize a nil resolution so a signed-out request, or one carrying a stale
+auth cookie, is not re-resolved on every call. An externally-assigned `CurrentRequest.user` SHALL still
+be returned without re-resolving.
+
+#### Scenario: The nil resolution is not repeated
+- **WHEN** `cama_current_user` is called twice on a request with no resolvable user
+- **THEN** the API/token resolution SHALL run only once
+
+#### Scenario: An externally set user is honoured
+- **WHEN** `CurrentRequest.user` is assigned before `cama_current_user` is called
+- **THEN** that user SHALL be returned and no resolution SHALL run
+
+### Requirement: Admin menu data attributes preserve quoted values
+`parse_datas` SHALL parse a `data-*` attribute value that is single- or double-quoted, so a value may
+contain the other quote character without being truncated.
+
+#### Scenario: A single-quoted value containing double quotes survives
+- **WHEN** a `datas` string contains `data-intro='<img style="…" />'`
+- **THEN** the parsed `intro` value SHALL retain the full markup including the double quotes
+
+### Requirement: Admin menu titles keep safe inline markup
+An admin menu title SHALL render its inline formatting rather than as escaped text. A title that is
+already an `ActiveSupport::SafeBuffer` (as core builds them) SHALL pass through unchanged; a plain-String
+title SHALL be sanitized to a safe inline subset (`span`, `small`, `i`, `b`, `strong`, `em`, and `class`),
+so scripts and event handlers are removed.
+
+#### Scenario: A plugin's inline badge renders
+- **WHEN** a menu title is the plain String `Orders <small class='label'>3</small>`
+- **THEN** the rendered menu SHALL contain the `<small>` element, not escaped text
+
+#### Scenario: A script or handler in a title is stripped
+- **WHEN** a menu title contains a `<script>` element or an `on*` handler attribute
+- **THEN** the rendered menu SHALL contain neither
+
+### Requirement: Models registered via cf_add_model reach the placement dropdown
+A model registered through `cf_add_model`, plus any a `custom_field_custom_models` hook appends, SHALL
+appear in the custom-field-group placement dropdown. The writer and the dropdown SHALL read the same
+`CurrentRequest` store.
+
+#### Scenario: A registered model is offered for placement
+- **WHEN** `cf_add_model(SomeModel)` is called before the custom-fields form renders
+- **THEN** `SomeModel` SHALL be among the models the placement dropdown lists
+
+### Requirement: The admin menu store supports in-place removal held across menu building
+The admin menu store SHALL keep the same object identity across all menu operations, and `@_admin_menus`
+SHALL alias it, so the `@_admin_menus.delete('key')` removal idiom in an `admin_before_load` hook removes
+a menu that `admin_menu_draw` then omits.
+
+#### Scenario: A reference held before an insert can still remove a menu
+- **WHEN** a reference to the store is taken, a menu is inserted, and the reference then deletes a key
+- **THEN** the store `admin_menu_draw` reads SHALL no longer contain that key
+
+### Requirement: Frontend readers honour legacy compatibility ivars
+When `CurrentRequest` state is unset, the frontend readers SHALL fall back to the legacy
+`@object` / `@cama_visited_*` / `@user` instance variables a plugin front controller may have set, so
+`the_title`, `is_home?`, menu-active and SEO helpers reflect that state. When `CurrentRequest` state is
+present it SHALL take precedence.
+
+#### Scenario: A plugin-set @object backs the frontend helpers
+- **WHEN** a front controller assigns `@object` and no `CurrentRequest.frontend_object` is set
+- **THEN** `the_title` SHALL return that object's title
+
+#### Scenario: CurrentRequest takes precedence over the legacy ivar
+- **WHEN** both `CurrentRequest.frontend_visited_post` and `@cama_visited_post` are set
+- **THEN** the reader SHALL return the `CurrentRequest` value
+

--- a/spec/controllers/camaleon_cms/admin_controller_spec.rb
+++ b/spec/controllers/camaleon_cms/admin_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::AdminController do
+  # Regression M19, controller half: the insert methods preserving store identity is pinned in
+  # menus_helper_spec, but the alias itself lives in admin_init_actions — master shipped
+  # `@_admin_menus = {}` (a separate hash), which no-oped the `@_admin_menus.delete('key')` idiom.
+  describe '#admin_init_actions (regression M19)' do
+    let(:controller) { described_class.new }
+    let(:site) { CamaleonCms::Site.first.decorate }
+
+    before { allow(controller).to receive(:current_site).and_return(site) }
+
+    it 'aliases @_admin_menus onto the live CurrentRequest admin menu store' do
+      controller.send(:admin_init_actions)
+
+      expect(controller.instance_variable_get(:@_admin_menus)).to equal(CurrentRequest.admin_menu_items)
+    end
+
+    it 'lets a delete through @_admin_menus reach the store admin_menu_draw reads' do
+      controller.send(:admin_init_actions)
+      controller.send(:admin_menu_add_menu, 'comments', { icon: 'c', title: 'Comments' })
+
+      controller.instance_variable_get(:@_admin_menus).delete('comments')
+
+      expect(CurrentRequest.admin_menu_items).not_to have_key('comments')
+    end
+  end
+end

--- a/spec/helpers/camaleon_cms/admin/custom_fields_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/custom_fields_helper_spec.rb
@@ -47,5 +47,26 @@ RSpec.describe CamaleonCms::Admin::CustomFieldsHelper, type: :helper do
 
       expect(helper.cf_extra_models_for_fields).to include(CamaleonCms::User)
     end
+
+    it 'does not accumulate hook-appended models across repeated calls' do
+      helper.cf_add_model(CamaleonCms::Post)
+      allow(helper).to receive(:hooks_run) { |_key, args| args[:models] << CamaleonCms::User }
+
+      first = helper.cf_extra_models_for_fields
+      second = helper.cf_extra_models_for_fields
+
+      expect(first).to eq([CamaleonCms::Post, CamaleonCms::User])
+      expect(second).to eq(first)
+      expect(CurrentRequest.extra_models_for_fields).to eq([CamaleonCms::Post])
+    end
+
+    it 'seeds from a controller-assigned legacy @_extra_models_for_fields without mutating it' do
+      legacy = [CamaleonCms::Post]
+      helper.instance_variable_set(:@_extra_models_for_fields, legacy)
+      allow(helper).to receive(:hooks_run) { |_key, args| args[:models] << CamaleonCms::User }
+
+      expect(helper.cf_extra_models_for_fields).to eq([CamaleonCms::Post, CamaleonCms::User])
+      expect(legacy).to eq([CamaleonCms::Post])
+    end
   end
 end

--- a/spec/helpers/camaleon_cms/admin/custom_fields_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/custom_fields_helper_spec.rb
@@ -34,4 +34,18 @@ RSpec.describe CamaleonCms::Admin::CustomFieldsHelper, type: :helper do
       expect(CurrentRequest.extra_models_for_fields).to include('Product', 'Service')
     end
   end
+
+  describe '#cf_extra_models_for_fields (regression M18)' do
+    it 'returns models registered through cf_add_model so they reach the placement dropdown' do
+      helper.cf_add_model(CamaleonCms::Post)
+
+      expect(helper.cf_extra_models_for_fields).to include(CamaleonCms::Post)
+    end
+
+    it 'includes models appended by a custom_field_custom_models hook' do
+      allow(helper).to receive(:hooks_run) { |_key, args| args[:models] << CamaleonCms::User }
+
+      expect(helper.cf_extra_models_for_fields).to include(CamaleonCms::User)
+    end
+  end
 end

--- a/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
@@ -21,6 +21,29 @@ RSpec.describe CamaleonCms::Admin::MenusHelper, type: :helper do
     end
   end
 
+  describe '#admin_menu_draw title sanitization (regression M22)' do
+    before { allow(helper).to receive(:site_current_url).and_return('http://test.host/admin/dashboard') }
+
+    it 'renders inline HTML in a plain-String menu title as markup, not escaped text' do
+      # camaleon-ecommerce ships a title like "Orders <small class='label'>3</small>"
+      admin_menu_add_menu('shop', { icon: 'cart', title: "Orders <small class='label'>3</small>", url: '#' })
+      html = helper.admin_menu_draw
+
+      expect(html).to include('<small')
+      expect(html).to include('3')
+      expect(html).not_to include('&lt;small')
+    end
+
+    it 'strips scripts and event handlers from a menu title' do
+      admin_menu_add_menu('x', { icon: 'x', title: '<span onclick="e()">hi</span><script>evil()</script>', url: '#' })
+      html = helper.admin_menu_draw
+
+      expect(html).to include('hi')
+      expect(html).not_to include('<script')
+      expect(html).not_to include('onclick')
+    end
+  end
+
   describe 'admin menu management with CurrentRequest' do
     it 'stores menu items in CurrentRequest instead of instance variables' do
       expect(CurrentRequest).to receive(:admin_menu_items=).and_call_original

--- a/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe CamaleonCms::Admin::MenusHelper, type: :helper do
       expect(html).not_to include('<script')
       expect(html).not_to include('onclick')
     end
+
+    it 'passes a core-composed SafeBuffer title through untouched' do
+      # Core builds titles via safe_join/content_tag; the data-count attribute sits outside the
+      # plain-String sanitize allowlist, so this fails if the SafeBuffer guard is ever dropped.
+      title = helper.safe_join([helper.content_tag(:span, 'Plugins', data: { count: 3 }), ' ',
+                                helper.content_tag(:small, '3', class: 'label')])
+
+      expect(helper.send(:cama_admin_menu_title, title)).to eql(title)
+    end
   end
 
   describe 'admin menu store identity (regression M19)' do

--- a/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
@@ -7,6 +7,20 @@ RSpec.describe CamaleonCms::Admin::MenusHelper, type: :helper do
 
   before { CurrentRequest.reset }
 
+  describe '#parse_datas (regression M22)' do
+    it 'keeps a single-quoted value that contains double quotes' do
+      datas = %(data-intro='<img style="max-width: 100%;" src="x.png" /> hi' data-position='right')
+      result = helper.send(:parse_datas, datas)
+
+      expect(result[:intro]).to eq('<img style="max-width: 100%;" src="x.png" /> hi')
+      expect(result[:position]).to eq('right')
+    end
+
+    it 'keeps a double-quoted value that contains single quotes' do
+      expect(helper.send(:parse_datas, %(data-note="it's here"))).to eq(note: "it's here")
+    end
+  end
+
   describe 'admin menu management with CurrentRequest' do
     it 'stores menu items in CurrentRequest instead of instance variables' do
       expect(CurrentRequest).to receive(:admin_menu_items=).and_call_original

--- a/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/menus_helper_spec.rb
@@ -44,6 +44,28 @@ RSpec.describe CamaleonCms::Admin::MenusHelper, type: :helper do
     end
   end
 
+  describe 'admin menu store identity (regression M19)' do
+    it 'lets a reference held before menu building (the @_admin_menus.delete idiom) still mutate the store' do
+      admin_menu_add_menu('comments', { icon: 'c', title: 'Comments' })
+      admin_menu_add_menu('media', { icon: 'm', title: 'Media' })
+      aliased = CurrentRequest.admin_menu_items # what admin_init_actions aliases into @_admin_menus
+      admin_menu_insert_menu_before('media', 'new', { icon: 'n', title: 'New' }) # identity-preserving op
+
+      aliased.delete('comments')
+
+      expect(CurrentRequest.admin_menu_items).not_to have_key('comments')
+      expect(CurrentRequest.admin_menu_items).to equal(aliased)
+    end
+
+    it 'preserves store identity on insert_after' do
+      admin_menu_add_menu('a', { icon: 'a', title: 'A' })
+      store = CurrentRequest.admin_menu_items
+      admin_menu_insert_menu_after('a', 'new', { icon: 'n', title: 'New' })
+
+      expect(CurrentRequest.admin_menu_items).to equal(store)
+    end
+  end
+
   describe 'admin menu management with CurrentRequest' do
     it 'stores menu items in CurrentRequest instead of instance variables' do
       expect(CurrentRequest).to receive(:admin_menu_items=).and_call_original

--- a/spec/helpers/camaleon_cms/admin/post_type_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/admin/post_type_helper_spec.rb
@@ -59,6 +59,18 @@ RSpec.describe CamaleonCms::Admin::PostTypeHelper, type: :helper do
       expect(result).not_to be_nil
     end
 
+    it 'falls back to the controller @post_type for the legacy 2-arg call (regression M23)' do
+      # #1178 kept this fallback; #1183 (Phase 6C) removed it, so overridden admin posts-index views
+      # calling the 2-arg form rendered nothing. camaleon-ecommerce is a live 2-arg caller.
+      taxonomies = double(decorate: [category])
+      controller.instance_variable_set(:@post_type, post_type)
+      allow(helper).to receive(:cama_admin_post_type_taxonomy_posts_path).and_return('/path')
+
+      result = helper.post_type_list_taxonomy(taxonomies, 'primary')
+
+      expect(result).to include('Test Category')
+    end
+
     it 'returns empty output if no post_type available from any source' do
       expect(helper.post_type_list_taxonomy([])).to eq('')
     end

--- a/spec/helpers/camaleon_cms/frontend/application_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/application_helper_spec.rb
@@ -71,10 +71,11 @@ RSpec.describe CamaleonCms::Frontend::ApplicationHelper, type: :helper do
       expect(CurrentRequest.frontend_current_theme).to eq(preview_theme)
     end
 
-    it 'does not use controller ivar fallback for frontend object' do
-      helper.instance_variable_set(:@object, site.the_post('sample-post').decorate)
+    it 'falls back to the controller @object ivar for the frontend object (regression M20)' do
+      post = site.the_post('sample-post').decorate
+      helper.instance_variable_set(:@object, post)
 
-      expect(helper.the_title).to be_nil
+      expect(helper.the_title).to eq(post.the_title)
     end
   end
 end

--- a/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/nav_menu_helper_spec.rb
@@ -339,7 +339,7 @@ RSpec.describe CamaleonCms::Frontend::NavMenuHelper do
   end
 
   describe '#cama_parse_menu_item current state' do
-    it 'does not use legacy visited post ivar fallback' do
+    it 'falls back to the legacy visited post ivar when CurrentRequest is unset (regression M20)' do
       create(:nav_menu_item, name: 'Post', kind: 'post', url: '42', parent: @menu)
       post = double(
         id: 42,
@@ -354,7 +354,7 @@ RSpec.describe CamaleonCms::Frontend::NavMenuHelper do
 
       result = helper.cama_parse_menu_item(@menu.children.first)
 
-      expect(result[:current]).to be(false)
+      expect(result[:current]).to be(true)
     end
 
     it 'marks post menu item as current from request-scoped visited post' do

--- a/spec/helpers/camaleon_cms/frontend/site_helper_spec.rb
+++ b/spec/helpers/camaleon_cms/frontend/site_helper_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+# Regression audit M20: the frontend readers ignored the legacy @object / @cama_visited_* ivars, so a
+# plugin front controller that set them (the 2.9.2 way) before rendering got nil-backed the_title /
+# is_home? / SEO helpers. Core writes both CurrentRequest and the ivar, so stock flows never reach the
+# fallback; these pin the restored read-side fallback.
+RSpec.describe CamaleonCms::Frontend::SiteHelper, type: :helper do
+  before do
+    CurrentRequest.reset
+    helper.singleton_class.include(CamaleonCms::Frontend::ContentSelectHelper)
+  end
+
+  after { CurrentRequest.reset }
+
+  describe '#camaleon_frontend_visited_state' do
+    it 'falls back to a plugin-set legacy @cama_visited_* ivar' do
+      helper.instance_variable_set(:@cama_visited_home, true)
+
+      expect(helper.send(:camaleon_frontend_visited_state, :frontend_visited_home)).to be(true)
+    end
+
+    it 'prefers CurrentRequest over the legacy ivar' do
+      CurrentRequest.frontend_visited_home = 'current'
+      helper.instance_variable_set(:@cama_visited_home, 'legacy')
+
+      expect(helper.send(:camaleon_frontend_visited_state, :frontend_visited_home)).to eq('current')
+    end
+  end
+
+  describe '#camaleon_frontend_object' do
+    it 'falls back to a plugin-set @object ivar' do
+      obj = instance_double(CamaleonCms::PostDecorator)
+      helper.instance_variable_set(:@object, obj)
+
+      expect(helper.send(:camaleon_frontend_object)).to eq(obj)
+    end
+  end
+end

--- a/spec/helpers/seo_helper_spec.rb
+++ b/spec/helpers/seo_helper_spec.rb
@@ -78,5 +78,38 @@ describe CamaleonCms::Frontend::SeoHelper do
         )
       end
     end
+
+    # Regression M20: the profile branch reads visited_user for the avatar/name/slogan; a plugin front
+    # controller that sets the legacy @user ivar (the 2.9.2 way) must still back it when
+    # CurrentRequest.frontend_user is unset.
+    context 'when visiting a profile (regression M20)' do
+      let(:legacy_user) do
+        instance_double(CamaleonCms::UserDecorator,
+                        the_avatar: '/legacy.png', the_name: 'Legacy', the_slogan: 'legacy bio')
+      end
+
+      before { CurrentRequest.frontend_visited_profile = true }
+
+      it 'builds the profile SEO from a plugin-set legacy @user ivar' do
+        helper.instance_variable_set(:@user, legacy_user)
+
+        result = helper.cama_the_seo
+
+        expect(result[:og][:title]).to eql("#{site.the_title} | Legacy")
+        expect(result[:og][:description]).to eql('legacy bio')
+        expect(result[:og][:image]).to eql('/legacy.png')
+      end
+
+      it 'prefers CurrentRequest.frontend_user over the legacy ivar' do
+        CurrentRequest.frontend_user = instance_double(
+          CamaleonCms::UserDecorator, the_avatar: '/current.png', the_name: 'Current', the_slogan: 'current bio'
+        )
+        helper.instance_variable_set(:@user, legacy_user)
+
+        result = helper.cama_the_seo
+
+        expect(result[:og][:title]).to eql("#{site.the_title} | Current")
+      end
+    end
   end
 end

--- a/spec/helpers/session_helper_spec.rb
+++ b/spec/helpers/session_helper_spec.rb
@@ -74,5 +74,21 @@ RSpec.describe CamaleonCms::SessionHelper, type: :helper do
       expect(helper.cama_current_user).to eq(decorated_user)
       expect(CurrentRequest.user).to eq(decorated_user)
     end
+
+    it 'memoizes a nil result so it is not re-resolved on every call (regression M16)' do
+      allow(helper).to receive(:cookie_auth_token_complete?).and_return(false)
+      expect(helper).to receive(:cama_calc_api_current_user).once.and_return(nil)
+
+      expect(helper.cama_current_user).to be_nil
+      expect(helper.cama_current_user).to be_nil
+    end
+
+    it 'returns an externally set CurrentRequest.user without re-resolving' do
+      cached = instance_double(CamaleonCms::User)
+      CurrentRequest.user = cached
+      expect(helper).not_to receive(:cama_calc_api_current_user)
+
+      expect(helper.cama_current_user).to eq(cached)
+    end
   end
 end


### PR DESCRIPTION
## What and Why

The `CurrentRequest` refactors (#1178, #1182, #1183 Phase 6C) and the admin-menu rewrite moved runtime state off controller instance variables and rebuilt the admin menu and helper surfaces — and silently broke a set of contracts that plugins, themes and overridden admin views rely on. This restores seven of them (all medium findings in the 2.9.2→master regression audit), one commit each, every one pinned by a spec that reproduced the regression first. Scope was set by the ecosystem survey (`docs/ai/ecosystem.md`).

- **M23** — `post_type_list_taxonomy` lost its 2-arg form's `@post_type` fallback, so overridden admin posts-index views rendered empty taxonomy columns (`camaleon-ecommerce`'s products index is a live caller). Restored.
- **M16** — `cama_current_user` stopped memoizing a signed-out resolution, re-running the API/token lookup on every call. A `CurrentRequest.user_resolved` flag memoizes it; an externally-set user is still honoured. (The `@cama_current_user` ivar-read half is intentionally not restored — no consumer writes that ivar.)
- **M22a** — `parse_datas` truncated a `data-*` value at the first quote of either kind, breaking core's own Menus tooltip; it is now quote-aware.
- **M22b** — menu titles were escaped whole, so a plugin's inline badge (`camaleon-ecommerce`'s Orders count, `<span><small class='label'>`) rendered as literal markup. A plain-String title is now sanitized to a safe inline subset (`span/small/i/b/strong/em` + `class`); SafeBuffer titles core builds pass through untouched. Master already escaped titles, so this is not a security change.
- **M18** — `cf_add_model` wrote `CurrentRequest` while the placement dropdown read the legacy ivar, so registered models never appeared; both now share one store. The `custom_field_custom_models` hook receives a copy of that store, so its appends reach only the read that ran it — repeated renders stay idempotent and a controller-assigned legacy ivar is never mutated.
- **M19** — the `@_admin_menus.delete('key')` removal idiom no-oped; `@_admin_menus` now aliases the live store and the insert methods mutate in place, so a reference held through menu building stays valid.
- **M20** — the frontend readers ignored the legacy `@object` / `@cama_visited_*` / `@user` ivars, so a plugin front controller setting them got nil-backed `the_title` / `is_home?` / SEO helpers; the read-side fallback is restored (the write side already emits the deprecation warning).

Behaviour and contracts are pinned by the new `runtime-compat-surfaces` OpenSpec capability. A follow-up review round then closed the coverage gaps the first pass left open — the `@_admin_menus` alias itself, the SEO profile read of the legacy `@user`, and the SafeBuffer title pass-through are each pinned by a spec that fails without its half of the fix — and hardened the M18 hook payload as described above.

**User-Visible Impact:** Overridden admin posts-index views and plugins such as `camaleon-ecommerce` render taxonomy columns and menu badges again; the admin Menus tooltip renders correctly; frontend helpers honour plugin-set legacy ivars once more. No change to stock installs beyond a fixed admin tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
