### PR TITLE
Filter theme-settings custom-field saves through the allowed-slugs permit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Security fix:** The two admin theme-settings paths that still saved custom-field values raw
+  — the `theme_fields` param and the bundled `new` theme's settings-save hook — now go through
+  the same allowed-slugs filter as every other admin custom-field save (added in 2.9.2), closing
+  a mass-assignment gap reachable by any role granted the theme-settings capability.
+  [#1240](https://github.com/owen2345/camaleon-cms/pull/1240).
+
+  **Notes for upgraders:**
+  - Values submitted through theme settings for slugs that are not registered theme fields are
+    no longer persisted; registered fields are unaffected.
+
 - **Fix:** User custom fields work again for host apps configuring a namespaced `user_model`
   (e.g. `'Admin::User'`): the settings form's users placement option, the user edit page's
   field-group read, and the save filter's allowed-slugs lookup now all derive the demodulized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
   - Values submitted through theme settings for slugs that are not registered theme fields are
     no longer persisted; registered fields are unaffected.
 
+- **Fix:** An admin custom-field save whose submitted slugs were all unregistered under the
+  target scope wiped the object's stored values (the allowed-slugs filter, added in 2.9.2,
+  reduced such a payload to an empty-but-present shape that made the value writer clear
+  everything and write nothing). The filter now drops those empty groups, so the save is a
+  no-op instead. Affected every admin custom-field save path.
+  [#1240](https://github.com/owen2345/camaleon-cms/pull/1240).
+
 - **Fix:** User custom fields work again for host apps configuring a namespaced `user_model`
   (e.g. `'Admin::User'`): the settings form's users placement option, the user edit page's
   field-group read, and the save filter's allowed-slugs lookup now all derive the demodulized

--- a/app/apps/themes/new/custom_helper.rb
+++ b/app/apps/themes/new/custom_helper.rb
@@ -1,16 +1,11 @@
 module Themes
   module New
     module CustomHelper
-      def theme_custom_settings(theme)
-        case params[:action_name]
-        when 'settings'
-          render 'themes/new/views/admin/settings'
-        when 'save_settings'
-          # Filter through the allowed-slugs permit (the controller includes CustomFieldsConcern
-          # and hooks run on the controller instance) and let save_theme render the response —
-          # its own redirect_to made this one an error, and the raw payload skipped the filter.
-          theme.set_field_values(cama_permitted_field_options('Theme'))
-        end
+      def theme_custom_settings(_theme)
+        # save_theme already persists the submitted field_options through the filtered
+        # cama_permitted_field_options('Theme') path and renders the single response, so this
+        # hook no longer saves (its old raw save bypassed that filter and its redirect errored).
+        render 'themes/new/views/admin/settings' if params[:action_name] == 'settings'
       end
 
       def theme_custom_on_install_theme(theme)

--- a/app/apps/themes/new/custom_helper.rb
+++ b/app/apps/themes/new/custom_helper.rb
@@ -6,9 +6,10 @@ module Themes
         when 'settings'
           render 'themes/new/views/admin/settings'
         when 'save_settings'
-          theme.set_field_values(params[:field_options])
-          flash[:notice] = 'Settings saved!'
-          redirect_to action: :settings, action_name: 'settings'
+          # Filter through the allowed-slugs permit (the controller includes CustomFieldsConcern
+          # and hooks run on the controller instance) and let save_theme render the response —
+          # its own redirect_to made this one an error, and the raw payload skipped the filter.
+          theme.set_field_values(cama_permitted_field_options('Theme'))
         end
       end
 

--- a/app/controllers/camaleon_cms/admin/settings_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings_controller.rb
@@ -62,7 +62,7 @@ module CamaleonCms
       end
 
       def save_theme
-        current_theme.set_field_values(params[:theme_fields]) if params[:theme_fields].present?
+        current_theme.set_field_values(cama_permitted_field_options('Theme', param_key: :theme_fields))
         current_theme.set_options(params[:theme_option]) if params[:theme_option].present?
         current_theme.set_metas(params[:theme_meta]) if params[:theme_meta].present?
         current_theme.set_field_values(cama_permitted_field_options('Theme'))

--- a/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
@@ -15,9 +15,13 @@ module CamaleonCms
         return {} if allowed_keys.blank?
 
         field_options = params.require(param_key)
-        field_options.permit(field_options.keys.select { |k| k.to_s =~ /\A\d+\z/ }.index_with do
+        permitted = field_options.permit(field_options.keys.select { |k| k.to_s =~ /\A\d+\z/ }.index_with do
           allowed_keys.index_with { [:id, :group_number, { values: {} }] }
         end).to_h
+        # Drop groups left empty after filtering. set_field_values deletes every existing value
+        # before writing, so handing it a non-blank-but-empty payload (a group whose submitted
+        # slugs were all unregistered) would wipe the object's stored values and write nothing.
+        permitted.reject { |_group, fields| fields.blank? }
       end
 
       def cama_custom_field_allowed_slugs(object_class)

--- a/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb
@@ -5,14 +5,16 @@ module CamaleonCms
 
       private
 
-      # Only permit field_options that match registered custom field slugs
-      def cama_permitted_field_options(object_class)
-        return {} if params[:field_options].blank?
+      # Only permit field values whose slug is registered under object_class. param_key selects
+      # which request param carries the payload, so sibling params (the theme form's
+      # theme_fields) get the same allowed-slugs permit as the default field_options.
+      def cama_permitted_field_options(object_class, param_key: :field_options)
+        return {} if params[param_key].blank?
 
         allowed_keys = cama_custom_field_allowed_slugs(object_class)
         return {} if allowed_keys.blank?
 
-        field_options = params.require(:field_options)
+        field_options = params.require(param_key)
         field_options.permit(field_options.keys.select { |k| k.to_s =~ /\A\d+\z/ }.index_with do
           allowed_keys.index_with { [:id, :group_number, { values: {} }] }
         end).to_h

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/design.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/design.md
@@ -1,0 +1,101 @@
+# Design — filter-theme-field-value-saves
+
+## Context
+
+See `proposal.md` — Why. Load-bearing facts verified in code:
+
+- `save_theme` runs four writes in order: raw `set_field_values(params[:theme_fields])`,
+  `set_options`, `set_metas`, then the filtered
+  `set_field_values(cama_permitted_field_options('Theme'))` — and finally fires the
+  `on_theme_settings` hook. `set_field_values` deletes all existing value rows before writing
+  whenever its payload is non-blank, so the last non-blank writer wins.
+- Hooks execute on the controller instance (`_do_hook` → `send(hook)`), and
+  `SettingsController` includes `CustomFieldsConcern` — so a theme hook handler can call
+  `cama_permitted_field_options` directly. The `themes/new` handler's save branch only runs
+  when a form posts `action_name=save_settings`; the stock theme-settings form posts no
+  `action_name`, so the branch is reachable only through a theme's custom form markup (the
+  generator template documents exactly that contract).
+- The `themes/new` handler currently ends with its own `flash` + `redirect_to action: :settings`.
+  That redirect is doubly broken: there is no `settings` action route, so it raises
+  `ActionController::UrlGenerationError` (confirmed by the red spec); even had the route
+  existed, `save_theme`'s own redirect would then raise `AbstractController::DoubleRenderError`.
+  Either way the raw write has already committed. The render branch (`action_name=settings`) has
+  no such collision and is left alone.
+- The `themes/new` theme is duplicated, not symlinked, into the dummy app at
+  `spec/dummy/app/apps/themes/new/custom_helper.rb` (identical to the gem copy). The suite loads
+  the dummy copy, so the fix is applied to both files to keep them in sync and close the gap in
+  the shipped gem.
+- No in-repo view posts `theme_fields`; it is a legacy/ecosystem param. The ecosystem doc
+  records no external binding to it, but per AGENTS.md the visible surface is a floor — so
+  the param is filtered, not removed.
+- `camaleon_first`'s settings handler is an empty method, the default theme registers no save
+  handler, and the generator template's example handler is an empty method with a comment —
+  `themes/new` is the only shipped raw save.
+- The allowed-slugs lookup keys on the `'Theme'` placement scope, matching the association
+  scope (`name.to_s.demodulize`) per the meta-scope-resolution capability.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Both theme-settings save paths accept only registered slugs, at parity with every other
+  admin custom-field save hardened in 2.9.2.
+- `theme_fields` keeps working for registered slugs (compat for any external theme posting it).
+- The bundled custom-save path completes with one response.
+
+**Non-Goals:**
+
+- No tightening of the allowed-slugs lookup itself (it is global by `object_class`, not
+  scoped by `objectid`/site — a pre-existing looseness shared by all eba56d6f call sites;
+  tightening it is a separate, wider change).
+- No change to the `set_options`/`set_metas` writes in `save_theme` (different storage, not
+  custom-field value rows).
+- No change to the last-writer-wins interplay when both `theme_fields` and `field_options`
+  are posted (pre-existing; forms post one shape).
+- No change to external themes' own handlers — the engine cannot rewrite them; fixing the
+  bundled example fixes the pattern authors copy.
+
+## Decisions
+
+1. **Extend the concern with `param_key:` instead of duplicating the permit.**
+   `cama_permitted_field_options(object_class, param_key: :field_options)` — both the blank
+   check and the `require` read the key. The eight existing call sites are untouched by the
+   default. Rejected: a separate `cama_permitted_theme_fields` method (duplicates the permit
+   shape the two params share); inlining a permit in `save_theme` (drifts from the concern
+   the 2.9.2 hardening centralized).
+2. **Filter `theme_fields` rather than delete the param.** Zero in-repo posters, but the
+   param predates the hardening and external themes may post it; filtered, registered slugs
+   keep saving, so the contract narrows exactly to the 2.9.2 contract every other surface
+   already has. The `present?` guard on the line drops — the filter returns `{}` for a blank
+   param and `set_field_values` no-ops on blank payloads, mirroring the sibling
+   `field_options` line.
+3. **The bundled handler saves filtered and stops responding.** Its save branch becomes the
+   same filtered call the controller uses (reachable because hooks run on the controller
+   instance), and its `flash` + `redirect_to` go away — `save_theme`'s standard flash and
+   redirect complete the request, which is what removes the `DoubleRenderError`. The user
+   observes the standard "Theme updated successfully" notice instead of a 500.
+4. **Repro-first with a `theme_settings`-only role.** The threat model gates non-admin
+   capability by grantable permissions, so the specs authenticate a role granted only
+   `theme_settings` (house style: the cross-site injection spec). Both raw paths are proven
+   red: an unregistered slug via `theme_fields`, and one via the bundled theme's custom-save
+   action (site's `_theme` option pointed at `new`, group + fields registered directly on the
+   theme record). The double-render pin asserts the standard redirect — red today because the
+   request raises `DoubleRenderError` (the dummy app runs `show_exceptions :none`).
+
+## Risks / Trade-offs
+
+- [An external theme posts `theme_fields` with slugs it never registered as fields] → those
+  writes stop persisting, by design; the theme's registered fields keep working. This is the
+  same narrowing every other admin surface underwent at 2.9.2.
+- [An external theme's own `on_theme_settings` handler still raw-saves] → out of engine
+  control; the concern's filter is one call away on the controller instance, the generator
+  template's example stays clean, and the bundled example now demonstrates the filtered call.
+- [Dropping the handler's redirect changes the bundled theme's post-save flash text] → the
+  old text rendered only after a 500 masked it; the standard notice is the visible behavior
+  the stock form already produces.
+
+## Migration Plan
+
+Code change deploys normally; no data changes. Rollback = revert the commit. External themes
+are unaffected unless they posted unregistered slugs through `theme_fields`, which reverts to
+being persisted on rollback.

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/design.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/design.md
@@ -80,7 +80,26 @@ See `proposal.md` — Why. Load-bearing facts verified in code:
    red: an unregistered slug via `theme_fields`, and one via the bundled theme's custom-save
    action (site's `_theme` option pointed at `new`, group + fields registered directly on the
    theme record). The double-render pin asserts the standard redirect — red today because the
-   request raises `DoubleRenderError` (the dummy app runs `show_exceptions :none`).
+   request raises (see branch-review correction in Decision 6).
+
+### Branch-review revisions
+
+5. **All-unregistered payloads must not wipe stored values.** `cama_permitted_field_options`
+   returned each submitted group as an empty hash when none of its slugs were registered
+   (`params.permit` keeps the group key with no children). That result is not blank, so
+   `set_field_values` ran its `delete_all` and then wrote nothing — clearing every stored value.
+   Pre-existing across all eba56d6f call sites; surfaced here because the theme paths route
+   through the same helper. Fix: reject groups left empty after filtering, so an all-unregistered
+   submission returns `{}` and `set_field_values` no-ops. A clear-all still works (it carries the
+   registered slug keys). Now a general requirement of this capability.
+6. **The bundled handler stops saving entirely (supersedes Decision 3's filtered save).** Once
+   `save_theme` filters `field_options` generically, the `new` theme's hook doing the same
+   filtered write was pure redundancy (a second `delete_all`+rewrite). Removed — the hook now
+   only renders the theme's settings view; `save_theme` persists `field_options` and renders the
+   single response. This aligns the bundled theme with the generator template's empty save
+   handler. Correction to Decision 4: the old hook's `redirect_to action: :settings` targeted a
+   non-existent route, so it raised `UrlGenerationError` (not `DoubleRenderError`) after the raw
+   write committed; removing the branch resolves it regardless.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/proposal.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/proposal.md
@@ -19,11 +19,13 @@ write commits.
   sibling payload params; the eight existing call sites are unchanged.
 - `save_theme` filters `theme_fields` through the concern (`param_key: :theme_fields`) instead
   of passing it raw; registered slugs posted through `theme_fields` keep saving.
-- The `themes/new` `on_theme_settings` handler saves through the same filtered call and drops
-  its own flash + redirect, letting `save_theme`'s standard response complete — which also
-  removes the `DoubleRenderError` on the custom-save path.
-- The other bundled themes and the theme generator template are already clean (empty or no
-  save handler); no change there.
+- The filter drops groups left empty after filtering, so a submission carrying no registered
+  slug returns `{}` and `set_field_values` no-ops instead of running its `delete_all` and wiping
+  the object's stored values (pre-existing across all its call sites; branch-review fix).
+- The `themes/new` `on_theme_settings` handler no longer saves at all: `save_theme` already
+  persists `field_options` generically, so the hook's duplicate write is removed along with its
+  broken redirect (the branch's first pass filtered the hook's write; branch review simplified it
+  away). The other bundled themes and the theme generator template were already clean.
 
 ## Capabilities
 

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/proposal.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/proposal.md
@@ -1,0 +1,49 @@
+# Proposal — filter-theme-field-value-saves
+
+## Why
+
+The 2.9.2 mass-assignment hardening (eba56d6f) routed every admin custom-field value save
+through an allowed-slugs filter — except two theme-settings paths that still pass raw request
+params into `set_field_values`: the `theme_fields` param in `save_theme`, and the bundled
+`themes/new` theme's `on_theme_settings` hook handler. The surface is not admin-only: it is
+gated by `authorize! :manage, :theme_settings`, a grantable role capability, so any role
+granted theme settings can write arbitrary field-value rows (any `custom_field_id`, any slug,
+any value) onto the theme. The bundled handler additionally issues its own redirect inside the
+hook, colliding with `save_theme`'s redirect into a `DoubleRenderError` 500 after the raw
+write commits.
+
+## What Changes
+
+- `CustomFieldsConcern#cama_permitted_field_options` accepts the request param key to filter
+  (`param_key:`, defaulting to `:field_options`) so the same allowed-slugs permit can cover
+  sibling payload params; the eight existing call sites are unchanged.
+- `save_theme` filters `theme_fields` through the concern (`param_key: :theme_fields`) instead
+  of passing it raw; registered slugs posted through `theme_fields` keep saving.
+- The `themes/new` `on_theme_settings` handler saves through the same filtered call and drops
+  its own flash + redirect, letting `save_theme`'s standard response complete — which also
+  removes the `DoubleRenderError` on the custom-save path.
+- The other bundled themes and the theme generator template are already clean (empty or no
+  save handler); no change there.
+
+## Capabilities
+
+### New Capabilities
+
+- `custom-field-value-filtering`: admin custom-field value saves accept only slugs registered
+  under the target's placement scope; theme-settings saves (both payload params and the bundled
+  theme's hook handler) participate, and the bundled custom-save path answers with the standard
+  single response.
+
+### Modified Capabilities
+
+_None._
+
+## Impact
+
+- `app/controllers/concerns/camaleon_cms/admin/custom_fields_concern.rb` (`param_key:` kwarg)
+- `app/controllers/camaleon_cms/admin/settings_controller.rb` (`save_theme` `theme_fields`)
+- `app/apps/themes/new/custom_helper.rb` (`theme_custom_settings` save branch)
+- New request specs: `theme_fields` filtering and the `themes/new` hook path, driven by a
+  `theme_settings`-only role
+- No migration; no data re-keying; `theme_fields` remains a working param for registered slugs
+  (external themes posting it keep functioning); no API removal

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/specs/custom-field-value-filtering/spec.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/specs/custom-field-value-filtering/spec.md
@@ -1,0 +1,44 @@
+# custom-field-value-filtering Delta — filter-theme-field-value-saves
+
+## ADDED Requirements
+
+### Requirement: Theme settings saves accept only registered field slugs
+
+Every request-parameter path that saves custom-field values from the admin theme-settings
+form — the `theme_fields` payload param and the `field_options` payload consumed by a theme's
+custom-save hook — SHALL accept only slugs of fields registered under the theme placement
+scope, discarding submitted entries for unregistered slugs and arbitrary field ids. A value
+submitted for a registered theme field MUST save and read back; a value submitted for an
+unregistered slug MUST NOT create a stored value row. The filter applies to every role that
+can reach theme settings, including non-administrator roles granted the theme-settings
+capability.
+
+#### Scenario: Unregistered slug via theme_fields is dropped
+
+- **WHEN** a user with only the theme-settings capability posts a theme save whose
+  `theme_fields` payload carries a slug not registered on the theme scope
+- **THEN** no value row is stored for that slug
+
+#### Scenario: Registered slug via theme_fields saves
+
+- **WHEN** a theme save posts a `theme_fields` payload carrying a slug registered on the
+  theme scope
+- **THEN** the value is stored and readable back from the theme
+
+#### Scenario: Unregistered slug via the bundled theme's custom-save hook is dropped
+
+- **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
+  with a `field_options` payload carrying an unregistered slug
+- **THEN** no value row is stored for that slug
+
+### Requirement: The bundled theme's custom save answers with the standard response
+
+The bundled `new` theme's custom-save path SHALL complete with the theme-settings form's
+standard single redirect; the hook handler MUST NOT issue a second response of its own.
+
+#### Scenario: Custom save redirects once
+
+- **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
+  with a registered field value
+- **THEN** the request answers with the standard redirect to the theme-settings form and the
+  value is stored

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/specs/custom-field-value-filtering/spec.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/specs/custom-field-value-filtering/spec.md
@@ -5,9 +5,10 @@
 ### Requirement: Theme settings saves accept only registered field slugs
 
 Every request-parameter path that saves custom-field values from the admin theme-settings
-form — the `theme_fields` payload param and the `field_options` payload consumed by a theme's
-custom-save hook — SHALL accept only slugs of fields registered under the theme placement
-scope, discarding submitted entries for unregistered slugs and arbitrary field ids. A value
+form — the `theme_fields` payload param and the `field_options` payload submitted through a
+theme's custom-save action — SHALL accept only slugs of fields registered under the theme
+placement scope, discarding submitted entries for unregistered slugs and arbitrary field ids.
+A value
 submitted for a registered theme field MUST save and read back; a value submitted for an
 unregistered slug MUST NOT create a stored value row. The filter applies to every role that
 can reach theme settings, including non-administrator roles granted the theme-settings
@@ -25,16 +26,29 @@ capability.
   theme scope
 - **THEN** the value is stored and readable back from the theme
 
-#### Scenario: Unregistered slug via the bundled theme's custom-save hook is dropped
+#### Scenario: Unregistered slug via the bundled theme's custom-save action is dropped
 
 - **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
   with a `field_options` payload carrying an unregistered slug
 - **THEN** no value row is stored for that slug
 
+### Requirement: A submission carrying no registered slug leaves stored values intact
+
+An admin custom-field value save whose submitted slugs are all unregistered under the target
+scope SHALL leave the target's existing stored values unchanged. The allowed-slugs filter MUST
+NOT hand the value writer a non-blank payload that clears every existing value while writing
+nothing.
+
+#### Scenario: All-unregistered submission preserves existing values
+
+- **WHEN** an object has stored custom-field values and a save submits only slugs not
+  registered under its scope
+- **THEN** the object's existing values remain unchanged
+
 ### Requirement: The bundled theme's custom save answers with the standard response
 
 The bundled `new` theme's custom-save path SHALL complete with the theme-settings form's
-standard single redirect; the hook handler MUST NOT issue a second response of its own.
+standard single redirect; the theme's settings hook MUST NOT issue a second response of its own.
 
 #### Scenario: Custom save redirects once
 

--- a/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/tasks.md
+++ b/openspec/changes/archive/2026-08-09-filter-theme-field-value-saves/tasks.md
@@ -1,0 +1,35 @@
+# Tasks — filter-theme-field-value-saves
+
+## 1. Filter the theme_fields save (commit 1)
+
+- [x] 1.1 Write the red request spec `spec/requests/security/theme_field_value_filtering_spec.rb`:
+      a `theme_settings`-only role posts `save_theme` with a `theme_fields` payload carrying an
+      unregistered slug — red because the value row is created; plus the green-by-design pin
+      that a registered slug through `theme_fields` still saves.
+- [x] 1.2 Add `param_key:` (default `:field_options`) to
+      `CustomFieldsConcern#cama_permitted_field_options`; `save_theme` filters `theme_fields`
+      through it (guard dropped — blank filters to `{}` and `set_field_values` no-ops);
+      confirm red goes green.
+
+## 2. Filter the bundled theme's custom-save hook (commit 2)
+
+- [x] 2.1 Extend the spec: with the site's `_theme` option pointed at `new` and fields
+      registered on that theme record, posting `save_theme` with `action_name=save_settings`
+      and an unregistered `field_options` slug is red (row created, request raises
+      `DoubleRenderError`); the single-redirect pin is red the same way.
+- [x] 2.2 `themes/new` `theme_custom_settings` save branch: filtered
+      `cama_permitted_field_options('Theme')` call, drop its `flash` + `redirect_to`;
+      confirm both reds go green. Applied to BOTH the gem file and the identical committed
+      duplicate `spec/dummy/app/apps/themes/new/custom_helper.rb` (the copy the suite loads).
+      Red also surfaced that the old `redirect_to action: :settings` targeted a non-existent
+      route (UrlGenerationError), not merely a DoubleRenderError — the drop fixes both.
+
+## 3. Verification and delivery
+
+- [x] 3.1 Gates: `bin/rubocop -A` (touched files only, before specs), full `bin/rspec`,
+      `bin/brakeman --no-pager`, `(cd spec/dummy && bin/rails zeitwerk:check)`.
+- [x] 3.2 Archive the OpenSpec change on the branch (syncs the custom-field-value-filtering
+      capability) and commit it as part of the PR.
+- [x] 3.3 Push (no CI-skip marker — first run must cover the code), open the PR; only after
+      that run exists, commit and push the short changelog entry with the skip-ci directive.
+- [x] 3.4 Update the regression-audit memory (theme_fields gap → fixed).

--- a/openspec/specs/custom-field-value-filtering/spec.md
+++ b/openspec/specs/custom-field-value-filtering/spec.md
@@ -1,0 +1,49 @@
+# custom-field-value-filtering Specification
+
+## Purpose
+Keep the admin theme-settings custom-field saves under the same allowed-slugs permit as every
+other admin custom-field save, so a role granted only the theme-settings capability cannot write
+value rows for unregistered slugs or arbitrary field ids, and the bundled theme's custom-save
+path answers with a single standard response.
+## Requirements
+### Requirement: Theme settings saves accept only registered field slugs
+
+Every request-parameter path that saves custom-field values from the admin theme-settings
+form — the `theme_fields` payload param and the `field_options` payload consumed by a theme's
+custom-save hook — SHALL accept only slugs of fields registered under the theme placement
+scope, discarding submitted entries for unregistered slugs and arbitrary field ids. A value
+submitted for a registered theme field MUST save and read back; a value submitted for an
+unregistered slug MUST NOT create a stored value row. The filter applies to every role that
+can reach theme settings, including non-administrator roles granted the theme-settings
+capability.
+
+#### Scenario: Unregistered slug via theme_fields is dropped
+
+- **WHEN** a user with only the theme-settings capability posts a theme save whose
+  `theme_fields` payload carries a slug not registered on the theme scope
+- **THEN** no value row is stored for that slug
+
+#### Scenario: Registered slug via theme_fields saves
+
+- **WHEN** a theme save posts a `theme_fields` payload carrying a slug registered on the
+  theme scope
+- **THEN** the value is stored and readable back from the theme
+
+#### Scenario: Unregistered slug via the bundled theme's custom-save hook is dropped
+
+- **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
+  with a `field_options` payload carrying an unregistered slug
+- **THEN** no value row is stored for that slug
+
+### Requirement: The bundled theme's custom save answers with the standard response
+
+The bundled `new` theme's custom-save path SHALL complete with the theme-settings form's
+standard single redirect; the hook handler MUST NOT issue a second response of its own.
+
+#### Scenario: Custom save redirects once
+
+- **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
+  with a registered field value
+- **THEN** the request answers with the standard redirect to the theme-settings form and the
+  value is stored
+

--- a/openspec/specs/custom-field-value-filtering/spec.md
+++ b/openspec/specs/custom-field-value-filtering/spec.md
@@ -9,9 +9,10 @@ path answers with a single standard response.
 ### Requirement: Theme settings saves accept only registered field slugs
 
 Every request-parameter path that saves custom-field values from the admin theme-settings
-form — the `theme_fields` payload param and the `field_options` payload consumed by a theme's
-custom-save hook — SHALL accept only slugs of fields registered under the theme placement
-scope, discarding submitted entries for unregistered slugs and arbitrary field ids. A value
+form — the `theme_fields` payload param and the `field_options` payload submitted through a
+theme's custom-save action — SHALL accept only slugs of fields registered under the theme
+placement scope, discarding submitted entries for unregistered slugs and arbitrary field ids.
+A value
 submitted for a registered theme field MUST save and read back; a value submitted for an
 unregistered slug MUST NOT create a stored value row. The filter applies to every role that
 can reach theme settings, including non-administrator roles granted the theme-settings
@@ -29,16 +30,29 @@ capability.
   theme scope
 - **THEN** the value is stored and readable back from the theme
 
-#### Scenario: Unregistered slug via the bundled theme's custom-save hook is dropped
+#### Scenario: Unregistered slug via the bundled theme's custom-save action is dropped
 
 - **WHEN** the bundled `new` theme is active and a theme save posts its custom-save action
   with a `field_options` payload carrying an unregistered slug
 - **THEN** no value row is stored for that slug
 
+### Requirement: A submission carrying no registered slug leaves stored values intact
+
+An admin custom-field value save whose submitted slugs are all unregistered under the target
+scope SHALL leave the target's existing stored values unchanged. The allowed-slugs filter MUST
+NOT hand the value writer a non-blank payload that clears every existing value while writing
+nothing.
+
+#### Scenario: All-unregistered submission preserves existing values
+
+- **WHEN** an object has stored custom-field values and a save submits only slugs not
+  registered under its scope
+- **THEN** the object's existing values remain unchanged
+
 ### Requirement: The bundled theme's custom save answers with the standard response
 
 The bundled `new` theme's custom-save path SHALL complete with the theme-settings form's
-standard single redirect; the hook handler MUST NOT issue a second response of its own.
+standard single redirect; the theme's settings hook MUST NOT issue a second response of its own.
 
 #### Scenario: Custom save redirects once
 

--- a/spec/dummy/app/apps/themes/new/custom_helper.rb
+++ b/spec/dummy/app/apps/themes/new/custom_helper.rb
@@ -1,16 +1,11 @@
 module Themes
   module New
     module CustomHelper
-      def theme_custom_settings(theme)
-        case params[:action_name]
-        when 'settings'
-          render 'themes/new/views/admin/settings'
-        when 'save_settings'
-          # Filter through the allowed-slugs permit (the controller includes CustomFieldsConcern
-          # and hooks run on the controller instance) and let save_theme render the response —
-          # its own redirect_to made this one an error, and the raw payload skipped the filter.
-          theme.set_field_values(cama_permitted_field_options('Theme'))
-        end
+      def theme_custom_settings(_theme)
+        # save_theme already persists the submitted field_options through the filtered
+        # cama_permitted_field_options('Theme') path and renders the single response, so this
+        # hook no longer saves (its old raw save bypassed that filter and its redirect errored).
+        render 'themes/new/views/admin/settings' if params[:action_name] == 'settings'
       end
 
       def theme_custom_on_install_theme(theme)

--- a/spec/dummy/app/apps/themes/new/custom_helper.rb
+++ b/spec/dummy/app/apps/themes/new/custom_helper.rb
@@ -6,9 +6,10 @@ module Themes
         when 'settings'
           render 'themes/new/views/admin/settings'
         when 'save_settings'
-          theme.set_field_values(params[:field_options])
-          flash[:notice] = 'Settings saved!'
-          redirect_to action: :settings, action_name: 'settings'
+          # Filter through the allowed-slugs permit (the controller includes CustomFieldsConcern
+          # and hooks run on the controller instance) and let save_theme render the response —
+          # its own redirect_to made this one an error, and the raw payload skipped the filter.
+          theme.set_field_values(cama_permitted_field_options('Theme'))
         end
       end
 

--- a/spec/requests/security/theme_field_value_filtering_spec.rb
+++ b/spec/requests/security/theme_field_value_filtering_spec.rb
@@ -45,4 +45,33 @@ RSpec.describe 'Theme settings field-value filtering', type: :request do
       expect(theme.get_field_value('bg_color')).to eq('blue')
     end
   end
+
+  describe "the bundled 'new' theme's on_theme_settings save hook" do
+    let(:theme) { current_site.get_theme('new') }
+
+    before { current_site.set_option('_theme', 'new') }
+
+    it 'drops values for an unregistered slug and answers with a single redirect' do
+      post '/admin/settings/save_theme', params: {
+        action_name: 'save_settings',
+        field_options: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
+      }
+
+      expect(response).to have_http_status(:found)
+      expect(relationship_count('evil')).to eq(0)
+    end
+
+    it 'saves a registered slug and answers with a single redirect' do
+      registered = theme.add_field_group({ name: 'New Theme Fields', slug: '_new-theme-fields' })
+                        .add_manual_field({ name: 'Footer', slug: 'footer_text' }, { field_key: 'text_box' })
+
+      post '/admin/settings/save_theme', params: {
+        action_name: 'save_settings',
+        field_options: { '0' => { 'footer_text' => { 'id' => registered.id.to_s, 'values' => { '0' => 'hi' } } } }
+      }
+
+      expect(response).to have_http_status(:found)
+      expect(theme.get_field_value('footer_text')).to eq('hi')
+    end
+  end
 end

--- a/spec/requests/security/theme_field_value_filtering_spec.rb
+++ b/spec/requests/security/theme_field_value_filtering_spec.rb
@@ -74,4 +74,27 @@ RSpec.describe 'Theme settings field-value filtering', type: :request do
       expect(theme.get_field_value('footer_text')).to eq('hi')
     end
   end
+
+  # A submission whose slugs are all unregistered filters to an empty payload. set_field_values
+  # deletes every existing value before writing, so an empty-but-present payload must not reach
+  # it, or a save carrying no registered slug wipes the object's stored values.
+  describe 'a submission carrying no registered slug' do
+    before { theme.save_field_value('bg_color', 'keep') }
+
+    it 'leaves existing values intact on the field_options path' do
+      post '/admin/settings/save_theme', params: {
+        field_options: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
+      }
+
+      expect(theme.get_field_value('bg_color')).to eq('keep')
+    end
+
+    it 'leaves existing values intact on the theme_fields path' do
+      post '/admin/settings/save_theme', params: {
+        theme_fields: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
+      }
+
+      expect(theme.get_field_value('bg_color')).to eq('keep')
+    end
+  end
 end

--- a/spec/requests/security/theme_field_value_filtering_spec.rb
+++ b/spec/requests/security/theme_field_value_filtering_spec.rb
@@ -3,10 +3,12 @@
 require 'rails_helper'
 
 # save_theme wrote two custom-field payloads straight into set_field_values without the 2.9.2
-# allowed-slugs filter every sibling admin save uses: the `theme_fields` param, and (for the
-# bundled `new` theme) the `field_options` payload its on_theme_settings hook re-saves raw --
-# the latter also colliding with save_theme's own redirect into a DoubleRenderError. The surface
-# is a grantable role capability (`:manage, :theme_settings`), reachable by non-admin roles.
+# allowed-slugs filter every sibling admin save uses: the `theme_fields` param, and the
+# `field_options` the bundled `new` theme's on_theme_settings hook re-saved raw (its redirect to
+# a non-existent route also errored after that write). Both now route through the filter, and the
+# bundled hook no longer saves at all -- save_theme persists field_options generically. The
+# surface is a grantable role capability (`:manage, :theme_settings`), reachable by non-admin
+# roles.
 RSpec.describe 'Theme settings field-value filtering', type: :request do
   init_site
 
@@ -46,7 +48,7 @@ RSpec.describe 'Theme settings field-value filtering', type: :request do
     end
   end
 
-  describe "the bundled 'new' theme's on_theme_settings save hook" do
+  describe 'a save with the bundled new theme active' do
     let(:theme) { current_site.get_theme('new') }
 
     before { current_site.set_option('_theme', 'new') }

--- a/spec/requests/security/theme_field_value_filtering_spec.rb
+++ b/spec/requests/security/theme_field_value_filtering_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# save_theme wrote two custom-field payloads straight into set_field_values without the 2.9.2
+# allowed-slugs filter every sibling admin save uses: the `theme_fields` param, and (for the
+# bundled `new` theme) the `field_options` payload its on_theme_settings hook re-saves raw --
+# the latter also colliding with save_theme's own redirect into a DoubleRenderError. The surface
+# is a grantable role capability (`:manage, :theme_settings`), reachable by non-admin roles.
+RSpec.describe 'Theme settings field-value filtering', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:theme_role) { current_site.user_roles.create!(name: 'Theme Manager', slug: 'theme_mgr') }
+  let(:editor) { create(:user, role: theme_role.slug, site: current_site) }
+  let(:theme) { current_site.get_theme }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:cama_authenticate)
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    theme_role.set_meta("_manager_#{current_site.id}", { 'theme_settings' => 1 })
+    group = theme.add_field_group({ name: 'Theme Fields', slug: '_theme-fields' })
+    @bg_field = group.add_manual_field({ name: 'Background', slug: 'bg_color' }, { field_key: 'text_box' })
+    sign_in_as(editor, site: current_site)
+  end
+
+  def relationship_count(slug)
+    CamaleonCms::CustomFieldsRelationship.where(custom_field_slug: slug).count
+  end
+
+  describe 'the theme_fields payload' do
+    it 'drops values for a slug not registered on the theme' do
+      post '/admin/settings/save_theme', params: {
+        theme_fields: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
+      }
+
+      expect(relationship_count('evil')).to eq(0)
+    end
+
+    it 'saves values for a registered slug' do
+      post '/admin/settings/save_theme', params: {
+        theme_fields: { '0' => { 'bg_color' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'blue' } } } }
+      }
+
+      expect(theme.get_field_value('bg_color')).to eq('blue')
+    end
+  end
+end

--- a/spec/requests/security/theme_field_value_filtering_spec.rb
+++ b/spec/requests/security/theme_field_value_filtering_spec.rb
@@ -31,20 +31,19 @@ RSpec.describe 'Theme settings field-value filtering', type: :request do
   end
 
   describe 'the theme_fields payload' do
-    it 'drops values for a slug not registered on the theme' do
+    # Mixed payload: the registered slug must save (proving the request reached save_theme past
+    # authorization) while the unregistered one is dropped -- a filter test that cannot pass
+    # merely because an authorization failure redirected before any write.
+    it 'keeps a registered slug while dropping an unregistered one' do
       post '/admin/settings/save_theme', params: {
-        theme_fields: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
-      }
-
-      expect(relationship_count('evil')).to eq(0)
-    end
-
-    it 'saves values for a registered slug' do
-      post '/admin/settings/save_theme', params: {
-        theme_fields: { '0' => { 'bg_color' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'blue' } } } }
+        theme_fields: { '0' => {
+          'bg_color' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'blue' } },
+          'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } }
+        } }
       }
 
       expect(theme.get_field_value('bg_color')).to eq('blue')
+      expect(relationship_count('evil')).to eq(0)
     end
   end
 
@@ -53,27 +52,24 @@ RSpec.describe 'Theme settings field-value filtering', type: :request do
 
     before { current_site.set_option('_theme', 'new') }
 
-    it 'drops values for an unregistered slug and answers with a single redirect' do
-      post '/admin/settings/save_theme', params: {
-        action_name: 'save_settings',
-        field_options: { '0' => { 'evil' => { 'id' => @bg_field.id.to_s, 'values' => { '0' => 'x' } } } }
-      }
-
-      expect(response).to have_http_status(:found)
-      expect(relationship_count('evil')).to eq(0)
-    end
-
-    it 'saves a registered slug and answers with a single redirect' do
+    # The registered slug saving proves the request reached save_theme past authorization; the
+    # single redirect proves the removed hook no longer double-renders; the unregistered slug is
+    # dropped by save_theme's generic field_options filter.
+    it 'keeps a registered slug while dropping an unregistered one, with a single redirect' do
       registered = theme.add_field_group({ name: 'New Theme Fields', slug: '_new-theme-fields' })
                         .add_manual_field({ name: 'Footer', slug: 'footer_text' }, { field_key: 'text_box' })
 
       post '/admin/settings/save_theme', params: {
         action_name: 'save_settings',
-        field_options: { '0' => { 'footer_text' => { 'id' => registered.id.to_s, 'values' => { '0' => 'hi' } } } }
+        field_options: { '0' => {
+          'footer_text' => { 'id' => registered.id.to_s, 'values' => { '0' => 'hi' } },
+          'evil' => { 'id' => registered.id.to_s, 'values' => { '0' => 'x' } }
+        } }
       }
 
       expect(response).to have_http_status(:found)
       expect(theme.get_field_value('footer_text')).to eq('hi')
+      expect(relationship_count('evil')).to eq(0)
     end
   end
 


### PR DESCRIPTION
## What and Why

The 2.9.2 mass-assignment hardening (`eba56d6f`) routed every admin custom-field value save
through an allowed-slugs filter (`CustomFieldsConcern#cama_permitted_field_options`) — except
two theme-settings paths that still passed raw request params into `set_field_values`:

- `SettingsController#save_theme` wrote `params[:theme_fields]` unfiltered.
- The bundled `new` theme's `on_theme_settings` hook re-saved `params[:field_options]` raw,
  *after* `save_theme`'s own filtered write, re-introducing whatever the filter had dropped.

The surface is not admin-only: it is gated by `authorize! :manage, :theme_settings`, a
grantable role capability, so any role granted theme settings could write custom-field value
rows for arbitrary field ids and unregistered slugs. The bundled hook additionally issued
`redirect_to action: :settings` — a route that does not exist — raising an error after the raw
write had already committed.

**The fix:**

- `cama_permitted_field_options` gains a `param_key:` keyword (default `:field_options`, leaving
  the eight existing call sites unchanged), and `save_theme` filters `theme_fields` through it.
- `save_theme` already filters `field_options` generically, so the bundled `new` theme's hook —
  whose only remaining role was that redundant write plus the broken redirect — no longer saves
  at all; it just renders its settings view, and `save_theme` renders the single standard
  response. This aligns the bundled theme with the generator template's empty save handler.
  Applied to the gem file and its identical committed duplicate under `spec/dummy`.

Registered field slugs still save; only unregistered slugs and arbitrary ids are rejected,
matching every other admin custom-field surface.

**Also fixed (pre-existing, every call site):** the allowed-slugs filter reduced a submission
whose slugs were *all* unregistered to an empty-but-present payload, which made
`set_field_values` run its `delete_all` and then write nothing — wiping the object's stored
values. The filter now drops those empty groups, so such a save is a no-op. Because this lives
in the shared helper, the fix covers every admin custom-field save path (posts, users,
categories, tags, post types, site, widgets, nav menus, themes), not only theme settings. A
clear-all still works, since it carries the registered slug keys.

## User-Visible Impact

Custom-field values submitted through theme settings for slugs that are not registered fields
are no longer saved (registered fields are unaffected); the bundled "new" theme's custom
settings save now completes normally instead of erroring; and an admin custom-field save that
contains no registered slug no longer wipes the object's existing values.
