### PR TITLE
Session fixes: login-page locale, case-insensitive return_to host, scalar user_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@
   back silently otherwise); same-host `return_to` destinations are followed regardless of host
   letter case and emitted with the canonical host; and malformed `?user_id[]=` requests on admin
   user routes no longer crash with a 500 or wrongly deny self-edits — a non-scalar `user_id` is
-  ignored and the route target wins. Regression audit M15/M17/M14.
+  ignored and the route target wins. Post-review hardening on the same PR: non-scalar locale
+  parameters (`?locale[]=`, `?cama_set_language[]=`) are likewise ignored on the admin session
+  pages and the site frontend instead of crashing with a 500, and a scalar `?locale=` naming a
+  language the site does not offer now renders the site's 404 page (in the site's own language)
+  instead of failing with a template error. Regression audit M15/M17/M14.
   [#1236](https://github.com/owen2345/camaleon-cms/pull/1236).
 
 - **Security fix:** Draft autosaves could be forged to parent a new draft under an arbitrary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Fix:** Three session-adjacent regressions: the admin login/register/forgot-password pages
+  render in the site's language again (with `?locale=` honored when the site offers it, falling
+  back silently otherwise); same-host `return_to` destinations are followed regardless of host
+  letter case and emitted with the canonical host; and malformed `?user_id[]=` requests on admin
+  user routes no longer crash with a 500 or wrongly deny self-edits — a non-scalar `user_id` is
+  ignored and the route target wins. Regression audit M15/M17/M14.
+  [#1236](https://github.com/owen2345/camaleon-cms/pull/1236).
+
 - **Security fix:** Draft autosaves could be forged to parent a new draft under an arbitrary
   existing post (a client-supplied `post[post_parent]` survived validation), and an edit-own-only
   user was locked out of autosaving their own post once someone else's autosave had created its

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -165,10 +165,11 @@ module CamaleonCms
       end
 
       # These pages render before authentication, so the site's languages — not a user
-      # preference — pick the locale; ?locale= applies only when the site offers it
+      # preference — pick the locale; ?locale= applies only when scalar (?locale[]=
+      # would crash to_sym) and offered by the site
       def set_login_locale
         site_languages = current_site.get_languages
-        requested = params[:locale].presence&.to_sym
+        requested = (params[:locale].presence&.to_sym if params[:locale].is_a?(String))
         I18n.locale = if site_languages.include?(requested)
                         requested
                       else

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -160,7 +160,20 @@ module CamaleonCms
         # NOTE: session[:cama_current_language] is for FRONTEND only (user's site language choice)
         # Admin should use admin language setting, not frontend language
         # This prevents language mixing when switching between frontend and admin contexts
+        set_login_locale
         hooks_run('session_before_load')
+      end
+
+      # These pages render before authentication, so the site's languages — not a user
+      # preference — pick the locale; ?locale= applies only when the site offers it
+      def set_login_locale
+        site_languages = current_site.get_languages
+        requested = params[:locale].presence&.to_sym
+        I18n.locale = if site_languages.include?(requested)
+                        requested
+                      else
+                        site_languages.first || I18n.default_locale
+                      end
       end
 
       def after_hook_session

--- a/app/controllers/camaleon_cms/admin/users_controller.rb
+++ b/app/controllers/camaleon_cms/admin/users_controller.rb
@@ -152,8 +152,13 @@ module CamaleonCms
         (user_id.present? && cama_current_user.id.to_s == user_id.to_s) || authorize!(:manage, :users)
       end
 
+      # Only a scalar user_id participates in target resolution (?user_id[]= would
+      # crash the record lookup and flip authorization); otherwise the route id wins
       def user_id_param
-        params[:user_id] || params[:id]
+        user_id = params[:user_id]
+        return params[:id] unless user_id.is_a?(String)
+
+        user_id
       end
 
       def user_params

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -288,9 +288,13 @@ module CamaleonCms
       end
 
       @_site_options = current_site.options
-      session[:cama_current_language] = params[:cama_set_language].to_sym if params[:cama_set_language].present?
+      # Only a scalar language param participates in locale resolution — a non-scalar
+      # (?locale[]= / ?cama_set_language[]=) would crash to_sym and 500 the request
+      set_language = params[:cama_set_language]
+      session[:cama_current_language] = set_language.to_sym if set_language.is_a?(String) && set_language.present?
       session[:cama_current_language] = nil if current_site.get_languages.exclude?(session[:cama_current_language])
-      I18n.locale = params[:locale] || session[:cama_current_language] || current_site.get_languages.first
+      requested_locale = params[:locale] if params[:locale].is_a?(String)
+      I18n.locale = requested_locale || session[:cama_current_language] || current_site.get_languages.first
       return page_not_found unless current_site.get_languages.include?(I18n.locale.to_sym)
 
       configure_frontend_lookup_prefixes

--- a/app/controllers/camaleon_cms/frontend_controller.rb
+++ b/app/controllers/camaleon_cms/frontend_controller.rb
@@ -295,10 +295,15 @@ module CamaleonCms
       session[:cama_current_language] = nil if current_site.get_languages.exclude?(session[:cama_current_language])
       requested_locale = params[:locale] if params[:locale].is_a?(String)
       I18n.locale = requested_locale || session[:cama_current_language] || current_site.get_languages.first
-      return page_not_found unless current_site.get_languages.include?(I18n.locale.to_sym)
-
+      # The availability gate renders the site's 404 (directly or via a custom error_404
+      # post), so the theme lookup prefixes must already be registered when it fires
       configure_frontend_lookup_prefixes
       theme_init
+      return if current_site.get_languages.include?(I18n.locale.to_sym)
+
+      # The unoffered locale must not style the 404 page or leak into its links
+      I18n.locale = current_site.get_languages.first
+      page_not_found
     end
 
     # initialize hooks before to execute action

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -176,14 +176,20 @@ module CamaleonCms
 
     private
 
-    # validate redirect url to prevent open redirect attacks
+    # validate redirect url to prevent open redirect attacks: relative or same-host only,
+    # host compared case-insensitively (RFC 3986); cross-site return_to on multisite is
+    # deliberately unsupported — a sibling-site allowlist would be its own security change.
+    # A passing absolute URL is emitted with the host in the request's canonical case, so
+    # Rails' own case-sensitive open-redirect protection stays active without tripping on it.
     def safe_redirect_url(url)
       return if url.blank?
 
       uri = URI.parse(url)
-      return if uri.host.present? && uri.host != request.host
+      return url if uri.host.blank?
+      return unless uri.host.casecmp?(request.host)
 
-      url
+      uri.host = request.host
+      uri.to_s
     rescue URI::InvalidURIError
       nil
     end

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/design.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/design.md
@@ -76,6 +76,24 @@ flipping the flag back on needs verification across the whole engine (any `redir
 `the_url`-derived value can be cross-host on wildcard-subdomain multisite). Spun off as its own
 follow-up; no engine change in this PR.
 
+## Post-review addendum
+
+Code review extended the change with three locale-parameter fixes; the decisions:
+
+5. **Non-scalar params never participate, anywhere.** The M14 scalar rule generalizes: a
+   non-scalar `?locale=` (admin and frontend) or `?cama_set_language=` is ignored in favor of
+   the rest of the resolution chain — not rejected with a 4xx, never a 500. Same rationale as
+   M14: degrade to the value the rest of the request already agrees on.
+6. **The frontend locale gate fires after theme lookup registration.** Both branches of
+   `page_not_found` (the 404 template under the theme layout, a custom `error_404` post via
+   `render_post`) need `configure_frontend_lookup_prefixes`; the reorder is safe because
+   neither that method nor `theme_init` depends on the locale, and passing requests execute
+   the same calls in the same relative order. Rejected: rendering the gate 404 with
+   `layout: false` (unstyled, diverges from every other frontend 404).
+7. **The rejected locale is replaced before the 404 renders.** `I18n.locale` resets to the
+   site's first language so the error page renders in the site's language and
+   `default_url_options` does not stamp the rejected locale onto the page's links.
+
 ## Risks / Trade-offs
 
 - [A site whose stored `languages_site` meta is malformed] → `get_languages` already rescues to

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/design.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/design.md
@@ -1,0 +1,89 @@
+# Design — fix-session-locale-and-redirects
+
+## Context
+
+See `proposal.md` — Why. Three independent one-site fixes, one commit each (M15 → M17 → M14).
+Constraints:
+
+- #1166 deliberately severed the frontend `session[:cama_current_language]` from admin context
+  (the surviving comment in `before_hook_session` records this); the regression is the collateral
+  loss of any locale resolution on the login-layout pages, not the severing itself.
+- `safe_redirect_url` is the single chokepoint for all three `return_to` consumers
+  (login-when-signed-in, post-login cookie in `cama_after_login`, logout), so the casecmp fix
+  lands once and covers every call site.
+- #1214 made `params[:user_id]` → `params[:id]` the canonical resolution chain
+  (`user-target-resolution` capability); the non-scalar hole sits inside that helper, so the fix
+  must not reorder the chain.
+- `spec/dummy` runs `show_exceptions = :none`, so a 500-class repro must assert the raised
+  exception or use the failing status observed through the app's own rescues.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Pre-auth session pages render in the site's language; `?locale=` works when the site offers it
+  and can never 500.
+- Same-host `return_to` destinations survive regardless of letter case; cross-host destinations
+  still fall back.
+- `?user_id[]=` neither crashes member routes nor flips authorization outcomes; it degrades to
+  the route target.
+
+**Non-Goals**
+
+- No sibling-site/multisite `return_to` allowlist — cross-host destinations keep falling back;
+  that would be its own security change (`camaleon_website` currently runs
+  `raise_on_open_redirects = false` awaiting a broader engine review — see the triage note).
+- No change to #1214's scalar `user_id` precedence, and no 4xx rejection of non-scalar values —
+  degrading to the path target keeps the authorization filter and record lookup agreed on one
+  record, which is the capability's invariant.
+- No signed-in admin locale changes (`get_admin_language` and the admin layout are untouched —
+  the pre-auth pages have no user to read a preference from, which is why the site's languages,
+  not a user setting, are the source).
+
+## Decisions
+
+1. **M15 guard = the site's configured languages**, not `I18n.available_locales`: `?locale=` is a
+   site-visitor affordance, so a locale the site does not offer should not be selectable even if
+   the host app ships translations for it; this also keeps the guard one predicate against data
+   already loaded (`get_languages`, symbols, memoized). Unknown values fall back to
+   `get_languages.first || I18n.default_locale` — assigning only vetted symbols means
+   `I18n::InvalidLocale` is unreachable.
+2. **M17 = `casecmp?` validation + canonical-host emission.** Validating alone is not enough:
+   Rails 8.1's own guard (`action_on_open_redirect = :raise`, active in `spec/dummy` via
+   `load_defaults`) compares hosts case-sensitively in `_url_host_allowed?`, so passing the
+   mixed-case URL through `redirect_to` raises `OpenRedirectError` — discovered by the repro
+   specs. `safe_redirect_url` therefore rewrites the validated URL's host to `request.host`
+   (functionally identical — hosts are case-insensitive) and returns `uri.to_s`, which keeps
+   Rails' protection active instead of bypassing it. Rejected: `allow_other_host: true` at the
+   three call sites (disables Rails' net exactly where a future regression in our own check
+   would need it); downcasing the whole URL (mangles path/query case).
+3. **M14 = scalar type-check inside `user_id_param`** (`params[:user_id]` participates only when
+   it `is_a?(String)`; query/body params are Strings or containers, so this is exactly
+   "scalar"). The helper stays the single place resolution happens; `validate_role`, `set_user`,
+   and `updated_ajax` all inherit the fix.
+4. **Repro-first specs**, one per finding, in the files named by the proposal. The M14 repro
+   pins the admin 500 (`find(Array)` returning an Array that crashes the action) and the
+   non-admin self-edit denial; both flip with the fix.
+
+## Triage note — `cama_site_check_existence` (not fixed here)
+
+`camaleon_website` runs `config.action_controller.raise_on_open_redirects = false` with a TODO
+naming this method. On current master the method's only cross-host redirect
+(`redirect_when_site_missing` → main site URL) already passes `allow_other_host: true` (added
+2024-06 in `d335a666`, pre-2.9.2); the inactive/maintenance redirects target the current site's
+own posts (same host). The host-app workaround therefore looks stale for the named method, but
+flipping the flag back on needs verification across the whole engine (any `redirect_to` of a
+`the_url`-derived value can be cross-host on wildcard-subdomain multisite). Spun off as its own
+follow-up; no engine change in this PR.
+
+## Risks / Trade-offs
+
+- [A site whose stored `languages_site` meta is malformed] → `get_languages` already rescues to
+  the host default; the new code only consumes its output.
+- [Callers relying on `?user_id[]=` being denied for self-edits] → that denial was an accident of
+  `Array#to_s` never matching; the specified behavior (resolve to the route id) is what #1214's
+  chain produces for every other malformed shape.
+
+## Migration Plan
+
+Code-only; no data or schema changes. Deploy normally; rollback = revert the three commits.

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/proposal.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/proposal.md
@@ -34,6 +34,24 @@ medium regressions, batched as PR 3 of the fix plan:
   `:id`. The #1214 scalar-`user_id` precedence is unchanged; `?user_id[]=` requests stop 500ing
   for managers and stop mis-denying self-edits, resolving to the path target instead.
 
+### Post-review additions (same branch)
+
+Code review of the three fixes surfaced three adjacent locale-parameter defects, fixed on this
+branch after the archive:
+
+- **Admin session pages**: the M15 resolver symbolized the raw `?locale=` parameter, so a
+  non-scalar value (`?locale[]=`) raised `NoMethodError` — a 500 on the pre-authentication
+  pages, violating this change's own "malformed values fall back silently" requirement. Only a
+  scalar `?locale=` participates now.
+- **Frontend non-scalar params**: `FrontendController#init_frontent` had the same unguarded
+  symbolization for `?locale=` and `?cama_set_language=` (pre-existing on master). Only scalar
+  values participate; non-scalars degrade to the session-language / site-first fallback chain.
+- **Frontend unoffered locale**: the locale availability gate called `page_not_found` before
+  the theme lookup prefixes were registered, so an unoffered scalar `?locale=` raised
+  `ActionView::MissingTemplate` instead of rendering a 404 (pre-existing on master, and the
+  same for a site's custom `error_404` post). The gate now fires after prefix registration and
+  renders the site's 404 in the site's first language.
+
 ## Capabilities
 
 ### New Capabilities
@@ -44,6 +62,9 @@ medium regressions, batched as PR 3 of the fix plan:
 - `session-return-redirects`: the `return_to` redirect policy shared by the three session call
   sites: relative and same-host-any-casing values pass, cross-host and unparsable values fall
   back to the safe default — never an error, never an off-host redirect.
+- `frontend-locale-resolution` (post-review): the frontend's scalar-only locale fallback chain
+  (`?locale=` → session language → site first language) and the unoffered-locale outcome — the
+  site's own 404 page in the site's language, never a server error.
 
 ### Modified Capabilities
 
@@ -55,9 +76,12 @@ medium regressions, batched as PR 3 of the fix plan:
 - `app/controllers/camaleon_cms/admin/sessions_controller.rb` (`before_hook_session`).
 - `app/helpers/camaleon_cms/session_helper.rb` (`safe_redirect_url`).
 - `app/controllers/camaleon_cms/admin/users_controller.rb` (`user_id_param`).
-- Specs: new `spec/requests/admin/sessions_locale_spec.rb`; extensions to
+- `app/controllers/camaleon_cms/frontend_controller.rb` (`init_frontent`) — post-review.
+- Specs: new `spec/requests/admin/sessions_locale_spec.rb` and (post-review)
+  `spec/requests/frontend_locale_spec.rb`; extensions to
   `spec/requests/security/open_redirect_session_spec.rb` and
   `spec/requests/admin/users_controller/member_route_target_resolution_spec.rb`.
 - No routes, models, JS, or data changes. Behavior deltas: localized session pages return,
   mixed-case same-host `return_to` works again, `?user_id[]=` degrades safely to the route
-  target.
+  target, non-scalar locale params degrade instead of erroring, and unoffered frontend locales
+  render the site's 404.

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/proposal.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/proposal.md
@@ -1,0 +1,63 @@
+## Why
+
+The 2026-08 regression audit (`REGRESSION-AUDIT-2026-08-03.md`) confirmed three session-adjacent
+medium regressions, batched as PR 3 of the fix plan:
+
+- **M15** — the admin login, register, and forgot-password pages lost localization. #1166 removed
+  the locale lines from `SessionsController#before_hook_session` (deliberately dropping the
+  frontend `session[:cama_current_language]` from admin context) and #1175 did not restore the
+  collateral loss: non-English sites now render those pages in the host's default locale, and
+  `?locale=` is ignored.
+- **M17** — `SessionHelper#safe_redirect_url` (added by #1168 to close open redirects) compares
+  hosts case-sensitively. A `return_to` naming the same host with different casing
+  (`HTTP://WWW.Example.COM/…`) is dropped to the fallback path on all three call sites:
+  login-when-signed-in, the post-login `return_to` cookie, and logout. Host names are
+  case-insensitive (RFC 3986/4343).
+- **M14** — the #1214 target-resolution fix made `params[:user_id]` authoritative on member
+  routes, but a non-scalar value (`?user_id[]=X`) slips through `user_id_param`:
+  `validate_role` mismatches it (wrongly denying self-edits), and for managers
+  `set_user`/`updated_ajax`'s `find(Array)` returns an Array that crashes the action with a 500.
+
+## What Changes
+
+- **M15**: `before_hook_session` resolves `I18n.locale` for the login-layout pages from the
+  site's configured languages: `?locale=` is honored when the site offers that locale, otherwise
+  the site's first language applies. Unknown or unoffered `?locale=` values fall back silently
+  (no `I18n::InvalidLocale`). The frontend `session[:cama_current_language]` remains uninvolved —
+  #1166's separation stands.
+- **M17**: `safe_redirect_url` compares the parsed host to `request.host` case-insensitively
+  (`casecmp?`). Relative URLs and same-host absolute URLs (any casing) pass; cross-host values
+  are still dropped to the safe fallback. Cross-site `return_to` on multisite remains
+  unsupported, now stated in the method's contract (a sibling-site allowlist would be its own
+  security change).
+- **M14**: `user_id_param` ignores a non-scalar `params[:user_id]`, falling back to the route's
+  `:id`. The #1214 scalar-`user_id` precedence is unchanged; `?user_id[]=` requests stop 500ing
+  for managers and stop mis-denying self-edits, resolving to the path target instead.
+
+## Capabilities
+
+### New Capabilities
+
+- `admin-login-locale`: locale resolution for the pre-authentication admin session pages
+  (login/register/forgot): site languages as the source, `?locale=` availability-guarded,
+  frontend session language excluded.
+- `session-return-redirects`: the `return_to` redirect policy shared by the three session call
+  sites: relative and same-host-any-casing values pass, cross-host and unparsable values fall
+  back to the safe default — never an error, never an off-host redirect.
+
+### Modified Capabilities
+
+- `user-target-resolution`: the canonical resolution requirement gains the scalar rule — a
+  non-scalar `user_id` parameter does not participate in resolution and the route id is used.
+
+## Impact
+
+- `app/controllers/camaleon_cms/admin/sessions_controller.rb` (`before_hook_session`).
+- `app/helpers/camaleon_cms/session_helper.rb` (`safe_redirect_url`).
+- `app/controllers/camaleon_cms/admin/users_controller.rb` (`user_id_param`).
+- Specs: new `spec/requests/admin/sessions_locale_spec.rb`; extensions to
+  `spec/requests/security/open_redirect_session_spec.rb` and
+  `spec/requests/admin/users_controller/member_route_target_resolution_spec.rb`.
+- No routes, models, JS, or data changes. Behavior deltas: localized session pages return,
+  mixed-case same-host `return_to` works again, `?user_id[]=` degrades safely to the route
+  target.

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/admin-login-locale/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/admin-login-locale/spec.md
@@ -1,0 +1,52 @@
+## Purpose
+
+Localize the pre-authentication admin session pages (login, register, forgot-password) from the
+site's configured languages, honoring an explicit `?locale=` request only when the site offers it.
+
+## ADDED Requirements
+
+### Requirement: Session pages localize from the site's languages
+
+The admin session pages rendered before authentication (login, register, forgot-password) SHALL
+resolve `I18n.locale` from the current site's configured languages: the site's first configured
+language by default. Sites whose first language is not the host application's default locale MUST
+NOT render these pages in the host default.
+
+#### Scenario: Non-English site renders its own language
+
+- **WHEN** a site's configured languages are `[es, en]` and a visitor opens `/admin/login`
+- **THEN** the page renders with Spanish translations
+
+#### Scenario: Site without configured languages uses the host default
+
+- **WHEN** a site has no stored language configuration
+- **THEN** the session pages render in the host application's default locale
+
+### Requirement: Explicit locale requests are availability-guarded
+
+A `?locale=` query parameter SHALL select the page locale only when the site's configured
+languages include that locale. Unknown, unoffered, or malformed values SHALL fall back to the
+default resolution silently — the request MUST NOT raise (`I18n::InvalidLocale`) or produce a
+server error.
+
+#### Scenario: Offered locale is honored
+
+- **WHEN** a site's configured languages are `[es, en]` and a visitor opens `/admin/login?locale=en`
+- **THEN** the page renders with English translations
+
+#### Scenario: Unoffered locale falls back
+
+- **WHEN** a site's configured languages are `[es]` and a visitor opens `/admin/login?locale=de`
+- **THEN** the page renders with Spanish translations
+- **AND** the response is not a server error
+
+### Requirement: Frontend language choice stays out of admin session pages
+
+The frontend visitor language stored in `session[:cama_current_language]` SHALL NOT influence the
+admin session pages' locale.
+
+#### Scenario: Frontend session language does not leak
+
+- **WHEN** a visitor's frontend session carries a language different from the site's first
+  configured language and the visitor opens `/admin/login` without a `?locale=` parameter
+- **THEN** the page renders in the site's first configured language

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/admin-login-locale/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/admin-login-locale/spec.md
@@ -40,6 +40,12 @@ server error.
 - **THEN** the page renders with Spanish translations
 - **AND** the response is not a server error
 
+#### Scenario: Non-scalar locale parameter falls back
+
+- **WHEN** a visitor opens `/admin/login?locale[]=en` (or any other non-scalar `locale` value)
+- **THEN** the page renders in the site's first configured language
+- **AND** the response is not a server error
+
 ### Requirement: Frontend language choice stays out of admin session pages
 
 The frontend visitor language stored in `session[:cama_current_language]` SHALL NOT influence the

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/frontend-locale-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/frontend-locale-resolution/spec.md
@@ -1,0 +1,48 @@
+## Purpose
+
+Define how the frontend resolves the request locale — from the `?locale=` parameter, the
+visitor's session language, and the site's configured languages — and what happens when a
+request names a locale the site does not offer. Added by the post-review hardening on this
+change's branch.
+
+## ADDED Requirements
+
+### Requirement: The frontend resolves its locale through a scalar-only fallback chain
+
+The frontend SHALL resolve `I18n.locale` in order: a scalar `?locale=` parameter, the visitor's
+session language (stored from a scalar `?cama_set_language=` parameter), then the site's first
+configured language. Only scalar values SHALL participate: a non-scalar `locale` or
+`cama_set_language` parameter (an array or hash, e.g. `?locale[]=`) SHALL be ignored in favor of
+the rest of the chain and MUST NOT produce a server error. A session language the site does not
+offer SHALL be dropped from the chain.
+
+#### Scenario: Non-scalar locale parameter is ignored
+
+- **WHEN** a visitor opens `/?locale[]=en`
+- **THEN** the page renders with the locale resolved from the rest of the chain
+- **AND** the response is not a server error
+
+#### Scenario: Non-scalar language-switch parameter is ignored
+
+- **WHEN** a visitor opens `/?cama_set_language[]=en`
+- **THEN** the page renders with the locale resolved from the rest of the chain
+- **AND** the response is not a server error
+
+#### Scenario: Offered scalar locale is honored
+
+- **WHEN** a site's configured languages include `en` and a visitor opens `/?locale=en`
+- **THEN** the page renders in English
+
+### Requirement: Unoffered locales produce the site's 404 page
+
+When the resolved locale is not among the site's configured languages, the frontend SHALL
+respond `404 Not Found` with the site's own error page — the standard 404 template or the
+site's configured custom `error_404` post — rendered through the active theme. The rejected
+locale SHALL NOT style the error page or leak into its links: the page SHALL render in the
+site's first configured language. The response MUST NOT be a server error.
+
+#### Scenario: Unoffered scalar locale renders the site 404
+
+- **WHEN** a site's configured languages are `[en]` and a visitor opens `/?locale=de`
+- **THEN** the response is `404 Not Found`
+- **AND** the body is the site's 404 page rendered in English

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/session-return-redirects/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/session-return-redirects/spec.md
@@ -1,0 +1,58 @@
+## Purpose
+
+Define the `return_to` redirect policy for the admin session flows — which caller-supplied
+destinations are followed and which fall back to the safe default — closing open redirects
+without dropping legitimate same-host destinations.
+
+## ADDED Requirements
+
+### Requirement: return_to redirects are same-host with case-insensitive comparison
+
+A caller-supplied `return_to` destination SHALL be followed only when it is relative (no host) or
+absolute on the requesting host, and the host comparison SHALL be case-insensitive (host names
+are case-insensitive per RFC 3986). A followed absolute destination SHALL be emitted with the
+host in the request's canonical case, so the framework's own case-sensitive open-redirect
+protection (`action_on_open_redirect`) stays active and never trips on a legitimate destination.
+Cross-host and unparsable destinations SHALL be dropped in favor of the flow's safe default
+path — never an error, never an off-host redirect. Cross-site destinations on multisite installs
+are deliberately unsupported by this policy; supporting sibling sites would be a separate
+security change.
+
+The policy SHALL apply uniformly to every session flow that consumes `return_to`: visiting the
+login page while already signed in, the post-login `return_to` cookie, and logout.
+
+#### Scenario: Mixed-case same-host destination is followed
+
+- **WHEN** a signed-in user opens `/admin/login?return_to=` naming the requesting host in a
+  different letter case (e.g. `http://WWW.EXAMPLE.COM/admin/posts`)
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case
+
+#### Scenario: Relative destination is followed
+
+- **WHEN** a session flow consumes a `return_to` that is a relative path
+- **THEN** the response redirects to that path
+
+#### Scenario: Cross-host destination falls back
+
+- **WHEN** a session flow consumes a `return_to` naming a different host
+- **THEN** the response redirects to the flow's safe default path
+
+#### Scenario: Unparsable destination falls back
+
+- **WHEN** a session flow consumes a `return_to` that is not a parsable URI
+- **THEN** the response redirects to the flow's safe default path
+
+#### Scenario: Post-login cookie honors a mixed-case same-host destination
+
+- **WHEN** a user logs in with a `return_to` cookie naming the requesting host in a different
+  letter case
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case
+
+#### Scenario: Logout honors a mixed-case same-host destination
+
+- **WHEN** a signed-in user logs out with `?return_to=` naming the requesting host in a
+  different letter case
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case after the session is closed

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/user-target-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/specs/user-target-resolution/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: The canonical helper resolves one ordered parameter chain
+
+The canonical helper SHALL resolve the target user id from `params[:user_id]` first, falling back to `params[:id]`. Only a **scalar** `user_id` SHALL participate in resolution: when `params[:user_id]` is non-scalar (an array or hash, e.g. `?user_id[]=X`), the helper SHALL ignore it and resolve from `params[:id]`, so a malformed injection can neither crash the action nor change which record the authorization filter and the lookup agree on.
+
+This ordering is deliberate for the nested route `PATCH /admin/users/:user_id/updated_ajax`, where the path segment lands in `params[:user_id]` and is therefore not attacker-controllable, while `params[:id]` is absent from the route and can only arrive by injection. Rails merges path parameters last (`ActionDispatch::Http::Parameters#parameters`), so a path segment always overrides a query-string or body value of the same name.
+
+On the member routes `/admin/users/:id` the ordering inverts which key is authoritative: the path segment lands in `params[:id]`, so an injected `user_id` takes precedence over it. This is not a privilege escalation — the authorization filter and the record lookup still resolve the same user, and any caller who passes the filter for that user is entitled to act on them — but it is observable, so it is specified here rather than left implicit.
+
+#### Scenario: Nested route with no injected key resolves to the path segment
+
+- **WHEN** an admin sends `PATCH /admin/users/<TARGET_ID>/updated_ajax` with new `password` parameters and no `id` parameter
+- **THEN** the system updates the password of the user identified by the path segment
+
+#### Scenario: Member route with no injected key resolves to the path segment
+
+- **WHEN** an admin sends `PATCH /admin/users/<TARGET_ID>` with `user` attributes and no `user_id` parameter
+- **THEN** the system updates the user identified by the path segment
+
+#### Scenario: Member route with an injected user_id resolves to the injected value
+
+- **WHEN** an admin sends `PATCH /admin/users/<USER_A_ID>?user_id=<USER_B_ID>` with `user` attributes
+- **THEN** the system updates user B
+- **AND** user A is unchanged
+
+#### Scenario: Impersonate resolves the injected value in preference to the path segment
+
+- **WHEN** an admin sends `GET /admin/users/<USER_A_ID>/impersonate?user_id=<USER_B_ID>`
+- **THEN** the session switches to user B
+- **AND** the session does not switch to user A
+
+Note: this scenario is the one that exercises `impersonate` against target resolution. It uses an admin caller deliberately — an admin holds `can :manage, :all`, so the resolved target alone decides the outcome. A non-admin caller cannot test this, because `cannot :impersonate` denies them whichever user resolves.
+
+#### Scenario: Non-scalar user_id falls back to the path segment
+
+- **WHEN** an admin sends `PATCH /admin/users/<USER_A_ID>?user_id[]=<USER_B_ID>` with `user` attributes
+- **THEN** the system updates user A (the path segment)
+- **AND** user B is unchanged
+- **AND** the response is not a server error
+
+#### Scenario: Non-scalar user_id does not deny a self-edit
+
+- **WHEN** a non-admin sends `PATCH /admin/users/<OWN_ID>?user_id[]=<OTHER_ID>` with `user` attributes
+- **THEN** the system updates only the caller's own record
+- **AND** the other user is unchanged

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/tasks.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/tasks.md
@@ -1,0 +1,46 @@
+## 1. M15 — admin login-page locale (commit 1)
+
+- [x] 1.1 New `spec/requests/admin/sessions_locale_spec.rb`: site languages `[es, en]` → login
+      page renders the Spanish `log_in` label (red on the unfixed controller); `?locale=en`
+      honored; `?locale=` not offered by the site falls back without a server error; frontend
+      `session[:cama_current_language]` does not leak in.
+- [x] 1.2 `SessionsController#before_hook_session`: resolve `I18n.locale` from
+      `current_site.get_languages` with the availability-guarded `?locale=` override; keep the
+      frontend-session separation comment accurate.
+- [x] 1.3 Spec file green; `bin/rubocop` clean on touched files; commit M15.
+
+## 2. M17 — case-insensitive same-host return_to (commit 2)
+
+- [x] 2.1 Extend `spec/requests/security/open_redirect_session_spec.rb`: mixed-case same-host
+      `return_to` is followed on login-when-signed-in, the post-login cookie, and logout (red on
+      the unfixed helper — currently falls back); cross-host still falls back (existing
+      negatives stay green).
+- [x] 2.2 `SessionHelper#safe_redirect_url`: `casecmp?` host comparison; state the same-host-only
+      (no multisite cross-site) contract in the method comment.
+- [x] 2.3 Spec file green; `bin/rubocop` clean on touched files; commit M17.
+
+## 3. M14 — non-scalar user_id degrades to the route target (commit 3)
+
+- [x] 3.1 Extend `spec/requests/admin/users_controller/member_route_target_resolution_spec.rb`:
+      admin `PATCH /admin/users/A?user_id[]=B` updates A with no server error (red: 500 via
+      `find(Array)`); non-admin self-edit with `?user_id[]=` succeeds on the path target (red:
+      wrongly denied today); scalar-injection scenarios stay green.
+- [x] 3.2 `UsersController#user_id_param`: only a scalar (String) `params[:user_id]`
+      participates; otherwise resolve from `params[:id]`.
+- [x] 3.3 Spec file green; `bin/rubocop` clean on touched files; commit M14.
+
+## 4. Verification and CI parity
+
+- [x] 4.1 Full `bin/rspec` suite green.
+- [x] 4.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 5. OpenSpec + PR protocol
+
+- [x] 5.1 `openspec validate fix-session-locale-and-redirects --strict` passes; archive the
+      change on-branch, syncing the two new capabilities and the `user-target-resolution`
+      amendment; commit the archived change (no `[skip ci]` — it heads the first push).
+- [x] 5.2 Push branch, open the PR (What and Why + User-Visible Impact; no files-changed/test
+      counts/logs/SHAs), first push runs CI.
+- [x] 5.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push; record
+      the `cama_site_check_existence` triage outcome for follow-up.

--- a/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/tasks.md
+++ b/openspec/changes/archive/2026-08-08-fix-session-locale-and-redirects/tasks.md
@@ -44,3 +44,15 @@
       counts/logs/SHAs), first push runs CI.
 - [x] 5.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push; record
       the `cama_site_check_existence` triage outcome for follow-up.
+
+## 6. Post-review hardening (same branch, after archive)
+
+- [x] 6.1 Admin: scalar guard for `?locale=` in `set_login_locale` (red-first spec in
+      `sessions_locale_spec.rb`); non-scalar scenario added to `admin-login-locale`.
+- [x] 6.2 Frontend: scalar guards for `?locale=` / `?cama_set_language=` in `init_frontent`
+      (red-first specs in new `spec/requests/frontend_locale_spec.rb`).
+- [x] 6.3 Frontend: register theme lookup prefixes before the locale availability gate and
+      reset the rejected locale, so unoffered locales render the site's 404 instead of a
+      `MissingTemplate` 500 (red-first spec); `frontend-locale-resolution` capability added.
+- [x] 6.4 Full gauntlet re-run (rspec, rubocop, brakeman, zeitwerk); changelog entry extended;
+      PR description updated.

--- a/openspec/specs/admin-login-locale/spec.md
+++ b/openspec/specs/admin-login-locale/spec.md
@@ -1,0 +1,52 @@
+# admin-login-locale Specification
+
+## Purpose
+Localize the pre-authentication admin session pages (login, register, forgot-password) from the
+site's configured languages, honoring an explicit `?locale=` request only when the site offers it.
+## Requirements
+### Requirement: Session pages localize from the site's languages
+
+The admin session pages rendered before authentication (login, register, forgot-password) SHALL
+resolve `I18n.locale` from the current site's configured languages: the site's first configured
+language by default. Sites whose first language is not the host application's default locale MUST
+NOT render these pages in the host default.
+
+#### Scenario: Non-English site renders its own language
+
+- **WHEN** a site's configured languages are `[es, en]` and a visitor opens `/admin/login`
+- **THEN** the page renders with Spanish translations
+
+#### Scenario: Site without configured languages uses the host default
+
+- **WHEN** a site has no stored language configuration
+- **THEN** the session pages render in the host application's default locale
+
+### Requirement: Explicit locale requests are availability-guarded
+
+A `?locale=` query parameter SHALL select the page locale only when the site's configured
+languages include that locale. Unknown, unoffered, or malformed values SHALL fall back to the
+default resolution silently — the request MUST NOT raise (`I18n::InvalidLocale`) or produce a
+server error.
+
+#### Scenario: Offered locale is honored
+
+- **WHEN** a site's configured languages are `[es, en]` and a visitor opens `/admin/login?locale=en`
+- **THEN** the page renders with English translations
+
+#### Scenario: Unoffered locale falls back
+
+- **WHEN** a site's configured languages are `[es]` and a visitor opens `/admin/login?locale=de`
+- **THEN** the page renders with Spanish translations
+- **AND** the response is not a server error
+
+### Requirement: Frontend language choice stays out of admin session pages
+
+The frontend visitor language stored in `session[:cama_current_language]` SHALL NOT influence the
+admin session pages' locale.
+
+#### Scenario: Frontend session language does not leak
+
+- **WHEN** a visitor's frontend session carries a language different from the site's first
+  configured language and the visitor opens `/admin/login` without a `?locale=` parameter
+- **THEN** the page renders in the site's first configured language
+

--- a/openspec/specs/admin-login-locale/spec.md
+++ b/openspec/specs/admin-login-locale/spec.md
@@ -39,6 +39,12 @@ server error.
 - **THEN** the page renders with Spanish translations
 - **AND** the response is not a server error
 
+#### Scenario: Non-scalar locale parameter falls back
+
+- **WHEN** a visitor opens `/admin/login?locale[]=en` (or any other non-scalar `locale` value)
+- **THEN** the page renders in the site's first configured language
+- **AND** the response is not a server error
+
 ### Requirement: Frontend language choice stays out of admin session pages
 
 The frontend visitor language stored in `session[:cama_current_language]` SHALL NOT influence the

--- a/openspec/specs/frontend-locale-resolution/spec.md
+++ b/openspec/specs/frontend-locale-resolution/spec.md
@@ -1,0 +1,48 @@
+# frontend-locale-resolution Specification
+
+## Purpose
+Define how the frontend resolves the request locale — from the `?locale=` parameter, the
+visitor's session language, and the site's configured languages — and what happens when a
+request names a locale the site does not offer.
+
+## Requirements
+
+### Requirement: The frontend resolves its locale through a scalar-only fallback chain
+
+The frontend SHALL resolve `I18n.locale` in order: a scalar `?locale=` parameter, the visitor's
+session language (stored from a scalar `?cama_set_language=` parameter), then the site's first
+configured language. Only scalar values SHALL participate: a non-scalar `locale` or
+`cama_set_language` parameter (an array or hash, e.g. `?locale[]=`) SHALL be ignored in favor of
+the rest of the chain and MUST NOT produce a server error. A session language the site does not
+offer SHALL be dropped from the chain.
+
+#### Scenario: Non-scalar locale parameter is ignored
+
+- **WHEN** a visitor opens `/?locale[]=en`
+- **THEN** the page renders with the locale resolved from the rest of the chain
+- **AND** the response is not a server error
+
+#### Scenario: Non-scalar language-switch parameter is ignored
+
+- **WHEN** a visitor opens `/?cama_set_language[]=en`
+- **THEN** the page renders with the locale resolved from the rest of the chain
+- **AND** the response is not a server error
+
+#### Scenario: Offered scalar locale is honored
+
+- **WHEN** a site's configured languages include `en` and a visitor opens `/?locale=en`
+- **THEN** the page renders in English
+
+### Requirement: Unoffered locales produce the site's 404 page
+
+When the resolved locale is not among the site's configured languages, the frontend SHALL
+respond `404 Not Found` with the site's own error page — the standard 404 template or the
+site's configured custom `error_404` post — rendered through the active theme. The rejected
+locale SHALL NOT style the error page or leak into its links: the page SHALL render in the
+site's first configured language. The response MUST NOT be a server error.
+
+#### Scenario: Unoffered scalar locale renders the site 404
+
+- **WHEN** a site's configured languages are `[en]` and a visitor opens `/?locale=de`
+- **THEN** the response is `404 Not Found`
+- **AND** the body is the site's 404 page rendered in English

--- a/openspec/specs/session-return-redirects/spec.md
+++ b/openspec/specs/session-return-redirects/spec.md
@@ -1,0 +1,58 @@
+# session-return-redirects Specification
+
+## Purpose
+Define the `return_to` redirect policy for the admin session flows — which caller-supplied
+destinations are followed and which fall back to the safe default — closing open redirects
+without dropping legitimate same-host destinations.
+## Requirements
+### Requirement: return_to redirects are same-host with case-insensitive comparison
+
+A caller-supplied `return_to` destination SHALL be followed only when it is relative (no host) or
+absolute on the requesting host, and the host comparison SHALL be case-insensitive (host names
+are case-insensitive per RFC 3986). A followed absolute destination SHALL be emitted with the
+host in the request's canonical case, so the framework's own case-sensitive open-redirect
+protection (`action_on_open_redirect`) stays active and never trips on a legitimate destination.
+Cross-host and unparsable destinations SHALL be dropped in favor of the flow's safe default
+path — never an error, never an off-host redirect. Cross-site destinations on multisite installs
+are deliberately unsupported by this policy; supporting sibling sites would be a separate
+security change.
+
+The policy SHALL apply uniformly to every session flow that consumes `return_to`: visiting the
+login page while already signed in, the post-login `return_to` cookie, and logout.
+
+#### Scenario: Mixed-case same-host destination is followed
+
+- **WHEN** a signed-in user opens `/admin/login?return_to=` naming the requesting host in a
+  different letter case (e.g. `http://WWW.EXAMPLE.COM/admin/posts`)
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case
+
+#### Scenario: Relative destination is followed
+
+- **WHEN** a session flow consumes a `return_to` that is a relative path
+- **THEN** the response redirects to that path
+
+#### Scenario: Cross-host destination falls back
+
+- **WHEN** a session flow consumes a `return_to` naming a different host
+- **THEN** the response redirects to the flow's safe default path
+
+#### Scenario: Unparsable destination falls back
+
+- **WHEN** a session flow consumes a `return_to` that is not a parsable URI
+- **THEN** the response redirects to the flow's safe default path
+
+#### Scenario: Post-login cookie honors a mixed-case same-host destination
+
+- **WHEN** a user logs in with a `return_to` cookie naming the requesting host in a different
+  letter case
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case
+
+#### Scenario: Logout honors a mixed-case same-host destination
+
+- **WHEN** a signed-in user logs out with `?return_to=` naming the requesting host in a
+  different letter case
+- **THEN** the response redirects to that destination with the host in the request's canonical
+  case after the session is closed
+

--- a/openspec/specs/user-target-resolution/spec.md
+++ b/openspec/specs/user-target-resolution/spec.md
@@ -3,9 +3,7 @@
 Define how `CamaleonCms::Admin::UsersController` resolves the target user for every action guarded by `validate_role`, and require that the record authorized is always the record acted upon. Covers both route families the controller exposes: the nested route (`PATCH /admin/users/:user_id/updated_ajax`) and the member routes (`/admin/users/:id` for `show`/`edit`/`update`/`destroy`/`impersonate`).
 
 `GET /admin/profile` is exempt from `validate_role` and is governed by the `profile-authorization` capability instead.
-
 ## Requirements
-
 ### Requirement: Target user resolution is canonical across authorization and mutation
 
 Every action in `CamaleonCms::Admin::UsersController` guarded by the `validate_role` filter SHALL resolve its target user through a single canonical parameter helper, and SHALL authorize and act upon the same resolved user.
@@ -42,7 +40,7 @@ Coverage note: the two nested-route scenarios below are satisfied by `spec/reque
 
 ### Requirement: The canonical helper resolves one ordered parameter chain
 
-The canonical helper SHALL resolve the target user id from `params[:user_id]` first, falling back to `params[:id]`.
+The canonical helper SHALL resolve the target user id from `params[:user_id]` first, falling back to `params[:id]`. Only a **scalar** `user_id` SHALL participate in resolution: when `params[:user_id]` is non-scalar (an array or hash, e.g. `?user_id[]=X`), the helper SHALL ignore it and resolve from `params[:id]`, so a malformed injection can neither crash the action nor change which record the authorization filter and the lookup agree on.
 
 This ordering is deliberate for the nested route `PATCH /admin/users/:user_id/updated_ajax`, where the path segment lands in `params[:user_id]` and is therefore not attacker-controllable, while `params[:id]` is absent from the route and can only arrive by injection. Rails merges path parameters last (`ActionDispatch::Http::Parameters#parameters`), so a path segment always overrides a query-string or body value of the same name.
 
@@ -71,6 +69,19 @@ On the member routes `/admin/users/:id` the ordering inverts which key is author
 - **AND** the session does not switch to user A
 
 Note: this scenario is the one that exercises `impersonate` against target resolution. It uses an admin caller deliberately — an admin holds `can :manage, :all`, so the resolved target alone decides the outcome. A non-admin caller cannot test this, because `cannot :impersonate` denies them whichever user resolves.
+
+#### Scenario: Non-scalar user_id falls back to the path segment
+
+- **WHEN** an admin sends `PATCH /admin/users/<USER_A_ID>?user_id[]=<USER_B_ID>` with `user` attributes
+- **THEN** the system updates user A (the path segment)
+- **AND** user B is unchanged
+- **AND** the response is not a server error
+
+#### Scenario: Non-scalar user_id does not deny a self-edit
+
+- **WHEN** a non-admin sends `PATCH /admin/users/<OWN_ID>?user_id[]=<OTHER_ID>` with `user` attributes
+- **THEN** the system updates only the caller's own record
+- **AND** the other user is unchanged
 
 ### Requirement: Unresolvable targets are reported in the endpoint's own error format
 
@@ -130,3 +141,4 @@ This requirement states the security outcome independently of the mechanism that
 - **AND** the caller's session is not switched to the admin
 
 Note on what enforces this scenario: denial here comes from `cannot :impersonate` in `CamaleonCms::Ability`, which rejects a non-admin caller whichever user the request resolves to. The scenario therefore holds even if target resolution were to regress — it is defense in depth for the outcome, not a test of the resolution mechanism. The resolution behavior of `impersonate` is exercised by the admin-caller scenario under the precedence requirement above. Both are kept deliberately: this one pins the outcome a reader of this requirement cares about, that one pins the mechanism.
+

--- a/spec/requests/admin/sessions_locale_spec.rb
+++ b/spec/requests/admin/sessions_locale_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin login page locale', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:spanish_log_in) { I18n.t('camaleon_cms.admin.button.log_in', locale: :es) }
+  let(:english_log_in) { I18n.t('camaleon_cms.admin.button.log_in', locale: :en) }
+
+  before do
+    current_site.set_meta('languages_site', %w[es en])
+    I18n.locale = I18n.default_locale
+  end
+
+  after { I18n.locale = I18n.default_locale }
+
+  it 'renders the login page in the site first language' do
+    get '/admin/login'
+
+    expect(response.body).to include(spanish_log_in)
+  end
+
+  it 'honors ?locale= when the site offers it' do
+    get '/admin/login', params: { locale: 'en' }
+
+    expect(response.body).to include(english_log_in)
+    expect(response.body).not_to include(spanish_log_in)
+  end
+
+  it 'falls back without an error when ?locale= is not offered by the site' do
+    current_site.set_meta('languages_site', %w[es])
+
+    get '/admin/login', params: { locale: 'de' }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(spanish_log_in)
+  end
+
+  it 'ignores the frontend session language' do
+    get '/', params: { cama_set_language: 'en' }
+
+    get '/admin/login'
+
+    expect(response.body).to include(spanish_log_in)
+  end
+end

--- a/spec/requests/admin/sessions_locale_spec.rb
+++ b/spec/requests/admin/sessions_locale_spec.rb
@@ -38,6 +38,13 @@ RSpec.describe 'Admin login page locale', type: :request do
     expect(response.body).to include(spanish_log_in)
   end
 
+  it 'ignores a non-scalar ?locale= instead of erroring' do
+    get '/admin/login', params: { locale: ['en'] }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include(spanish_log_in)
+  end
+
   it 'ignores the frontend session language' do
     get '/', params: { cama_set_language: 'en' }
 

--- a/spec/requests/admin/users_controller/member_route_target_resolution_spec.rb
+++ b/spec/requests/admin/users_controller/member_route_target_resolution_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe 'member route target resolution', type: :request do
     end
   end
 
+  context 'when the injected user_id is not a scalar' do
+    it 'updates the user named in the path with no server error' do
+      post cama_admin_login_path, params: { user: { username: admin_user.username, password: 'admin_secret' } }
+
+      patch "/admin/users/#{victim.id}?user_id[]=#{attacker.id}", params: { user: { first_name: 'ByAdmin' } }
+
+      expect(victim.reload.first_name).to eq('ByAdmin')
+      expect(attacker.reload.first_name).to eq('Attacker')
+    end
+
+    it 'resolves a self-edit to the path target instead of denying it' do
+      patch "/admin/users/#{attacker.id}?user_id[]=#{victim.id}", params: { user: { first_name: 'SelfEdit' } }
+
+      expect(attacker.reload.first_name).to eq('SelfEdit')
+      expect(victim.reload.first_name).to eq('Original')
+    end
+  end
+
   context 'when a low-privilege caller targets another user directly' do
     it 'denies a member-route edit and leaves the target unchanged' do
       patch "/admin/users/#{victim.id}", params: { user: { first_name: 'Pwned' } }

--- a/spec/requests/frontend_locale_spec.rb
+++ b/spec/requests/frontend_locale_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The frontend resolves its locale from ?locale=, the session language (set via
+# ?cama_set_language=), and the site's languages. A non-scalar value for either
+# param must degrade to the fallback chain instead of crashing the request.
+RSpec.describe 'Frontend locale resolution', type: :request do
+  init_site
+
+  before { I18n.locale = I18n.default_locale }
+
+  after { I18n.locale = I18n.default_locale }
+
+  it 'ignores a non-scalar ?locale= instead of erroring' do
+    get '/', params: { locale: ['en'] }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'ignores a non-scalar ?cama_set_language= instead of erroring' do
+    get '/', params: { cama_set_language: ['en'] }
+
+    expect(response).to have_http_status(:ok)
+  end
+
+  it 'still honors a scalar ?locale= the site offers' do
+    get '/', params: { locale: 'en' }
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/frontend_locale_spec.rb
+++ b/spec/requests/frontend_locale_spec.rb
@@ -29,4 +29,11 @@ RSpec.describe 'Frontend locale resolution', type: :request do
 
     expect(response).to have_http_status(:ok)
   end
+
+  it 'rejects an unoffered scalar ?locale= with the site 404 page instead of a server error' do
+    get '/', params: { locale: 'de' }
+
+    expect(response).to have_http_status(:not_found)
+    expect(response.body).to include(I18n.t('camaleon_cms.page_not_exist', locale: :en))
+  end
 end

--- a/spec/requests/security/open_redirect_session_spec.rb
+++ b/spec/requests/security/open_redirect_session_spec.rb
@@ -30,4 +30,39 @@ RSpec.describe 'Security: Open Redirect in SessionHelper', type: :request do
     expect(response.location).not_to include('evil.com')
     expect(response).to redirect_to(cama_admin_login_path)
   end
+
+  describe 'same-host return_to destinations (host compared case-insensitively)' do
+    it 'follows a mixed-case same-host return_to on login while signed in' do
+      post cama_admin_login_path, params: { user: { username: user.username, password: 'password' } }
+      get cama_admin_login_path, params: { return_to: 'http://WWW.EXAMPLE.COM/admin/posts' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq('http://www.example.com/admin/posts')
+    end
+
+    it 'follows a mixed-case same-host return_to cookie after login' do
+      post cama_admin_login_path,
+           params: { user: { username: user.username, password: 'password' } },
+           headers: { 'Cookie' => 'return_to=http://WWW.EXAMPLE.COM/admin/posts' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq('http://www.example.com/admin/posts')
+    end
+
+    it 'follows a mixed-case same-host return_to on logout' do
+      post cama_admin_login_path, params: { user: { username: user.username, password: 'password' } }
+      get cama_admin_logout_path, params: { return_to: 'http://WWW.EXAMPLE.COM/admin/login' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to eq('http://www.example.com/admin/login')
+    end
+
+    it 'follows a relative return_to' do
+      post cama_admin_login_path, params: { user: { username: user.username, password: 'password' } }
+      get cama_admin_login_path, params: { return_to: '/admin/posts' }
+
+      expect(response).to have_http_status(:found)
+      expect(response.location).to end_with('/admin/posts')
+    end
+  end
 end


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` (findings M15, M17, M14) confirmed three session-adjacent
regressions, fixed here one commit each:

- **Admin login-page locale (M15).** #1166 removed the locale resolution from the session pages
  while deliberately severing the frontend `session[:cama_current_language]` from admin context,
  and the follow-up revert never restored it: login, register, and forgot-password rendered in
  the host default locale on non-English sites, and `?locale=` was ignored. These
  pre-authentication pages now resolve `I18n.locale` from the site's configured languages, with
  `?locale=` honored only when the site offers that locale — an unknown value falls back silently
  instead of raising `I18n::InvalidLocale`. The frontend session language stays uninvolved,
  preserving #1166's separation.
- **Case-insensitive same-host `return_to` (M17).** #1168's `safe_redirect_url` compared hosts
  case-sensitively, dropping same-host destinations in different letter case to the fallback on
  all three call sites (login-while-signed-in, post-login cookie, logout). Hosts compare
  case-insensitively now, and the validated URL is emitted with the host in the request's
  canonical case — necessary because Rails 8.1's own open-redirect guard
  (`action_on_open_redirect = :raise`) is also case-sensitive, so passing the mixed-case URL
  through unchanged would have traded the silent fallback for an `OpenRedirectError` 500.
  Cross-host destinations still fall back: cross-site `return_to` on multisite remains
  deliberately unsupported (a sibling-site allowlist would be its own security change).
- **Non-scalar `user_id` (M14).** #1214 made `params[:user_id]` authoritative in the users
  controller's canonical target resolution, but `?user_id[]=X` slipped through: it wrongly denied
  self-edits naming the caller in the path, and crashed with a 500 for callers holding user
  management rights (`find(Array)` returns an Array the action can't use). Only a scalar
  `user_id` participates now; anything else falls back to the route `:id`. The #1214 scalar
  precedence is unchanged.

### Post-review hardening (same branch)

Code review of these fixes surfaced three adjacent locale-parameter defects, fixed here as well:

- **Non-scalar `?locale=` on the admin session pages.** The M15 resolver symbolized the raw
  parameter, so `?locale[]=` crashed the pre-authentication pages with a 500 — the same
  malformed-input class M14 guards, and a violation of this PR's own "malformed values fall
  back silently" contract. Only a scalar `?locale=` participates now.
- **Non-scalar `?locale=` / `?cama_set_language=` on the frontend.** The frontend locale
  resolution had the same unguarded symbolization (pre-existing on master), crashing any
  frontend page with a 500. Non-scalar values now degrade to the normal fallback chain
  (session language, then the site's first language).
- **Unoffered `?locale=` on the frontend answered with a 500 instead of a 404.** The locale
  availability gate rendered the error page before the theme's view lookup was registered
  (pre-existing on master), raising `ActionView::MissingTemplate` for e.g. `?locale=de` on an
  English-only site — and a site's custom 404 post would have hit the same wall. The gate now
  fires after theme registration and renders the site's own 404 page in the site's first
  language, without leaking the rejected locale into the page's links.

The `admin-login-locale` and `session-return-redirects` capabilities are new; the non-scalar rule
is amended into `user-target-resolution`; the post-review work adds `frontend-locale-resolution`
and the non-scalar scenario to `admin-login-locale`. All archived on the branch.

Also triaged (no code change): `camaleon_website` disables `raise_on_open_redirects` with a TODO
naming `cama_site_check_existence`. The method's only cross-host redirect has passed
`allow_other_host: true` since before 2.9.2, so the workaround looks stale for the named method;
whether the flag can be re-enabled needs an engine-wide review of `the_url`-derived redirects on
multisite — spun off as a follow-up rather than folded in here.

## User-Visible Impact

Non-English sites get localized login/register/forgot-password pages again (with a working,
validated `?locale=` switch), same-host `return_to` destinations are followed regardless of host
letter case (emitted with the canonical host), and malformed `?user_id[]=` requests neither crash
admin user pages nor block legitimate self-edits. Malformed `?locale[]=` and
`?cama_set_language[]=` values no longer crash the admin session pages or the frontend, and a
`?locale=` naming a language the site does not offer returns the site's themed 404 page instead
of a server error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
