### PR TITLE
Revert the object_class scope rename, drop the definition delete_all cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Rollback hazard (documentation):** Sidebar widget assignments created on this version are
+  stored with the compact `Widget::Assigned` discriminator. 2.9.2 reads only the full
+  `CamaleonCms::Widget::Assigned` name, so rolling back to 2.9.2 hides every assignment created
+  here (they reappear on re-upgrade — the upgrade direction reads both spellings), and raw SQL
+  filtering on the old value misses rows written here. Regression audit M7.
+
 - **Fix:** Three legacy model-API surfaces restored: `Media.find_by_key` (as an alias of
   `by_key` — the rename left legacy callers raising `NoMethodError`), `Post#unassign_category`
   (with its category-counter refresh made reliable on posts whose categories association is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Fix:** The `object_class` scope naming for metas, custom fields, and field groups returns to
+  the demodulized 2.9.2 contract (`'Main'`, `'User'`), reverting an unreleased rename to
+  prefix-qualified names that stranded every row existing installs had written; the widget admin
+  literals move with it, keeping widget custom-field values saving correctly (broken
+  2.8.x–2.9.2, now spec-pinned end to end). Also removes the bulk-delete cascade on the
+  definition associations: teardown belongs to the placement hook (which destroys groups with
+  callbacks), and on models without that hook the cascade raw-deleted definition rows while
+  orphaning their fields and option metas. Regression audit M9/M8/N4.
+  [#1238](https://github.com/owen2345/camaleon-cms/pull/1238).
+
+  **Notes for upgraders:**
+  - Rows written by unreleased master-tracking installs under the short-lived prefixed scopes
+    (`'Widget::Main'`, `'Admin::User'`) are not migrated; released installs are unaffected.
+
 - **Rollback hazard (documentation):** Sidebar widget assignments created on this version are
   stored with the compact `Widget::Assigned` discriminator. 2.9.2 reads only the full
   `CamaleonCms::Widget::Assigned` name, so rolling back to 2.9.2 hides every assignment created

--- a/app/controllers/camaleon_cms/admin/appearances/widgets/assign_controller.rb
+++ b/app/controllers/camaleon_cms/admin/appearances/widgets/assign_controller.rb
@@ -18,7 +18,7 @@ module CamaleonCms
 
           def update
             if @assigned.update(params.require(:assign).permit(:title, :content, :widget_id, :sidebar_id, :item_order))
-              @assigned.set_field_values(cama_permitted_field_options('Widget::Main'))
+              @assigned.set_field_values(cama_permitted_field_options('Main'))
               flash[:notice] = t('camaleon_cms.admin.widgets.assign.updated')
             else
               flash[:error] = t('camaleon_cms.admin.widgets.assign.error_updated')

--- a/app/models/camaleon_cms/custom_field_group.rb
+++ b/app/models/camaleon_cms/custom_field_group.rb
@@ -137,7 +137,7 @@ module CamaleonCms
           caption = "Fields for Categories in <b>#{site.post_types.find(objectid).decorate.the_title}</b>"
         when 'PostType_PostTag'
           caption = "Fields for Post tags in <b>#{site.post_types.find(objectid).decorate.the_title}</b>"
-        when 'Widget::Main'
+        when 'Main'
           widget_name = CamaleonCms::Widget::Main.find(objectid).name.translate
           caption = "Fields for Widget <b>(#{ERB::Util.html_escape(widget_name)})</b>"
         when 'Theme'

--- a/app/models/concerns/camaleon_cms/common_relationships.rb
+++ b/app/models/concerns/camaleon_cms/common_relationships.rb
@@ -16,13 +16,21 @@ module CamaleonCms
       has_many :custom_field_values, -> { where(object_class: object_class_name) },
                class_name: 'CamaleonCms::CustomFieldsRelationship', foreign_key: :objectid, dependent: :delete_all
 
+      # No dependent: on the definition associations (2.9.2 behavior). Teardown is owned by
+      # CustomFieldsRead#_destroy_custom_field_groups, which runs first and destroys groups WITH
+      # callbacks; a dependent here is inert at best, and on hook-less includers (PostComment) a
+      # delete_all removed group rows while orphaning their fields and option metas. A :destroy
+      # cascade is no alternative: custom_fields matches group rows too (same table, same scope)
+      # but its CustomField typing would skip group teardown.
+      # rubocop:disable Rails/HasManyOrHasOneDependent
       has_many :custom_fields, -> { where(object_class: object_class_name) },
-               class_name: 'CamaleonCms::CustomField', foreign_key: :objectid, dependent: :delete_all
+               class_name: 'CamaleonCms::CustomField', foreign_key: :objectid
 
       # valid only for simple groups and not for complex like: posts, post, ... where the group is for individual or
       # children groups
       has_many :custom_field_groups, -> { where(object_class: object_class_name) },
-               class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid, dependent: :delete_all
+               class_name: 'CamaleonCms::CustomFieldGroup', foreign_key: :objectid
+      # rubocop:enable Rails/HasManyOrHasOneDependent
     end
     # rubocop:enable Rails/InverseOf
   end

--- a/app/models/concerns/camaleon_cms/common_relationships.rb
+++ b/app/models/concerns/camaleon_cms/common_relationships.rb
@@ -6,7 +6,10 @@ module CamaleonCms
     # rubocop:disable Rails/InverseOf
 
     included do
-      object_class_name = name.to_s.delete_prefix('CamaleonCms::')
+      # Scopes use the demodulized class name (the 2.9.2 contract every install's rows were
+      # written under): 'Post', 'Main' for Widget::Main, and 'User' for a host Admin::User.
+      # to_s tolerates anonymous subclasses (STI specs build them), whose name is nil.
+      object_class_name = name.to_s.demodulize
       has_many :metas, -> { where(object_class: object_class_name) },
                class_name: 'CamaleonCms::Meta', foreign_key: :objectid, dependent: :destroy
 

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/design.md
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/design.md
@@ -1,0 +1,87 @@
+# Design — fix-scope-drift-and-cascade
+
+## Context
+
+See `proposal.md` — Why. All findings orbit `common_relationships.rb`, whose `included` block
+derives the `object_class` scope once per including class (`TermTaxonomy` and `PostDefault`
+re-include it per subclass via `inherited`, so every widget class gets its own name).
+Load-bearing facts verified in code and by live execution:
+
+- The 2.8.x–2.9.2 widget custom-fields breakage was a write/read mismatch: the assign
+  controller's allowed-slugs lookup and the group caption said `'Widget::Main'` (both eras)
+  while the association scope said `'Main'` (2.9.2) — submitted values were silently discarded
+  because the allowed-slugs set came back empty. The unreleased rename aligned the concern to
+  the literals; the maintainer-directed revert aligns the literals to the concern.
+- The custom-fields settings form cannot place groups on widgets (that optgroup is commented
+  out), and `owned_placement_ids` has no widget arm — so the assign controller and the caption
+  are the only widget-scope literals in the engine.
+- Group placement scopes disambiguate models by string, not id space (`'Post'` vs
+  `'PostType_Post'`): the audit's feared id collision between a post and its type's groups
+  cannot happen.
+- Teardown on owner destroy is owned by `CustomFieldsRead#_destroy_custom_field_groups`
+  (identical at 2.9.2 and master), which runs before any association dependent and destroys
+  groups **with callbacks**. Live-verified: with the `delete_all` present, a destroyed post's
+  group, fields, option metas, and values were all correctly gone — the hook, not the
+  `delete_all`, did that. The only includer without the hook is `PostComment`.
+- `CustomFieldGroup#destroy` is the complete teardown (`fields` → their option metas and
+  values; the group's own metas). The concern's `custom_fields` association matches group rows
+  too (same table, same scope), typed as `CustomField` — which has no `fields` association, so
+  any `dependent:` through it would skip group teardown.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- One scope-naming contract — demodulized, 2.9.2's — with zero migration surface: every row a
+  released install ever wrote keeps working (M9, M8 resolved by eliminating the rename).
+- Widget custom fields keep working (the rename's one real fix, preserved by aligning the
+  literals), pinned end to end.
+- Owner destroy neither raw-deletes definitions nor orphans their children (N4, corrected).
+- The `Widget::Assigned` rollback hazard is documented (M7).
+
+**Non-Goals**
+
+- No revert of the `post_class` STI discriminator compaction (M7's mechanism): it is guarded by
+  #1194's dual-read and #1224's STI fallback, pinned by the `legacy-widget-assignment-compatibility`
+  capability, and reverting it is a separate decision with H8-adjacent blast radius.
+- No repair task and no compatibility read for rows master-tracking installs wrote under the
+  short-lived prefixed scopes — deliberately abandoned, never released.
+- No `:destroy` cascade on the concern's definition associations (unsafe through the
+  `CustomField`-typed overlap; the hook owns teardown).
+
+## Decisions
+
+1. **Revert the naming, align the literals** (maintainer decision, 2026-08-09): the concern
+   returns to `name.demodulize`; the assign controller's `cama_permitted_field_options` call and
+   `get_caption`'s widget case move from `'Widget::Main'` to `'Main'`. Rejected: the audit
+   plan's origin-test seam plus repair task — both exist only to compensate for an unreleased
+   rename; reverting it deletes the problem instead of managing it.
+2. **The joint gets an end-to-end pin**: a request spec drives the assigned-widget save through
+   the real controller and asserts the value reads back. It is deliberately era-portable —
+   green whenever literal and scope agree, red on any future one-sided rename.
+3. **N4 = drop both `dependent: :delete_all`** (cop-pinned `Rails/HasManyOrHasOneDependent`,
+   the cop that motivated adding them): inert for hook-carrying models, orphan-producing for
+   hook-less ones. The lifecycle capability pins the hook's complete teardown (posts, post
+   types) and the hook-less leave-definitions behavior (comments), so the next cop sweep cannot
+   reintroduce the cascade without tripping specs.
+4. **Repro-first where a defect reproduces**: the demodulize spec's host-model and widget cases
+   were proven red against the prefixed concern earlier in this session (both directions); the
+   hook-less lifecycle example was proven red against the `delete_all` concern (group row
+   deleted). The teardown pins and the round-trip spec are green-by-design guards, stated as
+   such.
+
+## Risks / Trade-offs
+
+- [Master-tracking installs wrote prefixed rows since the rename] → deliberately abandoned;
+  master is unreleased, the changelog states the resolution, and re-keying back is a one-line
+  SQL update an affected tracker could run themselves.
+- [A future contributor "fixes" the caption or assign literal back to the class-derived name] →
+  the round-trip spec and the caption-escaping spec both go red on any one-sided change.
+- [Orphan group rows linger when a hook-less owner is destroyed] → 2.9.2 behavior, restored
+  deliberately; the alternative (raw delete) orphans worse (children without parents).
+
+## Migration Plan
+
+Code-only; no data changes, no rake task. Deploy normally; rollback = revert the commits. The
+M7 changelog note carries the only operator-facing caveat (rollback hides master-written widget
+assignments).

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/proposal.md
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+The 2026-08 regression audit batched the `common_relationships.rb` findings as PR 5 (M9, M8,
+M7-doc, N4). During implementation the maintainer directed a simpler resolution for the naming
+half, and live verification corrected the cascade finding:
+
+- **M9 / M8** — the unreleased scope rename (`name.demodulize` →
+  `name.delete_prefix('CamaleonCms::')`) re-keyed every nested engine scope (`'Main'` →
+  `'Widget::Main'`) and every namespaced host-model scope (`'User'` → `'Admin::User'`). That
+  stranded all rows 2.9.2-era installs ever wrote (M9 for host models, M8 for widget fields) and
+  would have required a compatibility seam plus a repair rake task. **Maintainer decision:
+  revert the rename entirely** — pure churn for an unreleased change — instead of compensating
+  for it.
+- **M7** — new `Widget::Assigned` rows write the compact `post_class` STI discriminator; 2.9.2
+  reads only the full name, so a rollback hides assignments created on master. A separate
+  mechanism from the `object_class` scopes; documented, not code-fixed.
+- **N4** — `41c16a7d` added `dependent: :delete_all` to the concern's `custom_fields` and
+  `custom_field_groups`. Live verification corrected the audited claim: teardown is owned by the
+  placement hook (`CustomFieldsRead#_destroy_custom_field_groups`), which runs first and
+  destroys groups **with callbacks** at both revisions — the `delete_all` was inert for every
+  hook-carrying model. It bit only hook-less includers (`PostComment`), where destroy
+  raw-deleted group rows while orphaning their fields and option metas.
+
+## What Changes
+
+- The `object_class` scopes return to the demodulized 2.9.2 contract, and the widget-side
+  literals move with them (the assign controller's allowed-slugs lookup and the group caption
+  case). This keeps the one real fix the rename carried — widget custom fields were broken
+  2.8.x–2.9.2 exactly because those literals said `'Widget::Main'` while the association scope
+  said `'Main'` — with the joint now aligned the other way and pinned end to end. Rows written
+  under the prefixed names by master-tracking installs are deliberately abandoned (never
+  released). No repair task.
+- Both `dependent: :delete_all` options are removed (cop-pinned): the placement hook keeps
+  owning teardown (now spec-pinned as complete), and hook-less owners return to 2.9.2's
+  leave-definitions behavior.
+- CHANGELOG documents the `Widget::Assigned` rollback hazard (M7).
+
+## Capabilities
+
+### New Capabilities
+
+- `meta-scope-resolution`: the demodulized `object_class` naming contract, including the
+  agreement between the widget admin surfaces and the association scopes.
+- `custom-field-definition-lifecycle`: the placement hook owns complete teardown on owner
+  destroy; hook-less owners do not cascade definitions.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/models/concerns/camaleon_cms/common_relationships.rb`,
+  `app/controllers/camaleon_cms/admin/appearances/widgets/assign_controller.rb`,
+  `app/models/camaleon_cms/custom_field_group.rb` (caption case), `CHANGELOG.md`.
+- Specs: new `spec/models/meta_scope_resolution_spec.rb`,
+  `spec/requests/admin/widget_field_values_spec.rb`,
+  `spec/models/custom_field_definition_lifecycle_spec.rb`; two security-spec fixtures follow the
+  scope naming.
+- No routes or schema changes; no rake task. Master-tracking installs lose rows written under
+  the short-lived prefixed scopes (accepted — unreleased).

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/specs/custom-field-definition-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/specs/custom-field-definition-lifecycle/spec.md
@@ -1,0 +1,40 @@
+## Purpose
+
+Pin who owns custom-field teardown when an owning object is destroyed — the placement hook, with
+complete callback-driven teardown — and that owners without the hook do not bulk-delete
+definition rows they cannot tear down properly.
+
+## ADDED Requirements
+
+### Requirement: Owner destroy tears down its field definitions completely
+
+A model carrying the placement hook (`CustomFieldsRead`) SHALL, when destroyed, destroy its
+attached custom-field groups **with callbacks**: the group rows, their fields, those fields'
+option metas, and the owner's stored values are all removed — nothing is left orphaned. Bulk
+row deletion (skipping callbacks) MUST NOT be part of this path.
+
+#### Scenario: Post destroy reaps its individual group
+
+- **WHEN** a post carrying an individual custom-field group (with a field holding option metas
+  and a stored value) is destroyed
+- **THEN** the group row, the field row, the field's option metas, and the post's stored values
+  are all gone
+
+#### Scenario: Post type destroy reaps its placement groups
+
+- **WHEN** a post type with a field group for its posts (placement scope `PostType_Post`) is
+  destroyed
+- **THEN** that group and its fields are destroyed with it
+
+### Requirement: Owners without the placement hook do not cascade definitions
+
+A model carrying only the common relationships (no placement hook — e.g. post comments) SHALL
+NOT delete custom-field definition rows when destroyed (2.9.2 behavior): without the hook there
+is no callback-driven teardown, and bulk deletion would remove group rows while orphaning their
+fields and option metas.
+
+#### Scenario: Comment destroy leaves attached definitions
+
+- **WHEN** a post comment carrying an attached custom-field group (with a field holding option
+  metas) is destroyed
+- **THEN** the group row, the field row, and the field's option metas still exist

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/specs/meta-scope-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/specs/meta-scope-resolution/spec.md
@@ -1,0 +1,49 @@
+## Purpose
+
+Define how a model's `object_class` scope name — the key under which its metas, custom fields,
+field groups, and stored values are read and written — is derived from its class name, and keep
+the widget admin surfaces agreeing with it, so refactors cannot silently strand existing rows or
+reopen the write/read mismatch that broke widget custom fields.
+
+## ADDED Requirements
+
+### Requirement: Scopes are the demodulized class name
+
+Every model carrying the common relationships SHALL scope its meta and custom-field rows under
+its **demodulized** class name — the 2.9.2 contract all existing installs' rows were written
+under: `CamaleonCms::Post` → `Post`, `CamaleonCms::Widget::Main` → `Main`, a host `Admin::User`
+→ `User`. Scope names MUST NOT carry namespace qualifiers.
+
+#### Scenario: Top-level engine class
+
+- **WHEN** a `CamaleonCms::Post` record builds a meta row
+- **THEN** the row's `object_class` is `Post`
+
+#### Scenario: Nested engine class
+
+- **WHEN** a `CamaleonCms::Widget::Main` record builds a meta row
+- **THEN** the row's `object_class` is `Main`
+
+#### Scenario: Namespaced host user model reads its 2.9.2 rows
+
+- **WHEN** a host model `Admin::User` (configured as the `user_model`) builds a meta row
+- **THEN** the row's `object_class` is `User`
+
+#### Scenario: Unnamespaced host class is unchanged
+
+- **WHEN** a top-level host model builds a meta row
+- **THEN** the row's `object_class` is the class name itself
+
+### Requirement: Widget admin surfaces agree with the scope names
+
+The widget admin flows that reference the widget scope by string — the assigned-widget save
+(allowed field slugs lookup) and the field-group caption — SHALL use the same demodulized name
+the association scope produces. A field value submitted for a group placed on a widget MUST save
+and read back; it MUST NOT be silently discarded by a scope-name mismatch (the 2.8.x–2.9.2
+breakage).
+
+#### Scenario: Assigned-widget field value round-trips
+
+- **WHEN** a widget carries a field group with a field, and the admin saves an assigned-widget
+  form submitting a value for that field
+- **THEN** the value is stored and readable back from the assigned widget

--- a/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/tasks.md
+++ b/openspec/changes/archive/2026-08-09-fix-scope-drift-and-cascade/tasks.md
@@ -1,0 +1,43 @@
+## 1. M9 + M8 — revert the scope naming, align the widget literals (commit 1)
+
+- [x] 1.1 `spec/models/meta_scope_resolution_spec.rb`: demodulize contract — `Post`, `Main`
+      (Widget::Main), `User` (stubbed `Admin::User`-style host class), plain host class
+      (host-model and widget directions proven red against the prefixed concern earlier in the
+      session).
+- [x] 1.2 `spec/requests/admin/widget_field_values_spec.rb`: assigned-widget field value
+      round-trips through the group placed on the widget (era-portable joint pin — red on any
+      one-sided rename).
+- [x] 1.3 `common_relationships.rb` → `name.demodulize`; assign controller allowed-slugs lookup
+      and `get_caption` widget case → `'Main'`; the two security-spec fixtures follow.
+- [x] 1.4 No repair task, no compatibility read (maintainer decision: unreleased churn,
+      prefixed rows abandoned). Specs green; rubocop clean; commit.
+
+## 2. M7 — rollback-hazard note (commit 2, docs-only, [skip ci])
+
+- [x] 2.1 CHANGELOG upgrader note: `Widget::Assigned` rows written on master are invisible to
+      2.9.2 after a rollback (`post_class` STI discriminator — separate mechanism, not
+      reverted).
+
+## 3. N4 — definition lifecycle (commit 3)
+
+- [x] 3.1 `spec/models/custom_field_definition_lifecycle_spec.rb`: hook teardown pins (post,
+      post type — complete, callback-driven) and the hook-less leave-definitions repro
+      (PostComment; proven red against the delete_all concern).
+- [x] 3.2 `common_relationships.rb`: drop `dependent: :delete_all` from `custom_fields` and
+      `custom_field_groups`, cop-pinned with the ownership rationale.
+- [x] 3.3 Specs green; rubocop clean; commit.
+
+## 4. Verification and CI parity
+
+- [x] 4.1 Full `bin/rspec` suite green.
+- [x] 4.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 5. OpenSpec + PR protocol
+
+- [x] 5.1 `openspec validate fix-scope-drift-and-cascade --strict` passes; archive on-branch
+      (syncs `meta-scope-resolution` and `custom-field-definition-lifecycle`); commit the
+      archived change (no `[skip ci]` — it heads the first push).
+- [x] 5.2 Push, open the PR (What and Why + User-Visible Impact; protocol constraints), first
+      push runs CI.
+- [x] 5.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/custom-field-definition-lifecycle/spec.md
+++ b/openspec/specs/custom-field-definition-lifecycle/spec.md
@@ -1,0 +1,40 @@
+# custom-field-definition-lifecycle Specification
+
+## Purpose
+Pin who owns custom-field teardown when an owning object is destroyed — the placement hook, with
+complete callback-driven teardown — and that owners without the hook do not bulk-delete
+definition rows they cannot tear down properly.
+## Requirements
+### Requirement: Owner destroy tears down its field definitions completely
+
+A model carrying the placement hook (`CustomFieldsRead`) SHALL, when destroyed, destroy its
+attached custom-field groups **with callbacks**: the group rows, their fields, those fields'
+option metas, and the owner's stored values are all removed — nothing is left orphaned. Bulk
+row deletion (skipping callbacks) MUST NOT be part of this path.
+
+#### Scenario: Post destroy reaps its individual group
+
+- **WHEN** a post carrying an individual custom-field group (with a field holding option metas
+  and a stored value) is destroyed
+- **THEN** the group row, the field row, the field's option metas, and the post's stored values
+  are all gone
+
+#### Scenario: Post type destroy reaps its placement groups
+
+- **WHEN** a post type with a field group for its posts (placement scope `PostType_Post`) is
+  destroyed
+- **THEN** that group and its fields are destroyed with it
+
+### Requirement: Owners without the placement hook do not cascade definitions
+
+A model carrying only the common relationships (no placement hook — e.g. post comments) SHALL
+NOT delete custom-field definition rows when destroyed (2.9.2 behavior): without the hook there
+is no callback-driven teardown, and bulk deletion would remove group rows while orphaning their
+fields and option metas.
+
+#### Scenario: Comment destroy leaves attached definitions
+
+- **WHEN** a post comment carrying an attached custom-field group (with a field holding option
+  metas) is destroyed
+- **THEN** the group row, the field row, and the field's option metas still exist
+

--- a/openspec/specs/meta-scope-resolution/spec.md
+++ b/openspec/specs/meta-scope-resolution/spec.md
@@ -1,0 +1,49 @@
+# meta-scope-resolution Specification
+
+## Purpose
+Define how a model's `object_class` scope name — the key under which its metas, custom fields,
+field groups, and stored values are read and written — is derived from its class name, and keep
+the widget admin surfaces agreeing with it, so refactors cannot silently strand existing rows or
+reopen the write/read mismatch that broke widget custom fields.
+## Requirements
+### Requirement: Scopes are the demodulized class name
+
+Every model carrying the common relationships SHALL scope its meta and custom-field rows under
+its **demodulized** class name — the 2.9.2 contract all existing installs' rows were written
+under: `CamaleonCms::Post` → `Post`, `CamaleonCms::Widget::Main` → `Main`, a host `Admin::User`
+→ `User`. Scope names MUST NOT carry namespace qualifiers.
+
+#### Scenario: Top-level engine class
+
+- **WHEN** a `CamaleonCms::Post` record builds a meta row
+- **THEN** the row's `object_class` is `Post`
+
+#### Scenario: Nested engine class
+
+- **WHEN** a `CamaleonCms::Widget::Main` record builds a meta row
+- **THEN** the row's `object_class` is `Main`
+
+#### Scenario: Namespaced host user model reads its 2.9.2 rows
+
+- **WHEN** a host model `Admin::User` (configured as the `user_model`) builds a meta row
+- **THEN** the row's `object_class` is `User`
+
+#### Scenario: Unnamespaced host class is unchanged
+
+- **WHEN** a top-level host model builds a meta row
+- **THEN** the row's `object_class` is the class name itself
+
+### Requirement: Widget admin surfaces agree with the scope names
+
+The widget admin flows that reference the widget scope by string — the assigned-widget save
+(allowed field slugs lookup) and the field-group caption — SHALL use the same demodulized name
+the association scope produces. A field value submitted for a group placed on a widget MUST save
+and read back; it MUST NOT be silently discarded by a scope-name mismatch (the 2.8.x–2.9.2
+breakage).
+
+#### Scenario: Assigned-widget field value round-trips
+
+- **WHEN** a widget carries a field group with a field, and the admin saves an assigned-widget
+  form submitting a value for that field
+- **THEN** the value is stored and readable back from the assigned widget
+

--- a/spec/models/custom_field_definition_lifecycle_spec.rb
+++ b/spec/models/custom_field_definition_lifecycle_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Custom field definition lifecycle', type: :model do
+  init_site
+
+  let(:site) { Cama::Site.first }
+  let(:post_type) { site.post_types.where(slug: 'post').first_or_create!(name: 'Post', site: site) }
+  let(:content) { create(:post, post_type: post_type, slug: 'lifecycle-post') }
+
+  # Green at 2.9.2 and on master alike: teardown is owned by
+  # CustomFieldsRead#_destroy_custom_field_groups, which runs before any association
+  # dependent. Pinned here because dropping the redundant delete_all is only safe
+  # while this hook keeps doing the complete job.
+  it 'tears down the individual group, field, option metas, and values on post destroy' do
+    group = content.add_custom_field_group(name: 'Individual Group', slug: 'individual-group')
+    field = group.add_manual_field({ name: 'Color', slug: 'color' }, { field_key: 'text_box' })
+    content.custom_field_values.create!(custom_field_id: field.id, custom_field_slug: 'color', value: 'red')
+
+    content.destroy!
+
+    expect(CamaleonCms::CustomFieldGroup.unscoped.exists?(group.id)).to be(false)
+    expect(CamaleonCms::CustomField.unscoped.exists?(field.id)).to be(false)
+    expect(CamaleonCms::Meta.where(object_class: 'CustomField', objectid: field.id)).to be_empty
+    expect(CamaleonCms::CustomFieldsRelationship.where(object_class: 'Post', objectid: content.id)).to be_empty
+  end
+
+  it 'reaps placement groups with callbacks on post type destroy' do
+    reap_type = create(:post_type, slug: 'reap-pt', site: site)
+    group = reap_type.add_custom_field_group({ name: 'PT Fields', slug: 'pt-fields' }, 'Post')
+    field = group.add_manual_field({ name: 'Field', slug: 'reap-field' }, { field_key: 'text_box' })
+
+    reap_type.destroy!
+
+    expect(CamaleonCms::CustomFieldGroup.unscoped.exists?(group.id)).to be(false)
+    expect(CamaleonCms::CustomField.unscoped.exists?(field.id)).to be(false)
+  end
+
+  it 'leaves definitions attached to a hook-less owner when it is destroyed' do
+    author = create(:user, site: site)
+    comment = content.comments.create!(user_id: author.id, content: 'a comment', approved: 'approved')
+    group = CamaleonCms::CustomFieldGroup.create!(
+      name: 'Comment Group', slug: 'comment-group',
+      object_class: 'PostComment', objectid: comment.id, parent_id: site.id
+    )
+    field = group.add_manual_field({ name: 'Rating', slug: 'rating' }, { field_key: 'text_box' })
+
+    comment.destroy!
+
+    expect(CamaleonCms::CustomFieldGroup.unscoped.exists?(group.id)).to be(true)
+    expect(CamaleonCms::CustomField.unscoped.exists?(field.id)).to be(true)
+    expect(CamaleonCms::Meta.where(object_class: 'CustomField', objectid: field.id)).to be_present
+  end
+end

--- a/spec/models/meta_scope_resolution_spec.rb
+++ b/spec/models/meta_scope_resolution_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Meta scope resolution', type: :model do
+  init_site
+
+  def host_class
+    # Name the class before including the concern — the scope name is captured at include time
+    Class.new(::CamaleonRecord) { self.table_name = CamaleonCms::User.table_name }
+  end
+
+  it 'demodulizes engine classes' do
+    expect(CamaleonCms::Post.new.metas.build.object_class).to eq('Post')
+  end
+
+  it 'demodulizes nested engine classes (the widget scopes)' do
+    expect(CamaleonCms::Widget::Main.new.metas.build.object_class).to eq('Main')
+  end
+
+  it 'demodulizes namespaced host classes' do
+    stub_const('SpecHost::Member', host_class)
+    SpecHost::Member.include(CamaleonCms::CommonRelationships)
+
+    expect(SpecHost::Member.new.metas.build.object_class).to eq('Member')
+  end
+
+  it 'keeps unnamespaced host classes as-is' do
+    stub_const('SpecMember', host_class)
+    SpecMember.include(CamaleonCms::CommonRelationships)
+
+    expect(SpecMember.new.metas.build.object_class).to eq('SpecMember')
+  end
+end

--- a/spec/requests/admin/widget_field_values_spec.rb
+++ b/spec/requests/admin/widget_field_values_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin widget assigned field values', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+  let(:widget) { current_site.widgets.create!(name: 'Field Widget', slug: 'field-widget') }
+  let(:sidebar) { current_site.sidebars.create!(name: 'Probe Sidebar', slug: 'probe-sidebar') }
+  let(:assigned) { sidebar.assigned.create!(title: 'Default', widget_id: widget.id) }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    group = widget.add_custom_field_group(name: 'Widget Fields', slug: 'widget-fields')
+    @color_field = group.add_manual_field({ name: 'Color', slug: 'color' }, { field_key: 'text_box' })
+    sign_in_as(admin, site: current_site)
+  end
+
+  # The 2.8.x–2.9.2 widget custom-fields breakage was exactly this joint: the assign save asked
+  # for allowed field slugs under one scope name while the widget's group was stored under
+  # another, so submitted values were silently discarded. Green means the controller's scope
+  # literal and the association scope agree end to end.
+  it 'saves an assigned-widget field value through the group placed on the widget' do
+    patch "/admin/appearances/widgets/sidebar/#{sidebar.id}/assign/#{assigned.id}", params: {
+      assign: { title: 'Default' },
+      field_options: { '0' => { 'color' => { 'id' => @color_field.id.to_s, 'values' => { '0' => 'red' } } } }
+    }
+
+    expect(response).to have_http_status(:found)
+    expect(assigned.reload.get_field_value('color')).to eq('red')
+  end
+end

--- a/spec/requests/security/cross_site_field_group_injection_spec.rb
+++ b/spec/requests/security/cross_site_field_group_injection_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe 'Cross-site custom field group injection', type: :request do
 
     it 'lets an administrator re-save a group whose stored placement is not in the select' do
       group = current_site.custom_field_groups.create!(
-        name: 'Widget Group', slug: '_widget-group', object_class: 'Widget::Main', objectid: current_site.id
+        name: 'Widget Group', slug: '_widget-group', object_class: 'Main', objectid: current_site.id
       )
       theme = current_site.get_theme
 

--- a/spec/requests/security/custom_field_group_caption_escaping_spec.rb
+++ b/spec/requests/security/custom_field_group_caption_escaping_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Security: custom field group caption escaping', type: :request d
 
   it 'escapes an injected widget name' do
     widget = current_site.widgets.create!(name: payload, slug: 'evil-widget')
-    place_group_on('Widget::Main', widget.id, '_evil-widget-group')
+    place_group_on('Main', widget.id, '_evil-widget-group')
 
     cell = caption_cell
     expect(injected_script_sources(cell)).to be_empty


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` batched the `common_relationships.rb` findings as PR 5
(M9, M8, M7, N4). Two findings resolved differently than the audit plan sketched — one by
maintainer decision, one by live verification:

- **The `object_class` scope naming reverts to 2.9.2's demodulized contract** (maintainer
  decision). The unreleased rename to prefix-qualified names (`'Main'` → `'Widget::Main'`,
  host `Admin::User` → `'Admin::User'`) stranded every row released installs ever wrote and
  would have needed a compatibility seam (M9) plus a repair rake task (M8) to manage. Reverting
  eliminates both. The one real fix the rename carried is preserved: widget custom fields were
  broken 2.8.x–2.9.2 because the assign controller's allowed-slugs lookup and the group caption
  said `'Widget::Main'` while the association scope said `'Main'` — those literals now move
  with the scope, and the joint is pinned by an end-to-end assigned-widget save spec that goes
  red on any future one-sided rename. Rows written under the prefixed names by master-tracking
  installs are deliberately abandoned (never released).
- **The bulk-delete cascade on the definition associations is removed** (N4, corrected during
  implementation). Live verification showed the audited claim was wrong for every model
  carrying the placement hook: `_destroy_custom_field_groups` runs before any association
  dependent and destroys an owner's field groups **with callbacks** — fields, option metas, and
  values included — at 2.9.2 and master alike, so the added `dependent: :delete_all` was inert
  there. It bit only hook-less includers (post comments), where destroy raw-deleted group rows
  while orphaning their fields and option metas. The dependents are gone (cop-pinned): the hook
  keeps owning teardown — now spec-pinned as complete — and hook-less owners return to 2.9.2's
  leave-definitions behavior. A `:destroy` cascade was rejected as unsafe: the `custom_fields`
  association matches group rows through the same table, but its `CustomField` typing would
  skip group teardown.
- **The `Widget::Assigned` rollback hazard is documented** (M7): the compact `post_class` STI
  discriminator — a separate mechanism from the scopes above, guarded by the #1194 dual-read on
  upgrade — makes assignments created on this version invisible after a rollback to 2.9.2.
  Documentation only.

Two new OpenSpec capabilities (`meta-scope-resolution`, `custom-field-definition-lifecycle`) are
archived on the branch.

## User-Visible Impact

Upgrading 2.9.2 installs keep every meta, custom field, and widget field row they ever wrote
(no migration, no rake task), widget custom-field values save and read back correctly, and
destroying content no longer orphans custom-field definitions on models without their own
teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
