### PR TITLE
Fix the namespaced user_model custom-fields scope joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Fix:** User custom fields work again for host apps configuring a namespaced `user_model`
+  (e.g. `'Admin::User'`): the settings form's users placement option and the user edit page's
+  field-group read now use the demodulized scope name (`'User'`) the association scope and the
+  save filter already used, so submitted user field values are no longer silently discarded
+  (broken since 2.9.2). Engine-default and top-level `User` installs are unaffected. Regression
+  audit N5. [#1239](https://github.com/owen2345/camaleon-cms/pull/1239).
+
+  **Notes for upgraders:**
+  - Namespaced-`user_model` installs run `bin/rails camaleon_cms:demodulize_user_field_groups`
+    once after upgrading: it re-keys user field groups stored under the old qualified placement
+    so they stay visible and editable. Idempotent; a no-op everywhere else.
+  - After that task runs, rolling back to 2.9.2 hides those groups on the user edit page until
+    re-upgrade (data intact — same class of hazard as the `Widget::Assigned` note below).
+
 - **Fix:** The `object_class` scope naming for metas, custom fields, and field groups returns to
   the demodulized 2.9.2 contract (`'Main'`, `'User'`), reverting an unreleased rename to
   prefix-qualified names that stranded every row existing installs had written; the widget admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,11 @@
 ## Unreleased
 
 - **Fix:** User custom fields work again for host apps configuring a namespaced `user_model`
-  (e.g. `'Admin::User'`): the settings form's users placement option and the user edit page's
-  field-group read now use the demodulized scope name (`'User'`) the association scope and the
-  save filter already used, so submitted user field values are no longer silently discarded
-  (broken since 2.9.2). Engine-default and top-level `User` installs are unaffected. Regression
-  audit N5. [#1239](https://github.com/owen2345/camaleon-cms/pull/1239).
+  (e.g. `'Admin::User'`): the settings form's users placement option, the user edit page's
+  field-group read, and the save filter's allowed-slugs lookup now all derive the demodulized
+  user-model scope name the association scope uses, so submitted user field values are no longer
+  silently discarded (broken since 2.9.2). Engine-default and top-level `User` installs are
+  unaffected. Regression audit N5. [#1239](https://github.com/owen2345/camaleon-cms/pull/1239).
 
   **Notes for upgraders:**
   - Namespaced-`user_model` installs run `bin/rails camaleon_cms:demodulize_user_field_groups`

--- a/app/controllers/camaleon_cms/admin/users_controller.rb
+++ b/app/controllers/camaleon_cms/admin/users_controller.rb
@@ -45,7 +45,7 @@ module CamaleonCms
         hooks_run('user_update', r)
         if @user.update(user_params)
           @user.set_metas(user_meta_params) if params[:meta].present?
-          @user.set_field_values(cama_permitted_field_options('User')) if params[:field_options].present?
+          @user.set_field_values(cama_permitted_field_options(user_field_scope)) if params[:field_options].present?
           r = { user: @user, message: t('camaleon_cms.admin.users.message.updated'), params: params }
           hooks_run('user_after_edited', r)
           flash[:notice] = r[:message]
@@ -117,7 +117,7 @@ module CamaleonCms
         hooks_run('user_create', r)
         if @user.save
           @user.set_metas(user_meta_params) if params[:meta].present?
-          @user.set_field_values(cama_permitted_field_options('User')) if params[:field_options].present?
+          @user.set_field_values(cama_permitted_field_options(user_field_scope)) if params[:field_options].present?
           r = { user: @user }
           hooks_run('user_created', r)
           flash[:notice] = t('camaleon_cms.admin.users.message.created')
@@ -169,6 +169,13 @@ module CamaleonCms
 
       def user_meta_params
         params.require(:meta).permit(:avatar, :slogan)
+      end
+
+      # Allowed field slugs must be keyed on the demodulized placement name the settings form
+      # emits and get_user_field_groups queries; keyed on a hardcoded 'User' the lookup finds no
+      # groups for a host user model that demodulizes to another name, discarding every value.
+      def user_field_scope
+        PluginRoutes.get_user_class_name.demodulize
       end
 
       def set_user

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -77,7 +77,9 @@ module CamaleonCms
     # return collections CustomFieldGroup
     # site: site object
     def get_user_field_groups(site)
-      site.custom_field_groups.where(object_class: self.class.to_s.parseCamaClass)
+      # Demodulized to match the association scope and the placement the settings form stores
+      # ('User' for a host Admin::User); parseCamaClass still strips a Draper Decorator suffix.
+      site.custom_field_groups.where(object_class: self.class.to_s.parseCamaClass.demodulize)
     end
 
     # get custom field value

--- a/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
+++ b/app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb
@@ -64,7 +64,8 @@
                                 </optgroup>
 
                                 <optgroup label="<%= t('camaleon_cms.admin.settings.others') %>">
-                                    <% value = "#{PluginRoutes.static_system_info['user_model'].presence || 'User'},#{current_site.id}" %>
+                                    <%# Demodulized: user groups are stored and read under the association's scope name %>
+                                    <% value = "#{PluginRoutes.get_user_class_name.demodulize},#{current_site.id}" %>
                                     <option value="<%= value %>" data-help="<%= t('camaleon_cms.admin.settings.tooltip.add_custom_field_users') %>"><%= t('camaleon_cms.admin.sidebar.users') %></option>
                                     <% value = "Site,#{current_site.id}" %>
                                     <option value="<%= value %>" data-help="<%= t('camaleon_cms.admin.settings.tooltip.add_custom_field_sites') %>"><%= t('camaleon_cms.admin.sidebar.site_settings') %></option>

--- a/lib/tasks/user_field_groups.rake
+++ b/lib/tasks/user_field_groups.rake
@@ -15,13 +15,13 @@ namespace :camaleon_cms do
     demodulized = configured.demodulize
 
     if configured.blank? || configured == demodulized
-      Rails.logger.info 'Nothing to re-key: the configured user model is not namespaced.'
+      puts 'Nothing to re-key: the configured user model is not namespaced.'
       next
     end
 
     count = CamaleonCms::CustomField.unscoped
                                     .where(object_class: configured)
                                     .update_all(object_class: demodulized) # rubocop:disable Rails/SkipsModelValidations
-    Rails.logger.info "Re-keyed #{count} user field group(s) from '#{configured}' to '#{demodulized}'."
+    puts "Re-keyed #{count} user field group(s) from '#{configured}' to '#{demodulized}'."
   end
 end

--- a/lib/tasks/user_field_groups.rake
+++ b/lib/tasks/user_field_groups.rake
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+namespace :camaleon_cms do
+  # Through 2.9.2 the custom-fields settings form emitted the raw `user_model` config string as
+  # the users placement option, so a namespaced host user model (e.g. 'Admin::User') stored its
+  # user field groups under the qualified name — which the demodulized association scope and the
+  # 2.9.2 allowed-slugs save filter cannot see. Re-key those group placements to the demodulized
+  # contract. Only the group rows move: their fields hang off parent_id under '_fields', group
+  # metas key off 'CustomFieldGroup', and value rows were always written under the demodulized
+  # name. Keyed to the current config: a host that renamed its user model after writing groups
+  # should temporarily restore the historical value while running the task.
+  desc 'Re-key user custom field groups stored under a namespaced user_model name'
+  task demodulize_user_field_groups: :environment do
+    configured = PluginRoutes.static_system_info['user_model'].presence.to_s
+    demodulized = configured.demodulize
+
+    if configured.blank? || configured == demodulized
+      Rails.logger.info 'Nothing to re-key: the configured user model is not namespaced.'
+      next
+    end
+
+    count = CamaleonCms::CustomField.unscoped
+                                    .where(object_class: configured)
+                                    .update_all(object_class: demodulized) # rubocop:disable Rails/SkipsModelValidations
+    Rails.logger.info "Re-keyed #{count} user field group(s) from '#{configured}' to '#{demodulized}'."
+  end
+end

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/design.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/design.md
@@ -43,8 +43,9 @@ See `proposal.md` — Why. Load-bearing facts verified in code and git history:
   but its naming is the host's contract, not the engine's user_model config.
 - No re-keying of rows written by unreleased master-tracking installs under the short-lived
   prefixed association scopes — already deliberately abandoned by #1238.
-- No change to the users controller literal or the association scope: both already say
-  `'User'`, which is the pinned contract.
+- No change to the association scope: it already derives the pinned demodulized name
+  (`name.to_s.demodulize`). (An earlier revision also kept the users controller's `'User'`
+  literal out of scope; branch review overturned that — see Decision 4.)
 
 ## Decisions
 
@@ -73,6 +74,20 @@ See `proposal.md` — Why. Load-bearing facts verified in code and git history:
    `legacy_camaleon_polymorphic_class` uses `safe_constantize`) are proven red against the
    current code. The user round-trip request spec is a green-by-design end-to-end pin, the
    sibling of #1238's widget pin, era-portable against any future one-sided rename.
+4. **The save filter derives from the same accessor (branch-review fix).** With the read, the
+   form emission, and the association all deriving the demodulized name dynamically, the
+   controller's hardcoded `cama_permitted_field_options('User')` became the one static surface
+   left: for a host user model whose demodulized name is not `'User'` (e.g. `Accounts::Member`
+   → `'Member'`), the other three surfaces agree while the filter finds no groups — the same
+   silent-discard anatomy this change repairs, harder to see because the group still renders.
+   Both users controller call sites now key on `PluginRoutes.get_user_class_name.demodulize`
+   (a private helper), mirroring the form emission; identical output for the engine default
+   and every `*::User` host. Proven red-first by a round-trip request spec stubbing a
+   `'SpecHost::Member'` config.
+5. **The repair task reports on stdout (branch-review fix).** Operators run it once from a
+   console; `Rails.logger.info` lands in the log file, in production potentially below the
+   configured level, and the task's config-miss and rollback caveats travel through that
+   output. `puts`, pinned by stdout assertions in the task spec.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/design.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/design.md
@@ -1,0 +1,97 @@
+# Design — fix-namespaced-user-field-scope
+
+## Context
+
+See `proposal.md` — Why. Load-bearing facts verified in code and git history:
+
+- The association scope was `'User'` at every released version: a hardcoded
+  `cama_define_common_relationships('User')` literal through 2.6.4, `name.demodulize` since the
+  concern refactor shipped in 2.7.0, restored (as `name.to_s.demodulize`) by #1238.
+- Two surfaces have carried a qualified name since the v1.0-era codebase:
+  `get_user_field_groups` reads `parseCamaClass` (which strips only `Decorator` and
+  `CamaleonCms::`, so a host `Admin::User` stays `'Admin::User'`), and the settings form emits
+  the raw `user_model` config string as the users placement option.
+- Through 2.9.1 this dual naming was harmless: the users controller passed
+  `params[:field_options]` to `set_field_values` unfiltered, and values were written and read
+  through the `'User'`-scoped association. The 2.9.2 mass-assignment hardening (eba56d6f) keys
+  the allowed-slugs lookup on the `'User'` literal, which finds no qualified groups — submitted
+  values are silently discarded (same anatomy as the widget joint fixed in #1238).
+- User field groups are site-global: placed with `objectid = site.id`, read through
+  `site.custom_field_groups` (tenancy scope) plus the placement class name. Values are per-user
+  through the association (`objectid = user.id`, `object_class: 'User'`), so no value rows and
+  no meta rows were ever written under the qualified name at any released version. Group field
+  rows hang off `parent_id` with `object_class: '_fields'`; group metas key off
+  `'CustomFieldGroup'`. Only the group placement rows are stranded.
+- Zero external consumers: a sweep of the 22 local ecosystem repos found no caller of
+  `get_user_field_groups` outside the engine.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Every user custom-fields surface (placement emission, user-page read, save filter,
+  association) agrees on the demodulized name, per the meta-scope-resolution contract.
+- Groups placed under the old qualified emission keep working after one idempotent repair task.
+- Zero behavioral change for non-namespaced installs (engine default and top-level host `User`).
+
+**Non-Goals:**
+
+- No compatibility read for qualified names in runtime code (see Decisions).
+- No change to the `custom_field_custom_models` hook option emission (`model.name` raw): hook
+  models are host-authored, and their groups are read back through the association-scoped
+  `get_field_groups` else-arm — a host registering a namespaced hook model has the same joint,
+  but its naming is the host's contract, not the engine's user_model config.
+- No re-keying of rows written by unreleased master-tracking installs under the short-lived
+  prefixed association scopes — already deliberately abandoned by #1238.
+- No change to the users controller literal or the association scope: both already say
+  `'User'`, which is the pinned contract.
+
+## Decisions
+
+1. **Demodulize at the source, in both qualified surfaces.**
+   `get_user_field_groups` becomes `self.class.to_s.parseCamaClass.demodulize` — parseCamaClass
+   is kept for its `Decorator` strip, demodulize collapses any namespace. The form option
+   becomes `PluginRoutes.get_user_class_name.demodulize` (the canonical accessor; its
+   `CamaleonCms::User` default demodulizes to the same `'User'` the old fallback emitted).
+   Rejected: a dual-spelling compatibility read (`where(object_class: [qualified, demodulized])`)
+   — it manages the divergence forever instead of deleting it, and the save filter would need
+   the same widening to actually fix the discard.
+2. **Repair task re-keys exactly what the old form emitted.** The task derives the qualified
+   name from the `user_model` config (`presence`, mirroring the old emission) and re-keys
+   `custom_fields` rows with that exact `object_class` to its demodulized form via one
+   `update_all`. Keyed to the current config: it deliberately covers an explicitly configured
+   `CamaleonCms::User` (whose groups were equally stranded — placed qualified, read
+   demodulized) and is a no-op when the config is blank or already demodulized. A host that
+   renamed its user model since writing groups must pass the historical name — documented in
+   the task's desc/comment rather than guessed at.
+   Rejected: a migration (project convention: backfills are rake tasks); per-row
+   `find_each`/`update_column` (the precedent for computed per-row values — this re-key is
+   uniform, so a single statement is simpler and naturally idempotent).
+3. **Repro-first where the defect reproduces.** The namespaced read (model spec) and the form
+   emission (request spec, `static_system_info` stubbed with a merged hash — safe because the
+   auth path resolves users through load-time associations and
+   `legacy_camaleon_polymorphic_class` uses `safe_constantize`) are proven red against the
+   current code. The user round-trip request spec is a green-by-design end-to-end pin, the
+   sibling of #1238's widget pin, era-portable against any future one-sided rename.
+
+## Risks / Trade-offs
+
+- [A namespaced-host admin re-saves an old qualified group before running the task] → the
+  placement validation admits both spellings (`owned_placement_ids` else-arm keys on the site
+  id), and the re-save path preserves a stored placement absent from the select — the group
+  stays qualified but intact; the task repairs it whenever it runs.
+- [The task's config-derived key misses rows if the host renamed its user model] → stated in
+  the task output; the update is a one-liner an operator can re-run with the historical name
+  re-keyed through the same task after temporarily restoring the config value.
+- [Stubbing `static_system_info` wholesale in specs could destabilize unrelated reads] → the
+  stub merges onto the real hash (only `user_model` differs) and is scoped to the examples that
+  need it.
+
+## Migration Plan
+
+Code change deploys normally; affected installs (namespaced `user_model` only) run
+`bin/rails camaleon_cms:demodulize_user_field_groups` once after deploy. Rollback = revert the
+commits. Rollback hazard after the task has run: 2.9.2's qualified reader no longer finds the
+re-keyed `'User'` groups, so they disappear from the user edit page until re-upgrade — data
+intact, nothing deleted. That is no worse than 2.9.2's steady state (where the groups rendered
+but every save was discarded), and it mirrors the documented `Widget::Assigned` hazard.

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/proposal.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/proposal.md
@@ -1,0 +1,44 @@
+# Proposal — fix-namespaced-user-field-scope
+
+## Why
+
+For a host app that configures a namespaced user model (`user_model: 'Admin::User'`), the user
+custom-fields feature silently discards every submitted value since 2.9.2: the settings form
+places groups under the raw qualified name and the user edit page reads them back the same way,
+but the save filter and the association scope both use the demodulized `'User'` — so the
+allowed-slugs lookup comes back empty (regression audit N5). The demodulized contract was just
+pinned by the `meta-scope-resolution` capability (PR #1238); these two surfaces still contradict
+it.
+
+## What Changes
+
+- `CustomFieldsRead#get_user_field_groups` derives its placement query from the demodulized
+  class name (keeping the `Decorator` strip), matching the association scope.
+- The custom-fields settings form emits the demodulized user-model name in the users placement
+  option, so new groups are stored under the name every other surface reads.
+- A new idempotent rake task re-keys group placements stored under the previously emitted
+  qualified name to the demodulized contract, so existing groups survive the read-side change.
+- Installs on the engine-default `CamaleonCms::User` or a top-level host `User` see no
+  behavioral change (all spellings already collapse to `'User'`).
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `meta-scope-resolution`: the "surfaces agree with the scope names" contract extends beyond the
+  widget admin to the user custom-fields surfaces (placement emission, user-page read), and
+  gains a repair-task requirement for legacy qualified placements.
+
+## Impact
+
+- `app/models/concerns/camaleon_cms/custom_fields_read.rb` (`get_user_field_groups`)
+- `app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb` (users placement option)
+- `lib/tasks/user_field_groups.rake` (new repair task) + task spec
+- Specs: `spec/models/meta_scope_resolution_spec.rb`, a new settings-form request spec, a new
+  user field-values round-trip request spec
+- No migration; no change for non-namespaced installs; no API removal (ecosystem sweep found
+  zero external `get_user_field_groups` consumers)

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/proposal.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/proposal.md
@@ -17,7 +17,11 @@ it.
 - The custom-fields settings form emits the demodulized user-model name in the users placement
   option, so new groups are stored under the name every other surface reads.
 - A new idempotent rake task re-keys group placements stored under the previously emitted
-  qualified name to the demodulized contract, so existing groups survive the read-side change.
+  qualified name to the demodulized contract, so existing groups survive the read-side change;
+  it reports its summary on stdout.
+- The users controller's save filter keys its allowed-slugs lookup on the same derived name
+  (`PluginRoutes.get_user_class_name.demodulize`) instead of a hardcoded `'User'`, so host
+  models that demodulize to another name get their values accepted too (branch-review fix).
 - Installs on the engine-default `CamaleonCms::User` or a top-level host `User` see no
   behavioral change (all spellings already collapse to `'User'`).
 
@@ -37,6 +41,7 @@ _None._
 
 - `app/models/concerns/camaleon_cms/custom_fields_read.rb` (`get_user_field_groups`)
 - `app/views/camaleon_cms/admin/settings/custom_fields/form.html.erb` (users placement option)
+- `app/controllers/camaleon_cms/admin/users_controller.rb` (save-filter scope derivation)
 - `lib/tasks/user_field_groups.rake` (new repair task) + task spec
 - Specs: `spec/models/meta_scope_resolution_spec.rb`, a new settings-form request spec, a new
   user field-values round-trip request spec

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/specs/meta-scope-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/specs/meta-scope-resolution/spec.md
@@ -1,51 +1,6 @@
-# meta-scope-resolution Specification
+# meta-scope-resolution Delta — fix-namespaced-user-field-scope
 
-## Purpose
-Define how a model's `object_class` scope name — the key under which its metas, custom fields,
-field groups, and stored values are read and written — is derived from its class name, and keep
-the widget admin surfaces agreeing with it, so refactors cannot silently strand existing rows or
-reopen the write/read mismatch that broke widget custom fields.
-## Requirements
-### Requirement: Scopes are the demodulized class name
-
-Every model carrying the common relationships SHALL scope its meta and custom-field rows under
-its **demodulized** class name — the 2.9.2 contract all existing installs' rows were written
-under: `CamaleonCms::Post` → `Post`, `CamaleonCms::Widget::Main` → `Main`, a host `Admin::User`
-→ `User`. Scope names MUST NOT carry namespace qualifiers.
-
-#### Scenario: Top-level engine class
-
-- **WHEN** a `CamaleonCms::Post` record builds a meta row
-- **THEN** the row's `object_class` is `Post`
-
-#### Scenario: Nested engine class
-
-- **WHEN** a `CamaleonCms::Widget::Main` record builds a meta row
-- **THEN** the row's `object_class` is `Main`
-
-#### Scenario: Namespaced host user model reads its 2.9.2 rows
-
-- **WHEN** a host model `Admin::User` (configured as the `user_model`) builds a meta row
-- **THEN** the row's `object_class` is `User`
-
-#### Scenario: Unnamespaced host class is unchanged
-
-- **WHEN** a top-level host model builds a meta row
-- **THEN** the row's `object_class` is the class name itself
-
-### Requirement: Widget admin surfaces agree with the scope names
-
-The widget admin flows that reference the widget scope by string — the assigned-widget save
-(allowed field slugs lookup) and the field-group caption — SHALL use the same demodulized name
-the association scope produces. A field value submitted for a group placed on a widget MUST save
-and read back; it MUST NOT be silently discarded by a scope-name mismatch (the 2.8.x–2.9.2
-breakage).
-
-#### Scenario: Assigned-widget field value round-trips
-
-- **WHEN** a widget carries a field group with a field, and the admin saves an assigned-widget
-  form submitting a value for that field
-- **THEN** the value is stored and readable back from the assigned widget
+## ADDED Requirements
 
 ### Requirement: User custom-field surfaces agree with the scope names
 
@@ -98,4 +53,3 @@ fields, and MUST be a no-op when the configured user model is not namespaced.
 
 - **WHEN** no namespaced user model is configured and the repair task runs
 - **THEN** no rows change
-

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/specs/meta-scope-resolution/spec.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/specs/meta-scope-resolution/spec.md
@@ -5,9 +5,10 @@
 ### Requirement: User custom-field surfaces agree with the scope names
 
 The user custom-fields flows that reference the user scope by string — the settings form's users
-placement option (where new groups are stored) and the user edit page's field-group read — SHALL
-use the demodulized user-model name the association scope produces (`'User'` for a host
-`Admin::User`, for the engine-default `CamaleonCms::User`, and for a top-level host `User`).
+placement option (where new groups are stored), the user edit page's field-group read, and the
+users save's allowed-slugs filter — SHALL use the demodulized user-model name the association
+scope produces (`'User'` for a host `Admin::User`, for the engine-default `CamaleonCms::User`,
+and for a top-level host `User`).
 A field group placed on users MUST render on the user edit page and MUST have its submitted
 values accepted by the save filter; values MUST NOT be silently discarded by a scope-name
 mismatch between placement, read, and save.
@@ -30,12 +31,20 @@ mismatch between placement, read, and save.
   form submitting a value for that field
 - **THEN** the value is stored and readable back from that user
 
+#### Scenario: Save filter accepts values for a non-User demodulized host model
+
+- **WHEN** the configured user model demodulizes to a name other than `'User'`, a field group
+  is placed on users under that name, and an administrator submits a value for one of its
+  fields
+- **THEN** the value is stored and readable back from that user
+
 ### Requirement: Legacy qualified user placements are repairable
 
 Installs that stored user field groups under a qualified user-model name (the pre-fix placement
 emission) SHALL have a repair task that re-keys those group placements to the demodulized name.
 The task MUST be idempotent, MUST NOT touch rows of other placement classes or the groups'
-fields, and MUST be a no-op when the configured user model is not namespaced.
+fields, and MUST be a no-op when the configured user model is not namespaced. It SHALL report
+the re-keyed count, or the no-op, on standard output.
 
 #### Scenario: Qualified group placement is re-keyed
 

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/tasks.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/tasks.md
@@ -1,0 +1,31 @@
+# Tasks — fix-namespaced-user-field-scope
+
+## 1. Demodulize the user custom-field scope surfaces (commit 1)
+
+- [x] 1.1 Write the red specs: namespaced-host `get_user_field_groups` derivation in
+      `spec/models/meta_scope_resolution_spec.rb`, and the users placement option emission in a
+      new `spec/requests/admin/settings/custom_fields_form_placement_spec.rb` (merged
+      `static_system_info` stub); confirm both fail against current code.
+- [x] 1.2 Fix `get_user_field_groups` (`parseCamaClass.demodulize`) and the form's users option
+      (`PluginRoutes.get_user_class_name.demodulize`); confirm the specs go green.
+- [x] 1.3 Add the green-by-design end-to-end pin `spec/requests/admin/user_field_values_spec.rb`
+      (sibling of the widget round-trip pin): group placed on users, admin saves a field value,
+      value reads back.
+
+## 2. Repair task for legacy qualified placements (commit 2)
+
+- [x] 2.1 Write `spec/lib/tasks/user_field_groups_rake_spec.rb`: re-keys the configured
+      qualified placement, leaves other placements and `_fields` rows untouched, no-op without a
+      namespaced config, re-keyed group becomes visible through `get_user_field_groups`.
+- [x] 2.2 Add `lib/tasks/user_field_groups.rake` (`camaleon_cms:demodulize_user_field_groups`):
+      config-derived key, single idempotent `update_all`, logged summary.
+
+## 3. Verification and delivery
+
+- [x] 3.1 Gates: `bin/rubocop -A` (touched files only, before specs), full `bin/rspec`,
+      `bin/brakeman --no-pager`, `(cd spec/dummy && bin/rails zeitwerk:check)`.
+- [x] 3.2 Archive the OpenSpec change on the branch (syncs the meta-scope-resolution delta) and
+      commit it as part of the PR.
+- [x] 3.3 Push, open the PR, then commit the short changelog entry referencing it (skip-ci
+      directive, per Phase 3).
+- [x] 3.4 Update the regression-audit memory (N5 → done) and the audit doc's fix-plan section.

--- a/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/tasks.md
+++ b/openspec/changes/archive/2026-08-09-fix-namespaced-user-field-scope/tasks.md
@@ -29,3 +29,15 @@
 - [x] 3.3 Push, open the PR, then commit the short changelog entry referencing it (skip-ci
       directive, per Phase 3).
 - [x] 3.4 Update the regression-audit memory (N5 → done) and the audit doc's fix-plan section.
+
+## 4. Branch-review fixes (commits 5–7)
+
+- [x] 4.1 Red spec: user round-trip with a `'SpecHost::Member'` config (the save filter keyed
+      on the `'User'` literal drops the value); key both users controller call sites on
+      `PluginRoutes.get_user_class_name.demodulize`; green.
+- [x] 4.2 Switch the repair task's summary and no-op notice from `Rails.logger.info` to `puts`,
+      red-first via stdout assertions in the task spec.
+- [x] 4.3 Amend the change artifacts (proposal, design, delta + main spec, this file) and the
+      changelog sentence that described the save filter as static; re-run the gates. This push
+      also carries the PR's first CI run — the changelog commit's skip-ci directive at the
+      previous head suppressed the run that should have covered commits 1–4.

--- a/openspec/specs/meta-scope-resolution/spec.md
+++ b/openspec/specs/meta-scope-resolution/spec.md
@@ -50,9 +50,10 @@ breakage).
 ### Requirement: User custom-field surfaces agree with the scope names
 
 The user custom-fields flows that reference the user scope by string — the settings form's users
-placement option (where new groups are stored) and the user edit page's field-group read — SHALL
-use the demodulized user-model name the association scope produces (`'User'` for a host
-`Admin::User`, for the engine-default `CamaleonCms::User`, and for a top-level host `User`).
+placement option (where new groups are stored), the user edit page's field-group read, and the
+users save's allowed-slugs filter — SHALL use the demodulized user-model name the association
+scope produces (`'User'` for a host `Admin::User`, for the engine-default `CamaleonCms::User`,
+and for a top-level host `User`).
 A field group placed on users MUST render on the user edit page and MUST have its submitted
 values accepted by the save filter; values MUST NOT be silently discarded by a scope-name
 mismatch between placement, read, and save.
@@ -75,12 +76,20 @@ mismatch between placement, read, and save.
   form submitting a value for that field
 - **THEN** the value is stored and readable back from that user
 
+#### Scenario: Save filter accepts values for a non-User demodulized host model
+
+- **WHEN** the configured user model demodulizes to a name other than `'User'`, a field group
+  is placed on users under that name, and an administrator submits a value for one of its
+  fields
+- **THEN** the value is stored and readable back from that user
+
 ### Requirement: Legacy qualified user placements are repairable
 
 Installs that stored user field groups under a qualified user-model name (the pre-fix placement
 emission) SHALL have a repair task that re-keys those group placements to the demodulized name.
 The task MUST be idempotent, MUST NOT touch rows of other placement classes or the groups'
-fields, and MUST be a no-op when the configured user model is not namespaced.
+fields, and MUST be a no-op when the configured user model is not namespaced. It SHALL report
+the re-keyed count, or the no-op, on standard output.
 
 #### Scenario: Qualified group placement is re-keyed
 

--- a/spec/lib/tasks/user_field_groups_rake_spec.rb
+++ b/spec/lib/tasks/user_field_groups_rake_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'user_field_groups Rake task', type: :task do
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rails.application.load_tasks
+  end
+
+  after(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    Rake::Task['camaleon_cms:demodulize_user_field_groups'].clear
+  end
+
+  describe 'camaleon_cms:demodulize_user_field_groups' do
+    let(:task) { Rake::Task['camaleon_cms:demodulize_user_field_groups'] }
+    let(:site) { Cama::Site.first }
+
+    before { task.reenable }
+
+    def stub_user_model(name)
+      allow(PluginRoutes).to receive(:static_system_info).and_return(
+        PluginRoutes.static_system_info.merge('user_model' => name)
+      )
+    end
+
+    # Groups were written by the pre-fix settings form under the raw user_model config string;
+    # build them unscoped to keep the spec honest about what it repairs.
+    def create_group(attrs)
+      CamaleonCms::CustomField.unscoped.create!({ name: 'User Group', slug: '_user-group' }.merge(attrs))
+    end
+
+    it 're-keys a group placement stored under the configured qualified name, idempotently' do
+      stub_user_model('Admin::User')
+      group = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
+
+      task.invoke
+
+      expect(group.reload.object_class).to eq('User')
+
+      task.reenable
+      expect { task.invoke }.not_to raise_error
+      expect(group.reload.object_class).to eq('User')
+    end
+
+    it 'makes the re-keyed group readable through the user field-group read again' do
+      stub_user_model('Admin::User')
+      stub_const('Admin::User', Class.new(::CamaleonRecord) { self.table_name = CamaleonCms::User.table_name })
+      Admin::User.include(CamaleonCms::CustomFieldsRead)
+      group = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
+      expect(Admin::User.new.get_user_field_groups(site).map(&:id)).not_to include(group.id)
+
+      task.invoke
+
+      expect(Admin::User.new.get_user_field_groups(site).map(&:id)).to include(group.id)
+    end
+
+    it 'leaves other placements and the group field rows untouched' do
+      stub_user_model('Admin::User')
+      site_group = create_group(object_class: 'Site', objectid: site.id, parent_id: site.id, slug: '_site-group')
+      qualified = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
+      field = CamaleonCms::CustomField.unscoped.create!(
+        name: 'Rating', slug: 'rating', object_class: '_fields', parent_id: qualified.id
+      )
+
+      task.invoke
+
+      expect(site_group.reload.object_class).to eq('Site')
+      expect(field.reload.object_class).to eq('_fields')
+      expect(field.reload.parent_id).to eq(qualified.id)
+    end
+
+    it 'is a no-op when the configured user model is not namespaced' do
+      stray = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
+
+      task.invoke
+
+      expect(stray.reload.object_class).to eq('Admin::User')
+    end
+  end
+end

--- a/spec/lib/tasks/user_field_groups_rake_spec.rb
+++ b/spec/lib/tasks/user_field_groups_rake_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe 'user_field_groups Rake task', type: :task do
       stub_user_model('Admin::User')
       group = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
 
-      task.invoke
+      # Operators run this once from a console; the summary must land on stdout, not in the log.
+      expect { task.invoke }.to output(/Re-keyed 1 user field group\(s\) from 'Admin::User' to 'User'/).to_stdout
 
       expect(group.reload.object_class).to eq('User')
 
@@ -73,7 +74,7 @@ RSpec.describe 'user_field_groups Rake task', type: :task do
     it 'is a no-op when the configured user model is not namespaced' do
       stray = create_group(object_class: 'Admin::User', objectid: site.id, parent_id: site.id)
 
-      task.invoke
+      expect { task.invoke }.to output(/Nothing to re-key/).to_stdout
 
       expect(stray.reload.object_class).to eq('Admin::User')
     end

--- a/spec/models/meta_scope_resolution_spec.rb
+++ b/spec/models/meta_scope_resolution_spec.rb
@@ -31,4 +31,32 @@ RSpec.describe 'Meta scope resolution', type: :model do
 
     expect(SpecMember.new.metas.build.object_class).to eq('SpecMember')
   end
+
+  describe '#get_user_field_groups' do
+    let(:site) { Cama::Site.first }
+
+    # The user-page read must query the same demodulized name the association scope and the
+    # save filter use — a qualified name here is how namespaced-host installs lost their
+    # user field values (audit N5).
+    it 'derives the demodulized name for a namespaced host user model' do
+      stub_const('SpecHost::Member', host_class)
+      SpecHost::Member.include(CamaleonCms::CustomFieldsRead)
+
+      expect(SpecHost::Member.new.get_user_field_groups(site).new.object_class).to eq('Member')
+    end
+
+    it 'finds groups placed on users under the demodulized name' do
+      stub_const('SpecHost::Member', host_class)
+      SpecHost::Member.include(CamaleonCms::CustomFieldsRead)
+      group = site.custom_field_groups.create!(
+        name: 'Member Fields', slug: '_member-fields', object_class: 'Member', objectid: site.id
+      )
+
+      expect(SpecHost::Member.new.get_user_field_groups(site).map(&:id)).to include(group.id)
+    end
+
+    it 'keeps the engine user model on User' do
+      expect(CamaleonCms::User.new.get_user_field_groups(site).new.object_class).to eq('User')
+    end
+  end
 end

--- a/spec/requests/admin/settings/custom_fields_form_placement_spec.rb
+++ b/spec/requests/admin/settings/custom_fields_form_placement_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin custom fields form: users placement option', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    sign_in_as(admin, site: current_site)
+  end
+
+  # The users option's value is the placement every user field group is stored under. Emitting
+  # the raw user_model config here is how namespaced-host installs ended up with groups the
+  # demodulized save filter cannot see (audit N5).
+  it 'emits the demodulized name for a namespaced host user model' do
+    allow(PluginRoutes).to receive(:static_system_info).and_return(
+      PluginRoutes.static_system_info.merge('user_model' => 'Admin::User')
+    )
+
+    get '/admin/settings/custom_fields/new'
+
+    expect(response.body).to include("value=\"User,#{current_site.id}\"")
+    expect(response.body).not_to include('Admin::User')
+  end
+
+  it 'emits User for the engine-default user model' do
+    get '/admin/settings/custom_fields/new'
+
+    expect(response.body).to include("value=\"User,#{current_site.id}\"")
+  end
+end

--- a/spec/requests/admin/user_field_values_spec.rb
+++ b/spec/requests/admin/user_field_values_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Admin user custom field values', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+  let(:member) { create(:user, role: 'client', site: current_site) }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    group = current_site.custom_field_groups.create!(
+      name: 'User Fields', slug: '_user-fields', object_class: 'User', objectid: current_site.id
+    )
+    @color_field = group.add_manual_field({ name: 'Color', slug: 'color' }, { field_key: 'text_box' })
+    sign_in_as(admin, site: current_site)
+  end
+
+  # Sibling of the widget round-trip pin: the users save asks for allowed field slugs under the
+  # 'User' literal while the group's placement comes from the settings form and the read from
+  # get_user_field_groups — green only while all of them agree, red on any one-sided rename.
+  it 'saves a user field value through the group placed on users' do
+    patch "/admin/users/#{member.id}", params: {
+      user: { username: member.username, email: member.email },
+      field_options: { '0' => { 'color' => { 'id' => @color_field.id.to_s, 'values' => { '0' => 'red' } } } }
+    }
+
+    expect(response).to have_http_status(:found)
+    expect(member.reload.get_field_value('color')).to eq('red')
+  end
+end

--- a/spec/requests/admin/user_field_values_spec.rb
+++ b/spec/requests/admin/user_field_values_spec.rb
@@ -30,4 +30,25 @@ RSpec.describe 'Admin user custom field values', type: :request do
     expect(response).to have_http_status(:found)
     expect(member.reload.get_field_value('color')).to eq('red')
   end
+
+  # The save filter must key its allowed-slugs lookup on the same demodulized name the settings
+  # form emits and get_user_field_groups queries: keyed on a hardcoded 'User' it finds no groups
+  # for a host model that demodulizes to another name, and every submitted value is dropped.
+  it 'accepts values for a host user model that demodulizes to a non-User name' do
+    allow(PluginRoutes).to receive(:static_system_info).and_return(
+      PluginRoutes.static_system_info.merge('user_model' => 'SpecHost::Member')
+    )
+    group = current_site.custom_field_groups.create!(
+      name: 'Member Fields', slug: '_member-fields', object_class: 'Member', objectid: current_site.id
+    )
+    tier_field = group.add_manual_field({ name: 'Tier', slug: 'tier' }, { field_key: 'text_box' })
+
+    patch "/admin/users/#{member.id}", params: {
+      user: { username: member.username, email: member.email },
+      field_options: { '0' => { 'tier' => { 'id' => tier_field.id.to_s, 'values' => { '0' => 'gold' } } } }
+    }
+
+    expect(response).to have_http_status(:found)
+    expect(member.reload.get_field_value('tier')).to eq('gold')
+  end
 end


### PR DESCRIPTION
## What and Why

For a host app that configures a **namespaced user model** (`user_model: 'Admin::User'`), the user custom-fields feature has silently discarded every submitted value since 2.9.2 (regression audit N5). Three surfaces disagreed on the scope name: the settings form emitted the raw config string as the users placement option and the user edit page read groups back the same way (both since the v1.0-era codebase), while the association scope and the users controller's allowed-slugs literal both use the demodulized `'User'` (the contract at every released version, pinned by the `meta-scope-resolution` capability in #1238). Through 2.9.1 the dual naming was harmless because the save path was unfiltered; the 2.9.2 mass-assignment hardening keys allowed slugs on `'User'`, finds no qualified groups, and drops the values — the same write/read joint anatomy as the widget fix in #1238.

This PR aligns the two qualified surfaces on the demodulized contract:

- `get_user_field_groups` derives its placement query with `parseCamaClass.demodulize` (keeping the Draper `Decorator` strip).
- The settings form's users placement option emits `PluginRoutes.get_user_class_name.demodulize`.
- A new idempotent repair task, `camaleon_cms:demodulize_user_field_groups`, re-keys group placements stored under the previously emitted qualified name. Groups only: fields hang off `parent_id` under `'_fields'`, group metas key off `'CustomFieldGroup'`, and value rows were always written demodulized (≤2.9.1) or never written (2.9.2). It is keyed to the current config and is a no-op when `user_model` is blank or already demodulized.

The namespaced read and the form emission are pinned by repro-first specs (proven red against the previous code), and a user field-value round-trip request spec — the sibling of #1238's widget pin — guards the whole joint era-portably. The archived OpenSpec change extends the `meta-scope-resolution` capability with the user-surfaces and repair-task requirements. An ecosystem sweep found zero external consumers of `get_user_field_groups`.

## User-Visible Impact

Hosts with a namespaced `user_model` get working user custom fields again (groups render and submitted values save) after running the one-time repair task; engine-default and top-level `User` installs see no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
