### PR TITLE
Model API restorations: find_by_key alias, unassign_category, nav ordering, removal docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Removed:** The `ActiveRecordExtras` mixin and with it the `update_or_create`,
+  `update_or_create!`, and `assign_or_new` model methods, formerly available on every Camaleon
+  model. External code that called them should use the Rails idiom instead:
+  `Model.find_or_initialize_by(lookup_attrs).tap { |r| r.assign_attributes(extra_attrs); r.save }`
+  (or `save!`). The 2026-08 ecosystem sweep found no plugin, theme, or host app calling these
+  methods; this note exists because the removal was previously undocumented. Regression audit M4.
+
 - **Fix:** Three session-adjacent regressions: the admin login/register/forgot-password pages
   render in the site's language again (with `?locale=` honored when the site offers it, falling
   back silently otherwise); same-host `return_to` destinations are followed regardless of host

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,15 +160,16 @@
 
 - **Fix:** Slug-uniqueness validation was silently inert on Rails 7.0+. `UniqValidator` and
   `PostUniqValidator` registered errors by pushing onto `errors[:base]`, which modern Rails
-  discards, so duplicate slugs (same taxonomy and parent) and recursive page hierarchies saved
-  without complaint; on Rails 6.1 the old pattern still worked. Errors are registered with
+  discards, so duplicate slugs and recursive page hierarchies saved without complaint; on
+  Rails 6.1 the old pattern still worked. Errors are registered with
   `errors.add` again. [#1222](https://github.com/owen2345/camaleon-cms/pull/1222).
 
   **Notes for upgraders**
 
-  - On Rails 7.0+, saves that duplicate an existing slug under the same parent and taxonomy, or
-    that create a looping page hierarchy, fail validation again — matching what Rails ≤ 6.1
-    installs always enforced.
+  - On Rails 7.0+, saves that duplicate a post slug already held by any non-draft, non-trashed
+    post of the same site — the scope is site-wide, across post types and parents (this entry
+    originally understated it as "same parent and taxonomy") — or that create a looping page
+    hierarchy, fail validation again, matching what Rails ≤ 6.1 installs always enforced.
   - Records duplicated while the validator was inert are not rewritten; they surface the
     "requires different slug" error the next time they are edited.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Fix:** Three legacy model-API surfaces restored: `Media.find_by_key` (as an alias of
+  `by_key` — the rename left legacy callers raising `NoMethodError`), `Post#unassign_category`
+  (with its category-counter refresh made reliable on posts whose categories association is
+  already loaded), and the default ascending-id ordering on `NavMenu`/`NavMenuItem` (rendered
+  menu order was and stays `term_order`). Also documents the `ActiveRecordExtras` removal (see
+  the entry below) and corrects the [#1222](https://github.com/owen2345/camaleon-cms/pull/1222)
+  claim about slug-uniqueness scope: it is site-wide across post types, now spec-pinned.
+  Regression audit M5/M6/M10/M4/M11.
+  [#1237](https://github.com/owen2345/camaleon-cms/pull/1237).
+
 - **Removed:** The `ActiveRecordExtras` mixin and with it the `update_or_create`,
   `update_or_create!`, and `assign_or_new` model methods, formerly available on every Camaleon
   model. External code that called them should use the Rails idiom instead:

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -32,6 +32,12 @@ module CamaleonCms
       end
     end
 
+    # legacy public name (pre-rename callers); the media table has no `key` column, so
+    # without the alias this falls through to Rails' dynamic finder and raises
+    class << self
+      alias find_by_key by_key
+    end
+
     # return all items of current folder
     def items
       coll = is_public ? site.public_media : site.private_media

--- a/app/models/camaleon_cms/nav_menu.rb
+++ b/app/models/camaleon_cms/nav_menu.rb
@@ -2,6 +2,9 @@ module CamaleonCms
   class NavMenu < CamaleonCms::TermTaxonomy
     normalize_attrs(:description)
 
+    # deterministic external iteration order (2.9.2 parity); render paths reorder(:term_order)
+    default_scope { order(id: :asc) }
+
     alias_attribute :site_id, :parent_id
 
     has_many :children, class_name: 'CamaleonCms::NavMenuItem', foreign_key: :parent_id, dependent: :destroy,

--- a/app/models/camaleon_cms/nav_menu_item.rb
+++ b/app/models/camaleon_cms/nav_menu_item.rb
@@ -6,6 +6,9 @@ module CamaleonCms
     # while scripts and event handlers are stripped, preventing stored XSS from menu managers.
     normalize_attrs(:name, :description)
 
+    # deterministic external iteration order (2.9.2 parity); render paths reorder(:term_order)
+    default_scope { order(id: :asc) }
+
     alias_attribute :site_id, :term_group
     alias_attribute :label, :name
     alias_attribute :url, :description

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -7,8 +7,6 @@ module CamaleonCms
     # attrs: [name, description, slug]
     attr_accessor :site_domain
 
-    # default_scope { where(taxonomy: :site).reorder(term_group: :desc) }
-
     has_many :post_types, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, dependent: :destroy,
                           inverse_of: :site
     has_many :nav_menus, class_name: 'CamaleonCms::NavMenu', foreign_key: :parent_id, dependent: :destroy,

--- a/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
+++ b/app/models/concerns/camaleon_cms/categories_tags_for_posts.rb
@@ -67,6 +67,18 @@ module CamaleonCms
       update_counts('categories')
     end
 
+    # Unassign this post from categories with ids: categories_id
+    # categories_id: (Array) array of category ids to unassign from this post, sample: [1,2,3]
+    def unassign_category(categories_id)
+      categories_id = [categories_id] if categories_id.is_a?(Integer)
+      # a loaded (stale) categories association would hide the removed ids from the
+      # counter refresh below — check_default_category loads it on every save
+      categories.reset
+      rescue_extra_data
+      term_relationships.where(term_taxonomy_id: categories_id).destroy_all
+      update_counts('categories')
+    end
+
     # Update the quantity of posts assigned for tags and categories assigned to this post
     def update_extra_data
       rescue_extra_data

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-08

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/design.md
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/design.md
@@ -1,0 +1,71 @@
+# Design — fix-model-api-restorations
+
+## Context
+
+See `proposal.md` — Why. Everything here is grounded in the 2026-08-05 ecosystem sweep
+(`ecosystem-plugin-bindings` capability, `docs/ai/ecosystem.md`): zero consumers exist for every
+surface in this PR, so each decision is made on core's own merits, and the removals being
+restored are insurance against unpublished external code, not observed breakage.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Restore the three cheap, loud-when-missing surfaces (M5 alias, M6 method, M10 ordering) at
+  2.9.2 parity on today's internals.
+- Make the documentation tell the truth: `ActiveRecordExtras` is gone on purpose (M4), and slug
+  uniqueness is site-wide (M11).
+
+**Non-Goals**
+
+- No `ActiveRecordExtras` code restore — zero consumers, never shipped in a release; the
+  changelog note carries the migration recipe (`find_or_initialize_by` + `assign_attributes`).
+- No `assign_tags`/`unassign_tags` restore — they were already broken at 2.9.2 (called a method
+  that never existed); restoring them would create API that never worked.
+- No Site ordering scope — the audited `term_group DESC` half is vacuous (`term_group` is never
+  written for sites); the commented remnant is deleted, not revived.
+- No change to `PostUniqValidator` behavior — M11 corrects the *claim* and pins the behavior;
+  narrowing the scope to per-post-type would be a product decision with migration implications,
+  out of audit scope.
+
+## Decisions
+
+1. **M5 = singleton alias** (`class << self; alias_method :find_by_key, :by_key; end`) directly
+   under `by_key`. Spec calls carry the `Rails/DynamicFindBy` cop pin, the same pattern #1223
+   used for the restored user finders. Rejected: defining a separate method (drifts), removing
+   the `by_key` name again (breaks #1168-era callers).
+2. **M6 = 2.9.2 body on the current counter API, plus `categories.reset` first.** Same signature
+   and semantics (single id or array, `rescue_extra_data`, relationships destroyed,
+   `update_counts('categories')` — the successor of 2.9.2's `update_counters`). The reset is a
+   deliberate addition: `check_default_category` loads the `categories` association on every
+   save of a category-managing post, and a loaded association makes `rescue_extra_data` and
+   `update_counts` pluck the stale in-memory list — the refresh then never targets the removed
+   category, and `TermRelationship`'s `before_destroy` counter callback recounts while the row
+   still exists, so nothing else corrects it (verbatim 2.9.2 had the same latent quirk). Without
+   the reset the restored method would violate its own counter contract in the default flow.
+   `assign_category` is left untouched — its counters are corrected by the relationship's
+   `after_create` callback, and touching it is out of this PR's scope.
+3. **M10 = order-only default scopes.** 2.9.2's scopes also carried `where(taxonomy: …)`, which
+   STI now supplies; only the ordering half is missing. All five render paths use
+   `reorder(:term_order)` (#1194), which replaces the default order — verified by grep and by the
+   existing menu specs staying green.
+4. **Repro-first where the failure is loud** (M5/M6 raise `NoMethodError` red). For M10 a
+   behavioral shuffle test would be vacuously green — SQLite returns insertion order for
+   unordered selects — so the spec asserts the generated SQL carries the ascending-id ORDER BY
+   (red on master, where the relation has no order), which is the actual contract external
+   iterators depend on. For M11 the spec pins existing behavior (the finding is a documentation
+   defect), so red-first does not apply; the cross-post-type example is the coverage that was
+   missing.
+
+## Risks / Trade-offs
+
+- [Default scopes are global: any query on NavMenu/NavMenuItem gains ORDER BY id] → exactly the
+  2.9.2 shape; render paths `reorder`; `count`/`update_columns` sites are order-insensitive; the
+  full suite guards the rest.
+- [`find_by_key` name triggers the `Rails/DynamicFindBy` cop at call sites] → callers pin it,
+  as #1223 established; core itself keeps calling `by_key`.
+
+## Migration Plan
+
+Code-only, additive; no data changes. Deploy normally; rollback = revert the commits. The M4
+changelog note is the migration guidance for external `update_or_create` callers.

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/proposal.md
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/proposal.md
@@ -1,0 +1,58 @@
+## Why
+
+The 2026-08 regression audit batched five model-API findings as PR 4. The 2026-08-05 ecosystem
+sweep (all 22 public plugin/theme/host repos) found **zero consumers** for every surface here, so
+these restorations are cheap insurance on core's own merits rather than live-break fixes — while
+two changelog claims need correcting because they misstate what shipped:
+
+- **M5** — `Media.find_by_key` was renamed `by_key` (#1168's `Rails/DynamicFindBy` sweep). An
+  external caller now hits Rails' dynamic finder against a `key` column that does not exist — a
+  loud `NoMethodError` where a working relation used to return.
+- **M6** — `unassign_category` (a working public API at 2.9.2) was removed together with the
+  genuinely broken `assign_tags`/`unassign_tags` pair; `assign_category` survived.
+- **M10** — NavMenu/NavMenuItem lost their `order(id: :asc)` default scopes: external iteration
+  order is now DB-arbitrary. (The Site half of the audited finding is vacuous — `term_group` is
+  never written for sites — so Site keeps no scope; its commented-out remnant is deleted.)
+- **M4** — the `ActiveRecordExtras` module (`update_or_create`, `update_or_create!`,
+  `assign_or_new`) was removed. Zero consumers exist; master has never shipped it in a release.
+  Disposition: **document as removed** with a migration note — no code restore.
+- **M11** — the #1222 changelog says slug uniqueness applies "under the same parent and
+  taxonomy", but `PostUniqValidator` queries `ptype.site.posts` — **site-wide across post
+  types**. A slug held by a Page blocks a Product of the same site. The claim is corrected and
+  the missing cross-post-type spec added; the behavior itself is unchanged.
+
+## What Changes
+
+- `Media.find_by_key` returns as an alias of `by_key` (same relation contract).
+- `CategoriesTagsForPosts#unassign_category` is restored on the current `update_counts`
+  counter API.
+- `NavMenu` and `NavMenuItem` regain `default_scope { order(id: :asc) }`; all five render paths
+  keep winning via `reorder(:term_order)` (#1194). Site's commented-out scope remnant is deleted.
+- CHANGELOG documents the `ActiveRecordExtras` removal with a migration note (M4) and corrects
+  the #1222 scope claim (M11).
+- New spec coverage: alias contract, unassign flow with counter updates, default-order SQL shape,
+  and the cross-post-type slug collision.
+
+## Capabilities
+
+### New Capabilities
+
+- `model-api-compatibility`: the restored legacy model surfaces — `Media.find_by_key` alias,
+  `unassign_category` with counter maintenance, and default navigation enumeration order (with
+  the render-path `term_order` precedence).
+- `post-slug-uniqueness`: the actual slug-uniqueness contract — site-wide across post types,
+  drafts excluded — so the scope can never again be documented from assumption.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/models/camaleon_cms/media.rb`, `app/models/concerns/camaleon_cms/categories_tags_for_posts.rb`,
+  `app/models/camaleon_cms/nav_menu.rb`, `app/models/camaleon_cms/nav_menu_item.rb`,
+  `app/models/camaleon_cms/site.rb` (comment deletion only), `CHANGELOG.md`.
+- Specs: new `spec/models/model_api_compatibility_spec.rb`; extension to
+  `spec/validators/post_uniq_validator_spec.rb`.
+- No routes, controllers, views, or data changes. Behavior deltas: two restored methods,
+  deterministic default nav ordering (render output unchanged), corrected documentation.

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/specs/model-api-compatibility/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/specs/model-api-compatibility/spec.md
@@ -1,0 +1,49 @@
+## Purpose
+
+Pin the legacy model-API surfaces external plugins and host apps were written against — media
+lookup by key, category unassignment, and default navigation enumeration order — so style sweeps
+and refactors cannot silently remove them again.
+
+## ADDED Requirements
+
+### Requirement: Media lookup by key keeps its legacy name
+
+`CamaleonCms::Media.find_by_key` SHALL remain available as an alias of `by_key`, returning the
+same relation for the same key (including through association scopes such as a site's media).
+It MUST NOT fall through to Rails' dynamic finder (the media table has no `key` column, so the
+fallthrough is a `NoMethodError`).
+
+#### Scenario: Legacy and current name return the same relation
+
+- **WHEN** code calls `site.public_media.find_by_key('/folder/file.png')`
+- **THEN** the call returns the same records as `by_key` for that key
+- **AND** no error is raised
+
+### Requirement: Posts can be unassigned from categories
+
+`unassign_category(categories_id)` SHALL remove the post's relationships to the given category
+id(s) — accepting a single id or an array — and SHALL refresh the affected categories' post
+counters, mirroring `assign_category`'s counter maintenance.
+
+#### Scenario: Unassigning one of two categories
+
+- **WHEN** a post assigned to categories A and B calls `unassign_category(A.id)`
+- **THEN** the post remains assigned only to category B
+- **AND** category A's post counter reflects the removal
+
+### Requirement: Navigation menus enumerate in creation order by default
+
+`NavMenu` and `NavMenuItem` relations SHALL carry a default ascending-id order, so external
+iteration over menus and items is deterministic (2.9.2 parity). The admin and frontend render
+paths SHALL keep ordering by the drag-configured `term_order` (they `reorder`, which overrides
+the default).
+
+#### Scenario: Default relations are id-ordered
+
+- **WHEN** code enumerates `NavMenu` or `NavMenuItem` records without an explicit order
+- **THEN** the generated query orders by ascending id
+
+#### Scenario: Render paths keep term_order
+
+- **WHEN** the admin menu builder or the frontend menu helper renders menu items
+- **THEN** items appear in `term_order`, unaffected by the default scope

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/specs/post-slug-uniqueness/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/specs/post-slug-uniqueness/spec.md
@@ -1,0 +1,30 @@
+## Purpose
+
+State the actual scope of post slug uniqueness so documentation and upgrade notes describe what
+the validator enforces rather than what a changelog assumed.
+
+## ADDED Requirements
+
+### Requirement: Post slug uniqueness is site-wide across post types
+
+`PostUniqValidator` SHALL reject a slug that any non-draft, non-trashed post of the **same site**
+already holds — regardless of post type or parent. Drafts and draft children SHALL be exempt
+(both as the record being validated and as blocking records). Multilingual slugs SHALL collide
+per language through their translation markers.
+
+#### Scenario: Cross-post-type duplicate is refused
+
+- **WHEN** a published post of post type A holds slug `s` and a post of post type B in the same
+  site validates with slug `s`
+- **THEN** validation fails with the requires-different-slug error
+
+#### Scenario: Same-post-type duplicate is refused
+
+- **WHEN** a published post holds slug `s` and another post of the same post type validates with
+  slug `s`
+- **THEN** validation fails with the requires-different-slug error
+
+#### Scenario: Drafts do not participate
+
+- **WHEN** the record being validated is a draft
+- **THEN** validation is skipped entirely

--- a/openspec/changes/archive/2026-08-09-fix-model-api-restorations/tasks.md
+++ b/openspec/changes/archive/2026-08-09-fix-model-api-restorations/tasks.md
@@ -1,0 +1,50 @@
+## 1. M5 — Media.find_by_key alias (commit 1)
+
+- [x] 1.1 Spec in new `spec/models/model_api_compatibility_spec.rb`: `find_by_key` returns the
+      same records as `by_key` through a site's media scope (red: `NoMethodError` on the unfixed
+      model); call sites carry the `Rails/DynamicFindBy` pin.
+- [x] 1.2 Singleton alias in `media.rb` under `by_key`.
+- [x] 1.3 Spec green; rubocop clean on touched files; commit M5.
+
+## 2. M6 — unassign_category (commit 2)
+
+- [x] 2.1 Spec: post assigned to two categories, `unassign_category` with a single id leaves the
+      other assignment and refreshes the removed category's counter (red: `NoMethodError`).
+- [x] 2.2 Restore the 2.9.2 body on `update_counts('categories')` in
+      `categories_tags_for_posts.rb`, mirroring `assign_category`'s style.
+- [x] 2.3 Spec green; rubocop clean; commit M6.
+
+## 3. M10 — nav default ordering (commit 3)
+
+- [x] 3.1 Spec: `NavMenu.all` / `NavMenuItem.all` SQL carries the ascending-id ORDER BY (red on
+      master: no order); existing menu render specs stay green (`reorder(:term_order)` wins).
+- [x] 3.2 `default_scope { order(id: :asc) }` on both models; delete Site's commented-out scope
+      remnant.
+- [x] 3.3 Specs green; rubocop clean; commit M10.
+
+## 4. M4 — document ActiveRecordExtras as removed (commit 4, docs-only, [skip ci])
+
+- [x] 4.1 CHANGELOG Unreleased: removal note for `update_or_create`/`update_or_create!`/
+      `assign_or_new` with the `find_or_initialize_by` migration recipe.
+
+## 5. M11 — slug-uniqueness scope truth (commit 5)
+
+- [x] 5.1 Extend `spec/validators/post_uniq_validator_spec.rb` with the cross-post-type
+      collision example (pins existing behavior — red-first N/A, documentation defect).
+- [x] 5.2 Amend the #1222 changelog entry: "same taxonomy and parent" → site-wide across post
+      types.
+
+## 6. Verification and CI parity
+
+- [x] 6.1 Full `bin/rspec` suite green.
+- [x] 6.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 7. OpenSpec + PR protocol
+
+- [x] 7.1 `openspec validate fix-model-api-restorations --strict` passes; archive on-branch
+      (syncs `model-api-compatibility` + `post-slug-uniqueness`); commit the archived change
+      (no `[skip ci]` — it heads the first push).
+- [x] 7.2 Push, open the PR (What and Why + User-Visible Impact; protocol constraints), first
+      push runs CI.
+- [x] 7.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/model-api-compatibility/spec.md
+++ b/openspec/specs/model-api-compatibility/spec.md
@@ -1,0 +1,49 @@
+# model-api-compatibility Specification
+
+## Purpose
+Pin the legacy model-API surfaces external plugins and host apps were written against — media
+lookup by key, category unassignment, and default navigation enumeration order — so style sweeps
+and refactors cannot silently remove them again.
+## Requirements
+### Requirement: Media lookup by key keeps its legacy name
+
+`CamaleonCms::Media.find_by_key` SHALL remain available as an alias of `by_key`, returning the
+same relation for the same key (including through association scopes such as a site's media).
+It MUST NOT fall through to Rails' dynamic finder (the media table has no `key` column, so the
+fallthrough is a `NoMethodError`).
+
+#### Scenario: Legacy and current name return the same relation
+
+- **WHEN** code calls `site.public_media.find_by_key('/folder/file.png')`
+- **THEN** the call returns the same records as `by_key` for that key
+- **AND** no error is raised
+
+### Requirement: Posts can be unassigned from categories
+
+`unassign_category(categories_id)` SHALL remove the post's relationships to the given category
+id(s) — accepting a single id or an array — and SHALL refresh the affected categories' post
+counters, mirroring `assign_category`'s counter maintenance.
+
+#### Scenario: Unassigning one of two categories
+
+- **WHEN** a post assigned to categories A and B calls `unassign_category(A.id)`
+- **THEN** the post remains assigned only to category B
+- **AND** category A's post counter reflects the removal
+
+### Requirement: Navigation menus enumerate in creation order by default
+
+`NavMenu` and `NavMenuItem` relations SHALL carry a default ascending-id order, so external
+iteration over menus and items is deterministic (2.9.2 parity). The admin and frontend render
+paths SHALL keep ordering by the drag-configured `term_order` (they `reorder`, which overrides
+the default).
+
+#### Scenario: Default relations are id-ordered
+
+- **WHEN** code enumerates `NavMenu` or `NavMenuItem` records without an explicit order
+- **THEN** the generated query orders by ascending id
+
+#### Scenario: Render paths keep term_order
+
+- **WHEN** the admin menu builder or the frontend menu helper renders menu items
+- **THEN** items appear in `term_order`, unaffected by the default scope
+

--- a/openspec/specs/post-slug-uniqueness/spec.md
+++ b/openspec/specs/post-slug-uniqueness/spec.md
@@ -1,0 +1,30 @@
+# post-slug-uniqueness Specification
+
+## Purpose
+State the actual scope of post slug uniqueness so documentation and upgrade notes describe what
+the validator enforces rather than what a changelog assumed.
+## Requirements
+### Requirement: Post slug uniqueness is site-wide across post types
+
+`PostUniqValidator` SHALL reject a slug that any non-draft, non-trashed post of the **same site**
+already holds — regardless of post type or parent. Drafts and draft children SHALL be exempt
+(both as the record being validated and as blocking records). Multilingual slugs SHALL collide
+per language through their translation markers.
+
+#### Scenario: Cross-post-type duplicate is refused
+
+- **WHEN** a published post of post type A holds slug `s` and a post of post type B in the same
+  site validates with slug `s`
+- **THEN** validation fails with the requires-different-slug error
+
+#### Scenario: Same-post-type duplicate is refused
+
+- **WHEN** a published post holds slug `s` and another post of the same post type validates with
+  slug `s`
+- **THEN** validation fails with the requires-different-slug error
+
+#### Scenario: Drafts do not participate
+
+- **WHEN** the record being validated is a draft
+- **THEN** validation is skipped entirely
+

--- a/spec/models/model_api_compatibility_spec.rb
+++ b/spec/models/model_api_compatibility_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Model API compatibility', type: :model do
+  init_site
+
+  let(:site) { Cama::Site.first }
+
+  describe 'Media.find_by_key' do
+    let!(:folder) { site.public_media.create!(name: 'compat', folder_path: '/', is_folder: true) }
+
+    it 'returns the same records as by_key' do
+      # rubocop:disable Rails/DynamicFindBy
+      legacy = site.public_media.find_by_key('/compat')
+      # rubocop:enable Rails/DynamicFindBy
+
+      expect(legacy).to eq(site.public_media.by_key('/compat'))
+      expect(legacy).to contain_exactly(folder)
+    end
+  end
+end

--- a/spec/models/model_api_compatibility_spec.rb
+++ b/spec/models/model_api_compatibility_spec.rb
@@ -54,4 +54,17 @@ RSpec.describe 'Model API compatibility', type: :model do
       expect(cat_b.reload.count).to eq(0)
     end
   end
+
+  describe 'navigation default ordering' do
+    # A behavioral shuffle test would be vacuously green (SQLite returns insertion
+    # order for unordered selects); the contract external iterators depend on is the
+    # ORDER BY itself. Render paths override it via reorder(:term_order).
+    it 'orders NavMenu relations by ascending id by default' do
+      expect(CamaleonCms::NavMenu.all.to_sql).to match(/ORDER BY.*id.* ASC/i)
+    end
+
+    it 'orders NavMenuItem relations by ascending id by default' do
+      expect(CamaleonCms::NavMenuItem.all.to_sql).to match(/ORDER BY.*id.* ASC/i)
+    end
+  end
 end

--- a/spec/models/model_api_compatibility_spec.rb
+++ b/spec/models/model_api_compatibility_spec.rb
@@ -19,4 +19,39 @@ RSpec.describe 'Model API compatibility', type: :model do
       expect(legacy).to contain_exactly(folder)
     end
   end
+
+  describe '#unassign_category' do
+    # has_category makes manage_categories? true, so the restored method's counter
+    # refresh actually runs (it also auto-assigns the post type's default category
+    # on save, which the assertions tolerate)
+    let(:post_type) do
+      create(:post_type, slug: 'compat-pt', site: @site).tap { |pt| pt.set_option(:has_category, true) }
+    end
+    let(:cat_a) { post_type.categories.create!(name: 'Cat A', slug: 'compat-cat-a') }
+    let(:cat_b) { post_type.categories.create!(name: 'Cat B', slug: 'compat-cat-b') }
+    let(:post) { create(:post, post_type: post_type, slug: 'compat-post', status: 'published') }
+
+    before { post.assign_category([cat_a.id, cat_b.id]) }
+
+    it 'removes the assignment and refreshes the category counters' do
+      expect(cat_a.reload.count).to eq(1)
+
+      post.unassign_category(cat_a.id)
+
+      remaining = post.categories.reload.pluck(:id)
+      expect(remaining).to include(cat_b.id)
+      expect(remaining).not_to include(cat_a.id)
+      expect(cat_a.reload.count).to eq(0)
+      expect(cat_b.reload.count).to eq(1)
+    end
+
+    it 'accepts an array of ids' do
+      post.unassign_category([cat_a.id, cat_b.id])
+
+      remaining = post.categories.reload.pluck(:id)
+      expect(remaining).not_to include(cat_a.id)
+      expect(remaining).not_to include(cat_b.id)
+      expect(cat_b.reload.count).to eq(0)
+    end
+  end
 end

--- a/spec/validators/post_uniq_validator_spec.rb
+++ b/spec/validators/post_uniq_validator_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe CamaleonCms::PostUniqValidator, type: :model do
       end
     end
 
+    context 'when the slug duplicates a published post of another post type in the same site' do
+      it 'registers a base error (uniqueness is site-wide, not per post type)' do
+        other_type = create(:post_type, slug: 'other-pt', site: @site)
+        create(:post, post_type: other_type, slug: 'shared-slug', status: 'published')
+        duplicate = build(:post, post_type: post_type, slug: 'shared-slug')
+
+        expect(validate_post(duplicate))
+          .to contain_exactly(a_string_matching(I18n.t('camaleon_cms.admin.post.message.requires_different_slug')))
+      end
+    end
+
     context 'when the parent chain loops back to the post' do
       it 'registers a recursive-hierarchy error' do
         post_type.set_option(:has_parent_structure, true)


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` batched five model-API findings as PR 4 (M5, M6, M10, M4,
M11), one commit each. The 2026-08 ecosystem sweep found **zero consumers** for every surface
here, so the restorations are cheap insurance for unpublished external code rather than
live-break fixes — and two changelog claims needed correcting because they misstate what shipped:

- **`Media.find_by_key`** returns as an alias of `by_key`. The `Rails/DynamicFindBy` rename left
  legacy callers falling through to Rails' dynamic finder against a `key` column that does not
  exist — a `NoMethodError` where a working relation used to return.
- **`unassign_category`** is restored (it was removed together with the genuinely broken
  `assign_tags`/`unassign_tags` pair, which stay gone — they never worked). Same 2.9.2 semantics
  on today's counter API, plus one deliberate addition: the categories association is reset
  before capturing state, because `check_default_category` loads it on every save and a stale
  loaded copy silently exempted the removed category from the counter refresh — a latent quirk
  verbatim 2.9.2 also had (the relationship model's `before_destroy` recount runs while the row
  still exists, so nothing else corrects it).
- **NavMenu/NavMenuItem** regain their `order(id: :asc)` default scopes — STI now supplies the
  `taxonomy` predicate the 2.9.2 scopes carried, but nothing supplied the ordering half, leaving
  external iteration DB-arbitrary. All five admin/frontend render paths keep winning via
  `reorder(:term_order)`. Site's commented-out scope remnant is deleted (its `term_group DESC`
  half was vacuous — sites never write `term_group`).
- **`ActiveRecordExtras` is documented as removed** (`update_or_create`, `update_or_create!`,
  `assign_or_new`) with a `find_or_initialize_by` migration recipe — the removal was previously
  undocumented; the module stays gone.
- **The slug-uniqueness scope claim is corrected**: `PostUniqValidator` enforces site-wide
  uniqueness across post types and parents, not the "same parent and taxonomy" the #1222 entry
  claimed. The behavior is unchanged; the missing cross-post-type spec now pins it.

Two new OpenSpec capabilities (`model-api-compatibility`, `post-slug-uniqueness`) are archived on
the branch.

## User-Visible Impact

External plugins and host apps calling the legacy media/category APIs stop crashing, menu
iteration order is deterministic again (rendered menu order is unchanged), and the changelog now
tells upgraders the truth about the removed `update_or_create` family and the site-wide slug
scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
