### PR TITLE
Draft autosave: create-only validated post_parent and per-user buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Security fix:** Draft autosaves could be forged to parent a new draft under an arbitrary
+  existing post (a client-supplied `post[post_parent]` survived validation), and an edit-own-only
+  user was locked out of autosaving their own post once someone else's autosave had created its
+  draft. `post_parent` is now create-only, derived solely from the validated `post_id`, and draft
+  buffers are per-user, authorized against the post being edited — no request can read, overwrite,
+  re-parent, or detach another user's buffer. Regression audit M12/M13.
+  [#1235](https://github.com/owen2345/camaleon-cms/pull/1235).
+
+  **Notes for upgraders:**
+  - Each editor now keeps a private autosave buffer per post, so the admin drafts list can show
+    one draft per editing user; any successful save of a post still removes all of its buffers.
+  - Roles holding only `edit_other` can now autosave posts they can edit but not author
+    (previously the first autosave of such a post was silently denied).
+
 - **Fix:** Restores seven admin and frontend runtime-compatibility contracts broken by the
   `CurrentRequest` and admin-menu refactors: the 2-arg `post_type_list_taxonomy` (which rendered empty
   taxonomy columns in overridden admin posts-index views), signed-out `cama_current_user` memoization,

--- a/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
@@ -60,14 +60,16 @@ module CamaleonCms
         def set_post_data_params
           post_data = params
                       .require(:post).permit(
-                        :title, :slug, :content, :excerpt, :status, :comment_status, :post_parent, :visibility,
+                        :title, :slug, :content, :excerpt, :status, :comment_status, :visibility,
                         :visibility_value, :post_order, :published_at
                       ).to_h
           post_data.delete(:created_at) if params[:post][:created_at].blank?
           post_data.delete(:updated_at) if params[:post][:updated_at].blank?
           post_data[:status] = 'draft_child'
-          if params[:post_id].present? && current_site.posts.where(id: params[:post_id]).exists?
-            post_data[:post_parent] = params[:post_id]
+          if action_name == 'create'
+            @draft_parent_post = current_site.posts.find_by(id: params[:post_id]) if params[:post_id].present?
+            # post_parent is create-only and always overwritten — never client-writable via post[post_parent]
+            post_data[:post_parent] = @draft_parent_post&.id
           end
           post_data[:data_tags] = params[:tags].to_s
           post_data[:data_categories] = params[:categories] || []

--- a/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
+++ b/app/controllers/camaleon_cms/admin/posts/drafts_controller.rb
@@ -9,16 +9,20 @@ module CamaleonCms
         end
 
         def create
-          if params[:post_id].present?
-            @post_draft = @post_type.posts.drafts.where(post_parent: params[:post_id]).first
+          if @draft_parent_post.present?
+            # A draft buffer is an artifact of editing its parent post — authorize that post,
+            # and only ever touch the current user's own buffer
+            authorize! :update, @draft_parent_post
+            @post_draft = @post_type.posts.drafts.where(post_parent: @draft_parent_post.id,
+                                                        user_id: cama_current_user.id).first
             if @post_draft.present?
-              authorize! :update, @post_draft
               @post_draft.set_option('draft_status', @post_draft.status)
               @post_draft.attributes = @post_data
             end
+          else
+            authorize! :create_post, @post_type
           end
           if @post_draft.blank?
-            authorize! :create_post, @post_type
             @post_draft = @post_type.posts.new(@post_data)
             @post_draft.user_id = cama_current_user.id
           end
@@ -38,8 +42,8 @@ module CamaleonCms
         end
 
         def update
-          @post_draft = @post_type.posts.drafts.find(params[:id])
-          authorize! :update, @post_draft
+          @post_draft = @post_type.posts.drafts.where(user_id: cama_current_user.id).find(params[:id])
+          authorize! :update, @post_draft.parent || @post_draft
           @post_draft.attributes = @post_data
           r = { post: @post_draft, post_type: @post_type }
           hooks_run('update_post_draft', r)
@@ -51,6 +55,11 @@ module CamaleonCms
             msg = { error: @post_draft.errors.full_messages }
           end
           render json: msg
+        rescue ActiveRecord::RecordNotFound
+          # Another user's buffer answers exactly like a nonexistent draft id (same rescue
+          # behavior as PostsController#set_post) — no existence oracle for foreign buffers
+          flash[:error] = t('camaleon_cms.admin.post.message.error', post_type: @post_type.decorate.the_title)
+          redirect_to cama_admin_path
         end
 
         def destroy; end

--- a/app/views/camaleon_cms/admin/posts/form.html.erb
+++ b/app/views/camaleon_cms/admin/posts/form.html.erb
@@ -11,7 +11,8 @@
                         <% if !@post.new_record? %>
                             <%= safe_join([t('camaleon_cms.admin.page_title.edit'), ' ', @post_type.the_title, ': ', @post_decorate.the_title]) %> <%= raw @post_decorate.the_status.html_safe %>
                         <% end %>
-                        <%= link_to raw("#{t('camaleon_cms.admin.button.view_draft')}"), {action: :edit, id: @post.drafts.pluck('id')}, id: "view_draft", class: "label label-warning label-form", title: "#{t('camaleon_cms.admin.button.view_draft')}", target: '_blank' if @post.drafts.present? %>
+                        <% cama_own_draft = @post.drafts.where(user_id: cama_current_user.id).first %>
+                        <%= link_to raw("#{t('camaleon_cms.admin.button.view_draft')}"), {action: :edit, id: cama_own_draft.id}, id: "view_draft", class: "label label-warning label-form", title: "#{t('camaleon_cms.admin.button.view_draft')}", target: '_blank' if cama_own_draft %>
                         <%= t('camaleon_cms.admin.page_title.create') + " " + @post_type.the_title.to_s if @post.new_record? %>
                     </h4>
 

--- a/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/design.md
+++ b/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/design.md
@@ -1,0 +1,96 @@
+# Design — fix-draft-autosave-scoping
+
+## Context
+
+See `proposal.md` — Why. Both defects live in
+`app/controllers/camaleon_cms/admin/posts/drafts_controller.rb`, introduced by #1196 while adding
+authorization to a previously unguarded endpoint. Constraints:
+
+- The CanCan `:update` rule for posts (`CamaleonCms::Ability`) grants edit-own-only roles
+  `post.user_id == user.id` — evaluated against whatever object `authorize!` receives.
+- The shipped autosave JS (`app/assets/javascripts/camaleon_cms/admin/_post.js`) sends
+  `data.post_id` on both create and update, and PATCHes only the draft id it received from its own
+  earlier create — no legitimate client re-parents a draft or touches another user's draft.
+- Publishing/saving a post destroys all of its buffers (`@post.drafts.destroy_all` on update with
+  drafts; `draft_id`-targeted destroy on create), which bounds buffer accumulation.
+- Maintainer decision (2026-08-08, supersedes the first draft of this design): a shared per-post
+  buffer with parent-post authorization still lets one authorized editor destroy another's
+  unpublished work-in-progress; adopt per-user buffers instead, plus create-only `post_parent`.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- `post_parent` mirrors only the *validated* `params[:post_id]` of a create request — never the
+  client-writable `post[post_parent]`, and never mutable after creation.
+- No user can read, overwrite, re-parent, or detach another user's draft buffer.
+- Autosave works for every user entitled to edit the post: edit-own-only owners (M13's lock-out),
+  and `edit_other` holders editing someone else's post (a #1196 `:create_post`-only edge).
+
+**Non-Goals**
+
+- No change to how published posts, the posts index/drafts tab, or `PostsController` consume
+  drafts (the listing showing one buffer per editing user is an accepted consequence, not a
+  redesign of those surfaces).
+- No repair/migration for buffers that predate the fix: an existing shared buffer simply remains
+  its creator's buffer; other editors get fresh buffers; any successful save still clears all.
+- No change to the XHR error format: an `AccessDenied` autosave still receives the admin HTML
+  redirect. Making autosave failures visible as JSON is a possible later hardening, out of scope
+  here.
+
+## Decisions
+
+1. **`post_parent` is create-only** (assigned unconditionally on create from the validated
+   `params[:post_id]`, or nil; update never touches it; `:post_parent` leaves the permit list).
+   Alternatives rejected:
+   - *Guarded assignment only when the param is valid* — that is exactly what created M12: the
+     permitted `post[post_parent]` survived the untaken branch.
+   - *Unconditional mirror on update too (2.9.2's shape)* — restores a sharp edge where a `PATCH`
+     omitting `post_id` detaches the draft; nothing legitimate needs update-time re-parenting.
+2. **Per-user buffers, enforced at lookup scope.** `create` finds the draft by (post type, parent
+   post, current user); `update` finds by (post type, current user, id). Another user's buffer is
+   *unreachable* (`RecordNotFound`), not merely denied — invisibility can't regress into an
+   authorization-order bug, and it leaves no oracle about other users' drafts. Alternative
+   rejected (maintainer decision): shared slot with `authorize! :update` on the parent — closes
+   M13 but keeps cross-user WIP destruction inside the authorized-editor group.
+3. **Authorization follows the post being edited.** Validated parent present →
+   `authorize! :update, parent` for creating or overwriting the user's own buffer under it (a
+   buffer is an artifact of editing that post; permission loss on the post revokes autosave too).
+   No parent → `authorize! :create_post, @post_type` (authoring new content). This deliberately
+   lets `edit_other`-only roles autosave posts they can edit but not author — fixing that #1196
+   edge is a consequence of the principle, pinned by a scenario. The draft row is the authorize
+   target only for parentless drafts (their creator).
+4. **`user_id` preservation strengthens into per-user ownership.** #1196's "preserve on
+   overwrite" requirement was the anti-ownership-theft control; with per-user scoping, cross-user
+   overwrite is impossible, so ownership can never change hands — the requirement is restated in
+   those terms rather than removed.
+5. **The edit form's "view draft" link scopes to the current user's buffer.** The existing
+   `@post.drafts.pluck('id')` interpolates an *array* into one URL — already broken the moment a
+   post has two drafts (reachable today via M12's collision). With per-user buffers it must be
+   the user's own draft: `@post.drafts.where(user_id: cama_current_user.id).first`.
+6. **Repro-first request specs** in `spec/requests/security/draft_authorization_spec.rb`, per the
+   security-fix testing rule. The M13/per-user positives and the parent-gate negatives must fail
+   against the pre-fix controller (verified by running the new specs against a checkout of
+   master's controller); the create-only `post_parent` pin (update keeps its parent) guards the
+   fix's shape — master passes it, the naive unconditional-mirror variant fails it, which is the
+   point.
+
+## Risks / Trade-offs
+
+- [Admin drafts listing shows one buffer per editing user per post; abandoned buffers linger
+  until the post is next saved] → Bounded by `drafts.destroy_all` on every successful save;
+  listing/count changes are cosmetic and documented in the changelog upgrader notes.
+- [A pre-fix shared buffer keeps its creator's ownership; the post owner starts a fresh buffer
+  and does not see the other editor's pending autosave content] → Same information hiding the
+  per-user model prescribes going forward; the old buffer is not lost (visible in the drafts
+  listing, cleared on save).
+- [Rolling back to 2.9.2 with multiple buffers per post] → 2.9.2's unscoped
+  `where(post_parent: X).first` picks one buffer arbitrarily and its autosave overwrites it with
+  ownership transfer — the pre-#1196 status quo; extra buffers are cleared on the next successful
+  save. No data-shape hazard (plain `draft_child` rows throughout).
+
+## Migration Plan
+
+Code-only; no data or schema changes; no repair task needed. Deploy normally; rollback = revert
+the two commits. The behavior delta is confined to the admin drafts XHR endpoint and the edit
+form's view-draft link.

--- a/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/proposal.md
+++ b/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+The 2026-08 regression audit (findings M12 and M13, `REGRESSION-AUDIT-2026-08-03.md`) confirmed two
+defects that #1196 introduced into the draft autosave endpoint while fixing its missing
+authorization:
+
+- **M12** — `set_post_data_params` assigns `post_parent` only when `params[:post_id]` is present
+  and resolves to a real post, but `:post_parent` is also in the strong-parameters permit list. A
+  client-supplied `post[post_parent]` therefore survives unvalidated on every new-post autosave
+  (2.9.2 overwrote it unconditionally). A forged value parents the "new" draft under an arbitrary
+  existing post, where it collides with that post's draft slot (overwrite on next autosave,
+  `drafts.destroy_all` on update, stale `post_draft_id` → `RecordNotFound`). The existing
+  `draft-authorization` scenarios "post_parent nil for invalid post / when post_id absent" pass
+  only because they never smuggle the parameter — they are vacuous against this hole.
+- **M13** — both `authorize! :update` calls target the draft row itself. Since #1196 also
+  (correctly) froze `user_id` to the draft's creator, the CanCan `:update` rule for edit-own-only
+  roles (`post.user_id == user.id`) now checks the *draft creator* instead of the *post being
+  edited*. A user whose own post carries a draft created by someone else (e.g. an admin edited it
+  once) gets `CanCan::AccessDenied` on every autosave of their own post — the XHR receives an
+  HTML redirect and autosave silently stops.
+
+The maintainer reviewed the initially proposed fix (shared draft slot, authorization retargeted to
+the parent post) and directed a stronger resolution: as long as a single buffer is shared per
+post, *some* authorized user can destroy another editor's unpublished work-in-progress. Draft
+buffers therefore become **per-user**, eliminating cross-user draft access entirely instead of
+re-scoping it.
+
+## What Changes
+
+- **`post_parent` is create-only and never client-writable.** `set_post_data_params` drops
+  `:post_parent` from the permit list; on create it assigns the validated `params[:post_id]`
+  (a post existing in the current site) or nil, unconditionally; update never modifies
+  `post_parent` at all. A forged `PATCH` can no longer detach a draft from its post, and a forged
+  `POST` can no longer parent a draft under an arbitrary post.
+- **Draft buffers are per-user.** `create` looks up the draft scoped by post type, parent post,
+  **and current user**; `update`'s finder is scoped to the current user's drafts, so another
+  user's buffer is unreachable (`RecordNotFound`), not merely denied. No user can read, overwrite,
+  or detach another user's autosave buffer.
+- **Authorization follows the post being edited.** Creating or overwriting a buffer under an
+  existing post requires `authorize! :update` on that post; a parentless (new-post) buffer
+  requires `:create_post` on the post type. Consequently a role holding only `edit_other` can now
+  autosave while editing another user's post (its first autosave was denied under #1196's
+  `:create_post`-only rule), and a role that lost update rights on a post loses autosave there
+  too.
+- **The edit form's "view draft" link targets the current user's own buffer** (the existing
+  `@post.drafts.pluck('id')` produced a broken multi-id URL the moment a post had more than one
+  draft).
+- `user_id` semantics: new buffers stamp the current user; overwrites only ever touch the current
+  user's own buffer, so draft ownership never changes hands (strengthens #1196's preservation
+  requirement from "preserved on cross-user overwrite" to "cross-user overwrite impossible").
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `draft-authorization`: lookup requirements for create and update gain per-user scoping; the
+  authorization requirements re-target `authorize!` from the draft row to the parent post
+  (`:create_post` only for parentless buffers); the user_id-preservation requirement becomes the
+  per-user ownership contract; the `post_parent` requirement becomes create-only, validated,
+  never client-writable; a new requirement pins per-user buffer isolation (including the
+  own-buffer "view draft" link).
+
+## Impact
+
+- `app/controllers/camaleon_cms/admin/posts/drafts_controller.rb` (`create`, `update`,
+  `set_post_data_params`).
+- `app/views/camaleon_cms/admin/posts/form.html.erb` (view-draft link).
+- `spec/requests/security/draft_authorization_spec.rb` gains repro coverage for both findings and
+  the per-user isolation contract.
+- No route, model, JS, or schema changes; no migration. Pre-existing shared buffers keep working:
+  they remain their creator's buffer, other editors get fresh buffers on next autosave, and any
+  successful save of the post still destroys all of its buffers (`drafts.destroy_all`).
+- Admin-visible behavior change: the drafts listing can show one buffer per editing user per post
+  (previously exactly one shared buffer per post).

--- a/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/specs/draft-authorization/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/specs/draft-authorization/spec.md
@@ -1,7 +1,31 @@
-## Purpose
+## ADDED Requirements
 
-Ensure the admin draft autosave endpoint performs authorization checks and scoped lookups before mutating draft data, preventing cross-user draft overwrites and content integrity compromise.
-## Requirements
+### Requirement: Per-user draft buffers
+Autosave draft buffers SHALL be private to the user who created them. No request SHALL read,
+overwrite, re-parent, or detach another user's draft buffer, regardless of the requester's
+permissions on the parent post. Editing surfaces that link to a draft SHALL link to the current
+user's own buffer only.
+
+#### Scenario: Autosave never touches another user's buffer
+- **WHEN** a draft buffer for post 5 exists with User B's `user_id` and User A (authorized to
+  update post 5) sends `POST /admin/post_type/1/drafts` with `post_id=5`
+- **THEN** a separate draft owned by User A MUST be created (or User A's own existing buffer
+  updated)
+- **AND** User B's buffer MUST remain unchanged
+
+#### Scenario: Own buffer is reused across autosaves
+- **WHEN** User A already has a draft buffer for post 5 and sends another
+  `POST /admin/post_type/1/drafts` with `post_id=5`
+- **THEN** User A's existing buffer MUST be updated in place
+- **AND** no additional draft MUST be created
+
+#### Scenario: Edit form links to the current user's own buffer
+- **WHEN** drafts for post 5 exist for both User A and User B, and User A opens post 5's edit
+  form
+- **THEN** the "view draft" link MUST target User A's draft only
+
+## MODIFIED Requirements
+
 ### Requirement: Draft create scopes lookup to post type
 The `DraftsController#create` SHALL scope its draft lookup to the requested post type, the
 validated parent post, and the current user: `@post_type.posts.drafts.where(post_parent: <validated
@@ -155,28 +179,3 @@ neither `params[:post_id]` nor any request attribute re-parents or detaches an e
 - **WHEN** an update request for a parented draft omits `params[:post_id]` (or carries any other
   value)
 - **THEN** the draft's `post_parent` MUST remain unchanged
-
-### Requirement: Per-user draft buffers
-Autosave draft buffers SHALL be private to the user who created them. No request SHALL read,
-overwrite, re-parent, or detach another user's draft buffer, regardless of the requester's
-permissions on the parent post. Editing surfaces that link to a draft SHALL link to the current
-user's own buffer only.
-
-#### Scenario: Autosave never touches another user's buffer
-- **WHEN** a draft buffer for post 5 exists with User B's `user_id` and User A (authorized to
-  update post 5) sends `POST /admin/post_type/1/drafts` with `post_id=5`
-- **THEN** a separate draft owned by User A MUST be created (or User A's own existing buffer
-  updated)
-- **AND** User B's buffer MUST remain unchanged
-
-#### Scenario: Own buffer is reused across autosaves
-- **WHEN** User A already has a draft buffer for post 5 and sends another
-  `POST /admin/post_type/1/drafts` with `post_id=5`
-- **THEN** User A's existing buffer MUST be updated in place
-- **AND** no additional draft MUST be created
-
-#### Scenario: Edit form links to the current user's own buffer
-- **WHEN** drafts for post 5 exist for both User A and User B, and User A opens post 5's edit
-  form
-- **THEN** the "view draft" link MUST target User A's draft only
-

--- a/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/tasks.md
+++ b/openspec/changes/archive/2026-08-08-fix-draft-autosave-scoping/tasks.md
@@ -1,0 +1,45 @@
+## 1. M12 — create-only validated post_parent (commit 1)
+
+- [x] 1.1 Repro request specs in `spec/requests/security/draft_authorization_spec.rb`:
+      client-supplied `post[post_parent]` with `post_id` absent, and with `post_id` invalid, must
+      leave the created draft's `post_parent` nil (red against the pre-fix controller); plus the
+      create-only pin — a `PATCH` omitting `post_id` leaves a parented draft's `post_parent`
+      unchanged (guards against the unconditional-mirror variant).
+- [x] 1.2 In `set_post_data_params`: drop `:post_parent` from the permit list; on create only,
+      assign `post_data[:post_parent]` unconditionally from the validated `params[:post_id]`
+      (nil otherwise); update builds no `post_parent` at all.
+- [x] 1.3 Drafts request spec file green; `bin/rubocop` clean on touched files; commit M12
+      (spec + fix).
+
+## 2. M13 — per-user draft buffers (commit 2)
+
+- [x] 2.1 Repro request specs (verified red against master's controller): edit-own-only owner
+      autosaves own post while another user's buffer exists → 200, own buffer created, other
+      buffer untouched; own buffer reused on next autosave (no third row); `PATCH` on another
+      user's draft id → `RecordNotFound`, unchanged; no buffer creation under a post the user
+      cannot update (even holding `create_post`); draft ownership grants nothing under another
+      user's post; `edit_other`-only role autosaves another's post into its own buffer; edit
+      form's view-draft link targets the current user's own buffer when two buffers exist.
+- [x] 2.2 `DraftsController`: `create` resolves the validated parent once, authorizes
+      `:update` on it (or `:create_post` when parentless), and scopes the buffer lookup by
+      (post type, parent, current user); `update` scopes its finder by (post type, current user)
+      and authorizes `:update` on `@post_draft.parent || @post_draft`.
+- [x] 2.3 `form.html.erb`: view-draft link uses the current user's own buffer instead of
+      `@post.drafts.pluck('id')`.
+- [x] 2.4 Drafts request spec file green; `bin/rubocop` clean on touched files; commit M13
+      (specs + fix).
+
+## 3. Verification and CI parity
+
+- [x] 3.1 Full `bin/rspec` suite green.
+- [x] 3.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 4. OpenSpec + PR protocol
+
+- [x] 4.1 `openspec validate fix-draft-autosave-scoping --strict` passes; archive the change
+      on-branch (`openspec archive`) syncing the `draft-authorization` deltas; commit the archived
+      change as its own commit (no `[skip ci]` — it heads the first push).
+- [x] 4.2 Push branch, open the PR (What and Why + User-Visible Impact; no files-changed/test
+      counts/logs/SHAs), first push runs CI.
+- [x] 4.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/draft-authorization/spec.md
+++ b/openspec/specs/draft-authorization/spec.md
@@ -1,7 +1,9 @@
 ## Purpose
 
 Ensure the admin draft autosave endpoint performs authorization checks and scoped lookups before mutating draft data, preventing cross-user draft overwrites and content integrity compromise.
+
 ## Requirements
+
 ### Requirement: Draft create scopes lookup to post type
 The `DraftsController#create` SHALL scope its draft lookup to the requested post type, the
 validated parent post, and the current user: `@post_type.posts.drafts.where(post_parent: <validated

--- a/spec/requests/security/draft_authorization_spec.rb
+++ b/spec/requests/security/draft_authorization_spec.rb
@@ -177,6 +177,146 @@ RSpec.describe 'Security: Draft Authorization', type: :request do
     end
   end
 
+  describe 'per-user draft buffers' do
+    let(:contributor_role) { current_site.user_roles.find_by!(slug: 'contributor') }
+    let(:contributor) { create(:user, role: contributor_role.slug, site: current_site) }
+    let(:own_post) do
+      post_type.posts.create!(title: 'Own Post', slug: 'own-post', user_id: contributor.id, status: 'published')
+    end
+    let!(:admins_draft_of_own_post) do
+      post_type.posts.create!(
+        title: 'Admin Autosave', slug: 'admin-autosave', content: 'Admin content',
+        user_id: admin.id, status: 'draft_child', post_parent: own_post.id
+      )
+    end
+
+    before do
+      contributor_role.set_meta("_post_type_#{current_site.id}", { 'edit' => [post_type.id.to_s] })
+      sign_in_as(contributor, site: current_site)
+    end
+
+    it 'lets the post owner autosave into their own buffer while another user buffer exists' do
+      expect do
+        post "/admin/post_type/#{post_type.id}/drafts", params: {
+          post_id: own_post.id,
+          post: { title: 'Owner Update', content: 'Owner content' }
+        }
+      end.to(change { own_post.drafts.count }.by(1))
+
+      expect(response).to have_http_status(:ok)
+      own_buffer = CamaleonCms::Post.find(JSON.parse(response.body).dig('draft', 'id'))
+      expect(own_buffer.id).not_to eq(admins_draft_of_own_post.id)
+      expect(own_buffer.user_id).to eq(contributor.id)
+      expect(own_buffer.content).to eq('Owner content')
+    end
+
+    it 'leaves the other user buffer untouched' do
+      post "/admin/post_type/#{post_type.id}/drafts", params: {
+        post_id: own_post.id,
+        post: { title: 'Owner Update', content: 'Owner content' }
+      }
+
+      expect(admins_draft_of_own_post.reload.content).to eq('Admin content')
+      expect(admins_draft_of_own_post.reload.user_id).to eq(admin.id)
+    end
+
+    it 'reuses the own buffer on subsequent autosaves' do
+      post "/admin/post_type/#{post_type.id}/drafts", params: {
+        post_id: own_post.id,
+        post: { title: 'First', content: 'First content' }
+      }
+      own_buffer_id = JSON.parse(response.body).dig('draft', 'id')
+
+      expect do
+        post "/admin/post_type/#{post_type.id}/drafts", params: {
+          post_id: own_post.id,
+          post: { title: 'Second', content: 'Second content' }
+        }
+      end.not_to(change { own_post.drafts.count })
+
+      expect(JSON.parse(response.body).dig('draft', 'id')).to eq(own_buffer_id)
+      expect(CamaleonCms::Post.find(own_buffer_id).content).to eq('Second content')
+    end
+
+    it 'treats another user buffer as missing on PATCH' do
+      patch "/admin/post_type/#{post_type.id}/drafts/#{admins_draft_of_own_post.id}", params: {
+        post_id: own_post.id,
+        post: { title: 'Hijack', content: 'Hijack content' }
+      }
+
+      # Indistinguishable from a nonexistent draft id: the standard missing-record
+      # redirect, not an authorization denial (no existence oracle for foreign buffers)
+      expect(response).to redirect_to(%r{/admin\z})
+      expect(flash[:error])
+        .to eq(I18n.t('camaleon_cms.admin.post.message.error', post_type: post_type.decorate.the_title))
+      expect(admins_draft_of_own_post.reload.content).to eq('Admin content')
+    end
+
+    it 'does not create a buffer under a post the user cannot update' do
+      admins_post = post_type.posts.create!(title: 'Admins Post', slug: 'admins-post', user_id: admin.id,
+                                            status: 'published')
+
+      expect do
+        post "/admin/post_type/#{post_type.id}/drafts", params: {
+          post_id: admins_post.id,
+          post: { title: 'Sneaky', content: 'Sneaky content' }
+        }
+      end.not_to(change { current_site.posts.drafts.count })
+
+      expect(response).to have_http_status(:found)
+    end
+
+    it 'grants nothing from draft ownership under another user post' do
+      admins_post = post_type.posts.create!(title: 'Admins Post', slug: 'admins-post', user_id: admin.id,
+                                            status: 'published')
+      stray = post_type.posts.create!(
+        title: 'Stray', slug: 'stray-buffer', content: 'Original',
+        user_id: contributor.id, status: 'draft_child', post_parent: admins_post.id
+      )
+
+      post "/admin/post_type/#{post_type.id}/drafts", params: {
+        post_id: admins_post.id,
+        post: { title: 'Sneaky', content: 'Sneaky content' }
+      }
+
+      expect(response).to have_http_status(:found)
+      expect(stray.reload.content).to eq('Original')
+    end
+
+    it 'lets an edit_other role autosave another user post into its own buffer' do
+      editor_role = current_site.user_roles.find_by!(slug: 'editor')
+      editor_role.set_meta("_post_type_#{current_site.id}", { 'edit_other' => [post_type.id.to_s] })
+      editor = create(:user, role: 'editor', site: current_site)
+      sign_in_as(editor, site: current_site)
+      admins_post = post_type.posts.create!(title: 'Admins Post', slug: 'admins-post', user_id: admin.id,
+                                            status: 'published')
+
+      expect do
+        post "/admin/post_type/#{post_type.id}/drafts", params: {
+          post_id: admins_post.id,
+          post: { title: 'Review Pass', content: 'Review content' }
+        }
+      end.to(change { admins_post.drafts.count }.by(1))
+
+      expect(response).to have_http_status(:ok)
+      buffer = CamaleonCms::Post.find(JSON.parse(response.body).dig('draft', 'id'))
+      expect(buffer.user_id).to eq(editor.id)
+    end
+
+    it 'links the edit form view-draft to the current user own buffer' do
+      own_buffer = post_type.posts.create!(
+        title: 'Mine', slug: 'mine-buffer', content: 'Mine',
+        user_id: contributor.id, status: 'draft_child', post_parent: own_post.id
+      )
+
+      get "/admin/post_type/#{post_type.id}/posts/#{own_post.id}/edit"
+
+      expect(response).to have_http_status(:ok)
+      href = Nokogiri::HTML5.parse(response.body).at_css('#view_draft')['href']
+      expect(href).to end_with("/posts/#{own_buffer.id}/edit")
+    end
+  end
+
   describe 'post_parent validation' do
     before { sign_in_as(admin, site: current_site) }
 

--- a/spec/requests/security/draft_authorization_spec.rb
+++ b/spec/requests/security/draft_authorization_spec.rb
@@ -210,5 +210,37 @@ RSpec.describe 'Security: Draft Authorization', type: :request do
       draft = CamaleonCms::Post.find(json['draft']['id'])
       expect(draft.post_parent).to be_nil
     end
+
+    it 'discards a client-supplied post[post_parent] when post_id is absent' do
+      expect do
+        post "/admin/post_type/#{post_type.id}/drafts", params: {
+          post: { title: 'Smuggled Parent', content: 'Content', post_parent: published_post.id }
+        }
+      end.not_to(change { published_post.drafts.count })
+
+      json = JSON.parse(response.body)
+      draft = CamaleonCms::Post.find(json['draft']['id'])
+      expect(draft.post_parent).to be_nil
+    end
+
+    it 'discards a client-supplied post[post_parent] when post_id is invalid' do
+      post "/admin/post_type/#{post_type.id}/drafts", params: {
+        post_id: 999_999,
+        post: { title: 'Smuggled Parent', content: 'Content', post_parent: published_post.id }
+      }
+
+      json = JSON.parse(response.body)
+      draft = CamaleonCms::Post.find(json['draft']['id'])
+      expect(draft.post_parent).to be_nil
+    end
+
+    it 'never modifies post_parent on update' do
+      patch "/admin/post_type/#{post_type.id}/drafts/#{existing_draft.id}", params: {
+        post: { title: 'Updated Without post_id', content: 'Updated', post_parent: 999_999 }
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(existing_draft.reload.post_parent).to eq(published_post.id)
+    end
   end
 end


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` (findings M12 and M13) confirmed two defects that #1196
introduced into the draft autosave endpoint while adding its missing authorization:

- A client-supplied `post[post_parent]` survived on new-post autosaves — the permit list still
  carried `:post_parent` and the validated assignment ran only when `post_id` was present and
  valid — letting a forged autosave parent its draft under an arbitrary existing post and poison
  that post's draft slot (overwrite on the owner's next autosave, `drafts.destroy_all` on save, a
  stale `post_draft_id` ending in `RecordNotFound`).
- Both `authorize! :update` calls targeted the draft row, whose `user_id` #1196 deliberately froze
  to its creator — so an edit-own-only user whose post carried a draft autosaved by someone else
  was denied every subsequent autosave of their own post (the XHR receives an HTML redirect and
  autosave silently stops), while owning a draft row conversely granted overwrite under a post the
  user could not edit.

`post_parent` is now create-only: assigned unconditionally from the validated `post_id` (nil
otherwise), never client-writable, and immutable through update — the autosave JS sends `post_id`
on every request, so no legitimate caller re-parents a draft, and forged re-parenting or
detaching is gone.

Rather than only re-targeting authorization at the parent post — which would keep one shared
buffer per post that any authorized co-editor can clobber — draft buffers are now per-user
(maintainer decision during review): each editor autosaves into and reuses their own buffer;
authorization follows the post being edited (`:update` on the parent for parented buffers,
`:create_post` for parentless new-post drafts); and a foreign buffer id on update answers exactly
like a nonexistent one, so other users' buffers are unreachable rather than merely denied. A role
holding only `edit_other` can now autosave posts it can edit but not author — its first autosave
was previously denied silently. The edit form's "view draft" link targets the current user's own
buffer (the old array-`pluck` link generated a broken URL as soon as a post had two drafts).

The `draft-authorization` OpenSpec capability is amended accordingly, archived on the branch.

## User-Visible Impact

Multi-editor sites stop losing autosaved work: each editor keeps a private draft buffer per post
(so the admin drafts list can show one buffer per editor), edit-own-only and `edit_other` roles
get working autosave on the posts they may edit, and forged autosave requests can no longer
re-parent, detach, or reach other users' drafts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
