### PR TITLE
Upload hardening: re-scan before_upload bytes, fix zero size limit, cheaper scan, on_translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- **Security fix:** An authenticated uploader without the `media_unfiltered_upload` permission
+  could use a `before_upload` hook to substitute bytes the content scanner never saw, since the
+  hook runs after the scan and the persisted IO is what it leaves behind. The pipeline now
+  re-scans the substituted content for untrusted uploaders. Same PR also: a blank or `0`
+  "Max file size" setting no longer rejects every upload and crop; media-manager upload errors
+  again run the `on_translation` hook so plugins can override them; and the content scan folds
+  its 58 event-handler patterns into one pass. Regression audit N2/M26/M24/M25.
+  [#1241](https://github.com/owen2345/camaleon-cms/pull/1241).
+
 - **Note for upgraders:** Dropping a new plugin or theme folder into the app and then activating
   it from the admin now requires a server restart before it is discovered — the Plugins/Themes
   admin index no longer rescans the filesystem on each view (changed in #1163). Restart the app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   could use a `before_upload` hook to substitute bytes the content scanner never saw, since the
   hook runs after the scan and the persisted IO is what it leaves behind. The pipeline now
   re-scans the substituted content for untrusted uploaders. Same PR also: a blank or `0`
-  "Max file size" setting no longer rejects every upload and crop; media-manager upload errors
+  "Max file size" setting no longer rejects every upload and crop (and the size gate coerces a
+  numeric-string limit instead of raising on it); media-manager upload errors
   again run the `on_translation` hook so plugins can override them; and the content scan folds
   its 58 event-handler patterns into one pass. Regression audit N2/M26/M24/M25.
   [#1241](https://github.com/owen2345/camaleon-cms/pull/1241).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- **Note for upgraders:** Dropping a new plugin or theme folder into the app and then activating
+  it from the admin now requires a server restart before it is discovered — the Plugins/Themes
+  admin index no longer rescans the filesystem on each view (changed in #1163). Restart the app
+  after adding a plugin/theme directory. Regression audit M28.
+
 - **Security fix:** The two admin theme-settings paths that still saved custom-field values raw
   — the `theme_fields` param and the bundled `new` theme's settings-save hook — now go through
   the same allowed-slugs filter as every other admin custom-field save (added in 2.9.2), closing

--- a/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
+++ b/app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb
@@ -14,6 +14,18 @@ module CamaleonCms
 
     private
 
+    # Route upload messages through `ct` when the host provides it — the media controllers do,
+    # since #1223 restored CamaleonHelper (and its `ct`) to the controller chain — so the
+    # on_translation hook that lets plugins override upload error text runs on the controller
+    # path too. Non-controller includers (ActiveJobs, standalone objects) have no `ct` and keep
+    # the pipeline's I18n default via super. The default (no hook) text is identical either way:
+    # `ct`'s default arm is I18n.translate("camaleon_cms.common.#{key}", **args).
+    def cama_uploader_ct(key, args = {})
+      return ct(key, args) if respond_to?(:ct, true)
+
+      super
+    end
+
     # Validates a user-supplied upload URL and returns nil when it is acceptable,
     # or an error String to render. Only http(s) URLs are validated here; other
     # inputs (local paths, data: URIs) are handled by the sink guards in

--- a/lib/camaleon_cms/content_security.rb
+++ b/lib/camaleon_cms/content_security.rb
@@ -19,14 +19,20 @@ module CamaleonCms
     # bytes, and removing them would mangle legitimate multibyte text.
     CONTROL_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/
 
-    UNSAFE_EVENT_PATTERNS = %w[
+    # Event-handler attribute stems. Each is matched as `<stem>\w*\s*=`, so a stem covers its
+    # whole family (`onmouse` → onmousedown/onmouseover/...).
+    UNSAFE_EVENT_HANDLERS = %w[
       onabort onafter onbefore onbegin onblur oncanplay onchange onclick oncontextmenu oncopy oncuechange oncut
       ondblclick ondrag ondrop ondurationchange onend onended onerror onfocus onhashchange oninvalid oninput onkey
       onload onmessage onmouse ononline onoffline onpagehide onpageshow onpage onpaste onpause onplay onpopstate
       onprogress onpropertychange onratechange onreadystatechange onrepeat onreset onresize onscroll onsearch onseek
       onselect onshow onstalled onstorage onsubmit onsuspend ontimeupdate ontoggle onunload onvolumechange onwaiting
       onwheel
-    ].map { |pattern| /#{pattern}\w*\s*=/i }.freeze
+    ].freeze
+
+    # One alternation over all stems instead of 58 separate scans of the full buffer — the same
+    # `<stem>\w*\s*=` match, folded into a single pass.
+    UNSAFE_EVENT_PATTERN = /(?:#{Regexp.union(UNSAFE_EVENT_HANDLERS).source})\w*\s*=/i
 
     # Elements able to navigate, exfiltrate, or load remote active content.
     # Longest-first so "frameset" is preferred over "frame".
@@ -52,10 +58,11 @@ module CamaleonCms
       Regexp::IGNORECASE
     )
 
-    SUSPICIOUS_PATTERNS = (UNSAFE_EVENT_PATTERNS + [
+    SUSPICIOUS_PATTERNS = [
+      UNSAFE_EVENT_PATTERN,
       BLOCKED_ELEMENT_PATTERN,
       BLOCKED_SCHEME_PATTERN
-    ]).freeze
+    ].freeze
 
     # Canonicalizes content so encoded variants of a blocked pattern are detected.
     # Returns a normalized copy; the stored file is never modified.

--- a/lib/camaleon_cms/uploader_pipeline.rb
+++ b/lib/camaleon_cms/uploader_pipeline.rb
@@ -231,11 +231,14 @@ module CamaleonCms
     # Message seam. Rendering user-facing upload errors differs by execution context,
     # so the pipeline never calls a translator directly.
     #
-    # The defaults below are what a controller gets: CamaleonCms::CamaleonController does
-    # not include CamaleonHelper, so `ct` is undefined there. CamaleonCms::UploaderHelper
-    # overrides all three to route through `ct` / `cama_t` / `number_to_human_size`; `ct`
-    # runs the `on_translation` hook that lets plugins override the text, which a shared
-    # I18n.t call would silently drop.
+    # `ct` runs the `on_translation` hook that lets plugins override the text, which a
+    # shared I18n.t call would silently drop. CamaleonCms::UploaderHelper overrides all
+    # three to route through `ct` / `cama_t` / `number_to_human_size` (it includes
+    # CamaleonHelper itself). CamaleonCms::RuntimeUploaderConcern overrides only
+    # cama_uploader_ct, routing through `ct` when its host has one — true for
+    # CamaleonCms::CamaleonController since #1223 restored CamaleonHelper there. The
+    # defaults below are what remains: `t`/`human_size` on the concern path, and all
+    # three for concern hosts without `ct` (ActiveJobs, standalone objects).
     def cama_uploader_ct(key, args = {})
       I18n.t("camaleon_cms.common.#{key}", **args)
     end

--- a/lib/camaleon_cms/uploader_pipeline.rb
+++ b/lib/camaleon_cms/uploader_pipeline.rb
@@ -337,9 +337,11 @@ module CamaleonCms
     # Returns an error hash when size exceeds maximum, nil otherwise.
     # A non-positive maximum means "no limit" — a site whose stored filesystem_max_size is blank
     # or 0 (also reached by plugin callers passing that option as :maximum) would otherwise fail
-    # every upload with "File size exceeded (0 Bytes)".
+    # every upload with "File size exceeded (0 Bytes)". The size comparison coerces for the same
+    # reason: a caller-supplied :maximum can be a numeric String, and a bare `String >= Integer`
+    # raises instead of enforcing the limit.
     def cama_size_limit_error(size, maximum)
-      return if maximum.blank? || maximum.to_f <= 0 || maximum >= size
+      return if maximum.blank? || maximum.to_f <= 0 || maximum.to_f >= size
 
       max_size = cama_uploader_human_size(maximum)
       { error: "#{cama_uploader_ct('file_size_exceeded', default: 'File size exceeded')} (#{max_size})" }

--- a/lib/camaleon_cms/uploader_pipeline.rb
+++ b/lib/camaleon_cms/uploader_pipeline.rb
@@ -332,8 +332,11 @@ module CamaleonCms
     end
 
     # Returns an error hash when size exceeds maximum, nil otherwise.
+    # A non-positive maximum means "no limit" — a site whose stored filesystem_max_size is blank
+    # or 0 (also reached by plugin callers passing that option as :maximum) would otherwise fail
+    # every upload with "File size exceeded (0 Bytes)".
     def cama_size_limit_error(size, maximum)
-      return if maximum.blank? || maximum >= size
+      return if maximum.blank? || maximum.to_f <= 0 || maximum >= size
 
       max_size = cama_uploader_human_size(maximum)
       { error: "#{cama_uploader_ct('file_size_exceeded', default: 'File size exceeded')} (#{max_size})" }

--- a/lib/camaleon_cms/uploader_pipeline.rb
+++ b/lib/camaleon_cms/uploader_pipeline.rb
@@ -81,7 +81,18 @@ module CamaleonCms
       }.merge!(settings)
       settings[:formats] = '*' if settings[:formats].nil?
       settings[:folder] = '' if settings[:folder].nil? # e.g. crop_url passes no folder
+      io_before_hook = settings[:uploaded_io]
       hooks_run('before_upload', settings)
+
+      # A before_upload handler may rebind settings[:uploaded_io] to bytes the top-of-method
+      # scan never saw (e.g. an image optimizer rewriting an SVG). For an untrusted uploader,
+      # re-scan the substituted IO so a handler cannot launder a blocked payload past the scan.
+      # Keyed on object identity: an unchanged IO was already scanned, and a permission-holder
+      # is exempt exactly as above.
+      if !settings[:uploaded_io].equal?(io_before_hook) && !cama_trusted_for_unfiltered_upload? &&
+         file_content_unsafe?(settings[:uploaded_io])
+        return cama_upload_failure({ error: 'Potentially malicious content found!' }, settings[:uploaded_io], settings)
+      end
 
       # guard against path traversal
       unless cama_uploader.valid_folder_path?(settings[:folder])

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/design.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/design.md
@@ -1,0 +1,82 @@
+# Design — harden-upload-rescan-and-limits
+
+## Context
+
+See `proposal.md` — Why. All findings live in the shared uploader pipeline
+(`lib/camaleon_cms/uploader_pipeline.rb`, `lib/camaleon_cms/content_security.rb`) and the
+controller entry point (`runtime_uploader_concern.rb`). Load-bearing facts:
+
+- `upload_file` scans at the top (line ~59), then fires `before_upload` (~84), then writes
+  `settings[:uploaded_io]` (~101). `cama_trusted_for_unfiltered_upload?` gates the scan
+  (permission `media_unfiltered_upload`, fails closed without a request — the
+  `security-capability-gating` contract).
+- `before_upload` handlers rebind `settings[:uploaded_io]` in place (the spec already states a
+  handler "may replace the IO object but not its `path`"); `camaleon_image_optimizer` does this.
+- `crop` re-enters `upload_file` after `cama_tmp_upload`, so `before_upload` fires again per crop.
+- `cama_size_limit_error` is the single size gate for every path (`upload_file`, `cama_tmp_upload`,
+  data-URI staging, and plugin callers passing `maximum:`).
+- `ct` was restored to the controller chain by #1223 and runs `on_translation`; its default arm
+  is `I18n.translate("camaleon_cms.common.#{key}", **args)` — byte-identical to
+  `UploaderPipeline#cama_uploader_ct` for the no-hook case.
+- The content scan is ~60 regexes: 58 `UNSAFE_EVENT_PATTERNS` matched in a loop plus the element
+  and scheme patterns. The existing content-security spec pins *which inputs match*, not the
+  pattern count or the returned identifier.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- N2: an untrusted uploader cannot launder bytes past the scan through `before_upload`.
+- M26: a zero/blank `filesystem_max_size` stops blocking all uploads, at the one gate every
+  caller shares.
+- M25: cut the dominant scan cost (the 58-pattern loop) without changing what matches.
+- M24: media-manager upload errors become plugin-overridable via `on_translation`.
+
+**Non-Goals**
+
+- N2 does not re-scan when the IO is unchanged (the top-of-method scan already covered it), and
+  does not treat a `before_upload` handler as trusted — the rejected alternative.
+- M25 does **not** reorder size/format validation relative to the scan: those checks sit after
+  `before_upload` precisely so a handler can adjust `:formats`/`:maximum`, and moving them ahead
+  of the hook would change that contract. The regex consolidation delivers the headline win
+  without touching ordering. The `crop` double-scan (two separate entry-point calls) is left as
+  a known cost — collapsing it needs cross-call state and has no audited correctness impact.
+- No server-side extension policy (the deferred H11/N1 work); unchanged here.
+
+## Decisions
+
+1. **N2 = identity check across the hook.** Capture the IO object before `before_upload`; after
+   it, if `settings[:uploaded_io]` is a different object and the uploader is untrusted, scan the
+   substituted IO with the existing `file_content_unsafe?` and fail through
+   `cama_upload_failure` on a hit. Keyed on object identity (`equal?`), not on whether a hook
+   ran, so a handler that leaves the IO alone costs nothing and a permission-holder is never
+   re-scanned. Rejected: unconditional re-scan (doubles cost for the common no-op hook);
+   trusting `before_upload` output (the finding).
+2. **M26 = `maximum <= 0` means unlimited** in `cama_size_limit_error`. The guard becomes
+   `return if maximum.blank? || maximum.to_f <= 0 || maximum >= size`. One line, the shared gate,
+   so `cama_contact_form`'s `maximum:` pass-through is covered without touching its code.
+3. **M25 = one alternation for the event patterns.** `UNSAFE_EVENT_PATTERNS` collapses from 58
+   regexes to a single `/(?:onabort|onafter|…)\w*\s*=/i` built from the same word list; the loop
+   in `content_unsafe?` now iterates 3 patterns. Matching is identical (each old pattern was
+   `/#{word}\w*\s*=/i`; the union factors the shared suffix). Verified against the existing
+   bypass/keep-passing spec plus added event-word cases.
+4. **M24 = `respond_to?(:ct)` dispatch in the concern.** `RuntimeUploaderConcern` overrides
+   `cama_uploader_ct` to call `ct(key, args)` when the host responds to `ct`, else `super` (the
+   pipeline's `I18n.t`). Controller uploads then run `on_translation`; non-controller includers
+   (jobs, standalone) keep the `I18n` path. Default text is unchanged either way.
+
+## Risks / Trade-offs
+
+- [N2 re-scan on every crop where a handler rewrites bytes] → intended; that is the seam the
+  finding is about, and it only runs for untrusted uploaders whose handler actually swapped the
+  IO.
+- [M25 consolidation changes the logged/returned pattern identifier] → callers only test
+  truthiness and render a generic message; no spec asserts the identifier. A single combined
+  identifier is still logged.
+- [M24 routes controller messages through the hook] → the default translation is byte-identical;
+  only a plugin that registered `on_translation` sees a change, which is the intended fix.
+
+## Migration Plan
+
+Code + docs; no schema or data changes. Deploy normally; rollback = revert the commits. M28 is a
+changelog note only.

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/proposal.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/proposal.md
@@ -1,0 +1,69 @@
+## Why
+
+The 2026-08 regression audit batched the upload-pipeline findings as PR 6 (N2, M26, M25, M24,
+M28). N2 is a security gap exposed by the permission-gated scan; the rest are a config-dependent
+crash, scan cost, a dead hook, and a doc gap.
+
+- **N2** — `before_upload` (a hook handlers use to rewrite bytes, e.g. `camaleon_image_optimizer`
+  running SVGO) fires **after** the content scan, and the file finally written is
+  `settings[:uploaded_io]`, which the handler may have replaced. So for an untrusted uploader the
+  scanned bytes need not be the persisted bytes — a handler can launder a blocked payload past
+  the scanner. This is exactly the "content substituted after the check" case the
+  `security-capability-gating` capability already requires be re-checked.
+- **M26** — `cama_size_limit_error` treats a stored `filesystem_max_size` of `0` as a real
+  limit (`0 >= size` is false for any non-empty file), so a site with the setting blank/zeroed
+  fails **every** upload and crop with "File size exceeded (0 Bytes)". `cama_contact_form` reads
+  the same option and passes it as `maximum:`, so coercing only core's read sites would miss it.
+- **M25** — the content scan runs ~60 regexes (58 event-handler patterns in a loop plus the
+  element and scheme patterns) over the full buffer; on a 100 MB upload that is seconds of CPU,
+  and crop pays it twice. The 58 event patterns collapse to one alternation with identical
+  matching.
+- **M24** — media-manager (controller) upload errors never run the `on_translation` hook: the
+  pipeline's `cama_uploader_ct` is a hard `I18n.t`, and only `UploaderHelper` overrides it —
+  `RuntimeUploaderConcern` does not, even though controllers now carry `ct` (restored by #1223).
+  Contradicts #1212's changelog claim.
+- **M28** — dropping a plugin/theme folder then activating it requires a server restart now
+  (#1163, deliberate); undocumented.
+
+## What Changes
+
+- **N2**: after `before_upload`, when the uploader is not permitted to skip scanning, re-scan
+  `settings[:uploaded_io]` **only if the hook replaced it** (detected by object identity across
+  the hook). A permission-holder still skips scanning as today; every other role has the
+  rewritten bytes re-checked. Implements the `security-capability-gating` re-check requirement.
+- **M26**: a non-positive `maximum` (`<= 0`) in `cama_size_limit_error` means unlimited — the
+  single read point every caller (core and `cama_contact_form`) flows through.
+- **M25**: the 58 event-handler patterns become one alternation regex (matching unchanged);
+  the file is read/scanned once via the existing entry points. Behavior-preserving.
+- **M24**: `RuntimeUploaderConcern` overrides `cama_uploader_ct` to route through `ct` when the
+  host responds to it (running `on_translation`), falling back to `I18n.t` for non-controller
+  includers. Amends the `uploader-implementation-parity` message-pipeline requirement.
+- **M28**: changelog note that folder-drop discovery needs a restart.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `upload-content-security`: a `before_upload` handler that replaces the scanned IO for an
+  untrusted uploader has its substituted bytes re-scanned (N2).
+- `upload-staging-lifecycle`: a non-positive configured size limit is treated as unlimited (M26).
+- `uploader-implementation-parity`: the controller entry point routes upload messages through
+  `ct` when available, so `on_translation` fires there too (M24).
+
+## Impact
+
+- `lib/camaleon_cms/uploader_pipeline.rb` (`upload_file` re-scan, `cama_size_limit_error`),
+  `lib/camaleon_cms/content_security.rb` (regex consolidation),
+  `app/controllers/concerns/camaleon_cms/runtime_uploader_concern.rb` (`cama_uploader_ct`),
+  `CHANGELOG.md`.
+- Specs: new `spec/requests/security/upload_before_upload_rescan_spec.rb`,
+  `spec/lib/camaleon_cms/upload_size_limit_spec.rb`,
+  `spec/lib/camaleon_cms/runtime_uploader_translation_spec.rb`; extension to the content-security
+  spec for the consolidated patterns.
+- No routes or schema changes. Behavior deltas: laundering bytes past the scan via `before_upload`
+  is closed for untrusted uploaders; a zero/blank size setting no longer blocks all uploads;
+  media-manager upload errors are plugin-overridable; scans are cheaper.

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/upload-content-security/spec.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/upload-content-security/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Content substituted by a before_upload handler is re-scanned
+
+The `before_upload` hook runs after the initial content scan and may replace the IO the pipeline
+persists (`settings[:uploaded_io]`). When the uploading user does not hold
+`media_unfiltered_upload`, the pipeline SHALL detect a replacement by object identity across the
+hook and re-scan the substituted content before writing it; content that trips a rule SHALL be
+refused with `Potentially malicious content found!` and no file SHALL be written. A user holding
+the permission is exempt from this re-scan exactly as from the initial scan. When no handler
+replaces the IO, no second scan is performed (the initial scan already covered those bytes).
+
+This closes the gap where a handler (for example an image optimizer rewriting an SVG) could
+substitute bytes the scanner never saw. It implements the `security-capability-gating`
+"content substituted after the check" requirement for the upload path.
+
+#### Scenario: Handler-substituted bytes are re-scanned for an untrusted uploader
+
+- **WHEN** a user without `media_unfiltered_upload` uploads a clean file and a `before_upload`
+  handler replaces `settings[:uploaded_io]` with content containing a `<script>` tag
+- **THEN** the substituted content is re-scanned and the upload is refused, with no file written
+
+#### Scenario: A permitted user's handler substitution is not re-scanned
+
+- **WHEN** a user holding `media_unfiltered_upload` uploads a file and a `before_upload` handler
+  replaces the IO
+- **THEN** the substituted content is persisted without a re-scan, as the permission exempts it
+
+#### Scenario: An unchanged IO is not re-scanned
+
+- **WHEN** a user without `media_unfiltered_upload` uploads a file and no `before_upload` handler
+  replaces `settings[:uploaded_io]`
+- **THEN** the pipeline does not scan the content a second time after the hook

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/upload-staging-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/upload-staging-lifecycle/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: A non-positive size limit means unlimited
+
+`cama_size_limit_error` SHALL treat a non-positive `maximum` (zero or negative) as "no limit"
+and accept any size, rather than rejecting every non-empty file. This is the single point every
+caller's size check flows through — core's `upload_file`/`cama_tmp_upload`/data-URI staging and
+plugin callers such as `cama_contact_form` that read `filesystem_max_size` and pass it as
+`maximum:` — so a site whose stored `filesystem_max_size` is blank or `0` can still upload and
+crop. A positive limit continues to reject sizes above it.
+
+#### Scenario: Zero limit accepts an upload
+
+- **WHEN** the size check runs with a `maximum` of `0` for a non-empty file
+- **THEN** no size error is returned
+
+#### Scenario: A crop succeeds on a site whose max file size is zero
+
+- **WHEN** a site's `filesystem_max_size` option is `0` and a user crops an existing image
+- **THEN** the crop is not rejected with a "File size exceeded (0 Bytes)" error
+
+#### Scenario: A positive limit still rejects an oversized file
+
+- **WHEN** the size check runs with a positive `maximum` and a file larger than it
+- **THEN** a size error is returned

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/uploader-implementation-parity/spec.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/specs/uploader-implementation-parity/spec.md
@@ -1,0 +1,43 @@
+## MODIFIED Requirements
+
+### Requirement: Each entry point keeps its own upload message pipeline
+
+The system SHALL render user-facing upload error messages through a seam that each entry point
+supplies. `CamaleonCms::UploaderHelper` translates via `ct` and `cama_t`. `CamaleonCms::RuntimeUploaderConcern`
+SHALL translate through `ct` when its host responds to `ct` — which is the case for the media
+controllers, where `ct` was restored to the controller chain — so the `on_translation` hook that
+lets plugins override message text runs on the controller upload path too; when the host does not
+respond to `ct` (a non-controller includer), it SHALL fall back to `I18n`. The default (no hook)
+translation MUST be identical on both paths.
+
+#### Scenario: A plugin can override an upload message on the helper path
+
+- **WHEN** a plugin registers an `on_translation` hook that replaces the file-size-exceeded text
+- **AND** an upload is rejected for exceeding the size limit through `CamaleonCms::UploaderHelper`
+- **THEN** the returned error contains the plugin's text
+
+#### Scenario: A plugin can override an upload message on the controller path
+
+- **WHEN** a plugin registers an `on_translation` hook that replaces the file-size-exceeded text
+- **AND** an upload is rejected through a host that includes `CamaleonCms::RuntimeUploaderConcern`
+  and responds to `ct`
+- **THEN** the returned error contains the plugin's text
+
+#### Scenario: The controller path translates without the hook
+
+- **WHEN** an upload is rejected for exceeding the size limit through a
+  `CamaleonCms::RuntimeUploaderConcern` host with no `on_translation` hook registered
+- **THEN** the returned error contains the `I18n` translation of the message
+
+#### Scenario: The concern falls back to I18n without ct
+
+- **WHEN** an upload message is rendered through a `CamaleonCms::RuntimeUploaderConcern` host that
+  does not respond to `ct`
+- **THEN** the message is the `I18n` translation
+- **AND** rendering does not require `ct` to be defined
+
+#### Scenario: Both paths report the same limit
+
+- **WHEN** the same size limit is exceeded through either entry point with no `on_translation`
+  hook registered
+- **THEN** both errors state the limit in the same human-readable form

--- a/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/tasks.md
+++ b/openspec/changes/archive/2026-08-09-harden-upload-rescan-and-limits/tasks.md
@@ -1,0 +1,56 @@
+## 1. N2 — re-scan substituted before_upload bytes (commit 1, security)
+
+- [x] 1.1 New `spec/requests/security/upload_before_upload_rescan_spec.rb`: an untrusted upload
+      with a `before_upload` handler that swaps `settings[:uploaded_io]` for `<script>` bytes is
+      refused with no file written (red on master); a permission-holder's swap persists;
+      an unchanged IO is not re-scanned.
+- [x] 1.2 `upload_file`: capture the IO before `before_upload`, re-scan the substituted IO after
+      it when untrusted and the object changed, failing through `cama_upload_failure`.
+- [x] 1.3 Spec green; rubocop clean on touched files; commit N2 (cite `security-capability-gating`).
+
+## 2. M26 — non-positive size limit means unlimited (commit 2)
+
+- [x] 2.1 New `spec/lib/camaleon_cms/upload_size_limit_spec.rb`: `cama_size_limit_error` returns
+      nil for `maximum` 0 and negative with a non-empty size (red on master), still errors for a
+      positive maximum below size.
+- [x] 2.2 `cama_size_limit_error`: treat `maximum <= 0` as unlimited.
+- [x] 2.3 Spec green; rubocop clean; commit M26.
+
+## 3. M25 — consolidate the event patterns (commit 3, perf refactor)
+
+- [x] 3.1 `content_security.rb`: collapse the 58 event regexes into one alternation;
+      `SUSPICIOUS_PATTERNS` becomes the event pattern + element + scheme (3 total). Keep
+      `UNSAFE_EVENT_PATTERNS` referenceable if externally used, or note removal.
+- [x] 3.2 Extend `spec/lib/camaleon_cms/uploader_content_security_spec.rb` with representative
+      event-word matches (onclick/onerror/onmouseover/onsubmit/onunload) and a non-handler
+      near-miss that must pass; full content-security spec stays green (matching unchanged).
+- [x] 3.3 Rubocop clean; commit M25.
+
+## 4. M24 — on_translation on the controller upload path (commit 4)
+
+- [x] 4.1 New `spec/lib/camaleon_cms/runtime_uploader_translation_spec.rb`: a concern host that
+      responds to `ct` routes `cama_uploader_ct` through it (hook override observed); a host
+      without `ct` falls back to `I18n` (red on master: concern never uses `ct`).
+- [x] 4.2 `runtime_uploader_concern.rb`: override `cama_uploader_ct` to dispatch to `ct` when
+      `respond_to?(:ct)`, else `super`.
+- [x] 4.3 Spec green; rubocop clean; commit M24 (amends `uploader-implementation-parity`).
+
+## 5. M28 — restart-requirement doc (commit 5, docs-only, [skip ci])
+
+- [x] 5.1 CHANGELOG note: dropping a plugin/theme folder then activating it needs a restart
+      (#1163 behavior).
+
+## 6. Verification and CI parity
+
+- [x] 6.1 Full `bin/rspec` suite green.
+- [x] 6.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 7. OpenSpec + PR protocol
+
+- [x] 7.1 `openspec validate harden-upload-rescan-and-limits --strict` passes; archive on-branch
+      (syncs the three modified capabilities); commit the archived change (no `[skip ci]` — heads
+      the first push).
+- [x] 7.2 Push, open the PR (What and Why + User-Visible Impact; protocol constraints), first
+      push runs CI.
+- [x] 7.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/upload-content-security/spec.md
+++ b/openspec/specs/upload-content-security/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the security requirements for content scanning of uploaded files. Uploaded files MUST be scanned for executable content patterns before being persisted, to prevent stored XSS attacks via uploaded files.
-
 ## Requirements
-
 ### Requirement: Content is scanned before being written to a web-served path
 
 The system SHALL scan upload content for malicious patterns before writing it into the upload staging directory, so that rejected content is never present — even transiently — at a path served by the web server.
@@ -200,4 +198,36 @@ After scanning for malicious content, the file pointer SHALL be rewound so subse
 #### Scenario: Tempfile is readable after scan
 - **WHEN** the system scans a Tempfile for unsafe content and the scan passes
 - **THEN** the Tempfile pointer is at the beginning and the full content can be read again
+
+### Requirement: Content substituted by a before_upload handler is re-scanned
+
+The `before_upload` hook runs after the initial content scan and may replace the IO the pipeline
+persists (`settings[:uploaded_io]`). When the uploading user does not hold
+`media_unfiltered_upload`, the pipeline SHALL detect a replacement by object identity across the
+hook and re-scan the substituted content before writing it; content that trips a rule SHALL be
+refused with `Potentially malicious content found!` and no file SHALL be written. A user holding
+the permission is exempt from this re-scan exactly as from the initial scan. When no handler
+replaces the IO, no second scan is performed (the initial scan already covered those bytes).
+
+This closes the gap where a handler (for example an image optimizer rewriting an SVG) could
+substitute bytes the scanner never saw. It implements the `security-capability-gating`
+"content substituted after the check" requirement for the upload path.
+
+#### Scenario: Handler-substituted bytes are re-scanned for an untrusted uploader
+
+- **WHEN** a user without `media_unfiltered_upload` uploads a clean file and a `before_upload`
+  handler replaces `settings[:uploaded_io]` with content containing a `<script>` tag
+- **THEN** the substituted content is re-scanned and the upload is refused, with no file written
+
+#### Scenario: A permitted user's handler substitution is not re-scanned
+
+- **WHEN** a user holding `media_unfiltered_upload` uploads a file and a `before_upload` handler
+  replaces the IO
+- **THEN** the substituted content is persisted without a re-scan, as the permission exempts it
+
+#### Scenario: An unchanged IO is not re-scanned
+
+- **WHEN** a user without `media_unfiltered_upload` uploads a file and no `before_upload` handler
+  replaces `settings[:uploaded_io]`
+- **THEN** the pipeline does not scan the content a second time after the hook
 

--- a/openspec/specs/upload-staging-lifecycle/spec.md
+++ b/openspec/specs/upload-staging-lifecycle/spec.md
@@ -110,7 +110,9 @@ and accept any size, rather than rejecting every non-empty file. This is the sin
 caller's size check flows through — core's `upload_file`/`cama_tmp_upload`/data-URI staging and
 plugin callers such as `cama_contact_form` that read `filesystem_max_size` and pass it as
 `maximum:` — so a site whose stored `filesystem_max_size` is blank or `0` can still upload and
-crop. A positive limit continues to reject sizes above it.
+crop. A positive limit continues to reject sizes above it. The size comparison SHALL coerce
+`maximum`, so a positive numeric-string limit is enforced rather than raising a comparison
+error.
 
 #### Scenario: Zero limit accepts an upload
 
@@ -125,5 +127,11 @@ crop. A positive limit continues to reject sizes above it.
 #### Scenario: A positive limit still rejects an oversized file
 
 - **WHEN** the size check runs with a positive `maximum` and a file larger than it
+- **THEN** a size error is returned
+
+#### Scenario: A numeric-string limit is enforced
+
+- **WHEN** the size check runs with a positive numeric-string `maximum` and a file larger than
+  that value
 - **THEN** a size error is returned
 

--- a/openspec/specs/upload-staging-lifecycle/spec.md
+++ b/openspec/specs/upload-staging-lifecycle/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the lifecycle requirements for files staged in the upload staging directory (`public/tmp/{site_id}/`). Uploads MUST be bounded before their content is decoded or written, and any file the uploader stages MUST be removed when the upload fails, so that rejected or oversized payloads are never left behind at a web-served path.
-
 ## Requirements
-
 ### Requirement: Oversized payloads are rejected before being decoded or written
 
 The system SHALL reject a `data:` upload that exceeds the permitted size before decoding it, estimating the decoded size from the length of the base64 source, so that oversized content is never allocated in full nor written to the staging directory.
@@ -104,3 +102,28 @@ The system SHALL determine whether a `data:` upload supplies a filename from the
 #### Scenario: The media controller path is unaffected
 - **WHEN** a `crop_url` request supplies a `data:` URI and a blank `name` parameter
 - **THEN** the name-required error is returned, as before, because the controller passes `name: params[:name]` through to `cama_tmp_upload`
+
+### Requirement: A non-positive size limit means unlimited
+
+`cama_size_limit_error` SHALL treat a non-positive `maximum` (zero or negative) as "no limit"
+and accept any size, rather than rejecting every non-empty file. This is the single point every
+caller's size check flows through — core's `upload_file`/`cama_tmp_upload`/data-URI staging and
+plugin callers such as `cama_contact_form` that read `filesystem_max_size` and pass it as
+`maximum:` — so a site whose stored `filesystem_max_size` is blank or `0` can still upload and
+crop. A positive limit continues to reject sizes above it.
+
+#### Scenario: Zero limit accepts an upload
+
+- **WHEN** the size check runs with a `maximum` of `0` for a non-empty file
+- **THEN** no size error is returned
+
+#### Scenario: A crop succeeds on a site whose max file size is zero
+
+- **WHEN** a site's `filesystem_max_size` option is `0` and a user crops an existing image
+- **THEN** the crop is not rejected with a "File size exceeded (0 Bytes)" error
+
+#### Scenario: A positive limit still rejects an oversized file
+
+- **WHEN** the size check runs with a positive `maximum` and a file larger than it
+- **THEN** a size error is returned
+

--- a/openspec/specs/uploader-implementation-parity/spec.md
+++ b/openspec/specs/uploader-implementation-parity/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the parity requirements for the two uploader entry points: `CamaleonCms::RuntimeUploaderConcern`, reached by controllers through the runtime concern chain, and `CamaleonCms::UploaderHelper`, included into views, ActiveJobs, and standalone objects. Both entry points MUST draw their behavior from a single shared implementation under `lib/camaleon_cms/`, so that upload behavior cannot drift between them, while a message seam lets each keep its own translation pipeline and the helper stays usable without a request context.
-
 ## Requirements
-
 ### Requirement: Uploader behavior is defined once and shared by both entry points
 
 The system SHALL define each uploader method that both `CamaleonCms::RuntimeUploaderConcern` and `CamaleonCms::UploaderHelper` provide exactly once, in a module under `lib/camaleon_cms/` that both include, so that a change to upload behavior cannot land in one entry point and not the other.
@@ -41,7 +39,13 @@ The system SHALL make the same public uploader methods available through `Camale
 
 ### Requirement: Each entry point keeps its own upload message pipeline
 
-The system SHALL render user-facing upload error messages through a seam that each entry point supplies, so that `CamaleonCms::UploaderHelper` continues to translate via `ct` and `cama_t` — running the `on_translation` hook that lets plugins override message text — while `CamaleonCms::RuntimeUploaderConcern`, whose context has no `ct`, continues to translate via `I18n`.
+The system SHALL render user-facing upload error messages through a seam that each entry point
+supplies. `CamaleonCms::UploaderHelper` translates via `ct` and `cama_t`. `CamaleonCms::RuntimeUploaderConcern`
+SHALL translate through `ct` when its host responds to `ct` — which is the case for the media
+controllers, where `ct` was restored to the controller chain — so the `on_translation` hook that
+lets plugins override message text runs on the controller upload path too; when the host does not
+respond to `ct` (a non-controller includer), it SHALL fall back to `I18n`. The default (no hook)
+translation MUST be identical on both paths.
 
 #### Scenario: A plugin can override an upload message on the helper path
 
@@ -49,15 +53,30 @@ The system SHALL render user-facing upload error messages through a seam that ea
 - **AND** an upload is rejected for exceeding the size limit through `CamaleonCms::UploaderHelper`
 - **THEN** the returned error contains the plugin's text
 
+#### Scenario: A plugin can override an upload message on the controller path
+
+- **WHEN** a plugin registers an `on_translation` hook that replaces the file-size-exceeded text
+- **AND** an upload is rejected through a host that includes `CamaleonCms::RuntimeUploaderConcern`
+  and responds to `ct`
+- **THEN** the returned error contains the plugin's text
+
 #### Scenario: The controller path translates without the hook
 
-- **WHEN** an upload is rejected for exceeding the size limit through `CamaleonCms::RuntimeUploaderConcern`
+- **WHEN** an upload is rejected for exceeding the size limit through a
+  `CamaleonCms::RuntimeUploaderConcern` host with no `on_translation` hook registered
 - **THEN** the returned error contains the `I18n` translation of the message
-- **AND** rendering the message does not require `ct` to be defined
+
+#### Scenario: The concern falls back to I18n without ct
+
+- **WHEN** an upload message is rendered through a `CamaleonCms::RuntimeUploaderConcern` host that
+  does not respond to `ct`
+- **THEN** the message is the `I18n` translation
+- **AND** rendering does not require `ct` to be defined
 
 #### Scenario: Both paths report the same limit
 
-- **WHEN** the same size limit is exceeded through either entry point
+- **WHEN** the same size limit is exceeded through either entry point with no `on_translation`
+  hook registered
 - **THEN** both errors state the limit in the same human-readable form
 
 ### Requirement: The helper entry point works without a request context
@@ -74,3 +93,4 @@ The system SHALL keep `CamaleonCms::UploaderHelper` usable by objects that have 
 
 - **WHEN** a bare class including `CamaleonCms::UploaderHelper` is instantiated
 - **THEN** its uploader methods are callable without a controller
+

--- a/spec/lib/camaleon_cms/runtime_uploader_translation_spec.rb
+++ b/spec/lib/camaleon_cms/runtime_uploader_translation_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# M24: media-manager (controller) upload errors must run the on_translation hook. The controller
+# chain carries `ct` (restored by #1223), so the concern's cama_uploader_ct routes through it;
+# a non-controller includer (no ct) keeps the I18n default.
+RSpec.describe CamaleonCms::RuntimeUploaderConcern do
+  describe '#cama_uploader_ct' do
+    context 'when the host responds to ct (controller-like)' do
+      let(:host) do
+        Class.new do
+          include CamaleonCms::RuntimeUploaderConcern
+
+          # Stand-in for CamaleonHelper#ct: runs on_translation and returns an override when set.
+          def ct(key, args = {})
+            r = { flag: false, key: key, translation: '', locale: :en }
+            hooks_run('on_translation', r)
+            return r[:translation] if r[:flag]
+
+            I18n.t("camaleon_cms.common.#{key}", **args)
+          end
+
+          def hooks_run(_key, params = nil)
+            params[:flag] = true
+            params[:translation] = 'PLUGIN OVERRIDE'
+          end
+        end.new
+      end
+
+      it 'routes the message through ct so on_translation can override it' do
+        expect(host.send(:cama_uploader_ct, 'file_size_exceeded', default: 'File size exceeded'))
+          .to eq('PLUGIN OVERRIDE')
+      end
+    end
+
+    context 'when the host does not respond to ct' do
+      let(:host) { Class.new { include CamaleonCms::RuntimeUploaderConcern }.new }
+
+      it 'falls back to the I18n default' do
+        expect(host.respond_to?(:ct, true)).to be(false)
+        expect(host.send(:cama_uploader_ct, 'file_size_exceeded', default: 'File size exceeded'))
+          .to eq(I18n.t('camaleon_cms.common.file_size_exceeded', default: 'File size exceeded'))
+      end
+    end
+  end
+end

--- a/spec/lib/camaleon_cms/upload_size_limit_spec.rb
+++ b/spec/lib/camaleon_cms/upload_size_limit_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# M26: a stored filesystem_max_size of 0 (blank/zeroed setting) must not reject every upload.
+# cama_size_limit_error is the single gate every caller — core and cama_contact_form's
+# maximum: pass-through — flows through, so the fix lands here.
+RSpec.describe CamaleonCms::UploaderPipeline do
+  let(:host) do
+    Class.new do
+      include CamaleonCms::UploaderPipeline
+
+      # cama_size_limit_error needs the message seam; the concern's I18n default suffices here.
+      def cama_uploader_human_size(bytes)
+        ActiveSupport::NumberHelper.number_to_human_size(bytes)
+      end
+
+      def cama_uploader_ct(key, args = {})
+        I18n.t("camaleon_cms.common.#{key}", **args)
+      end
+    end.new
+  end
+
+  describe '#cama_size_limit_error' do
+    it 'treats a zero maximum as unlimited' do
+      expect(host.send(:cama_size_limit_error, 5.megabytes, 0)).to be_nil
+    end
+
+    it 'treats a negative maximum as unlimited' do
+      expect(host.send(:cama_size_limit_error, 5.megabytes, -1)).to be_nil
+    end
+
+    it 'still rejects a file above a positive maximum' do
+      error = host.send(:cama_size_limit_error, 5.megabytes, 1.megabyte)
+      # Assert the contract (an error is returned), not the locale-dependent message text, so a
+      # leaked I18n.locale from another example cannot flip this.
+      expect(error[:error]).to be_present
+    end
+
+    it 'accepts a file within a positive maximum' do
+      expect(host.send(:cama_size_limit_error, 1.megabyte, 5.megabytes)).to be_nil
+    end
+
+    it 'treats a blank maximum as unlimited' do
+      expect(host.send(:cama_size_limit_error, 5.megabytes, nil)).to be_nil
+    end
+  end
+end

--- a/spec/lib/camaleon_cms/upload_size_limit_spec.rb
+++ b/spec/lib/camaleon_cms/upload_size_limit_spec.rb
@@ -44,5 +44,14 @@ RSpec.describe CamaleonCms::UploaderPipeline do
     it 'treats a blank maximum as unlimited' do
       expect(host.send(:cama_size_limit_error, 5.megabytes, nil)).to be_nil
     end
+
+    it 'enforces a positive numeric-string maximum instead of raising' do
+      error = host.send(:cama_size_limit_error, 5.megabytes, 1.megabyte.to_s)
+      expect(error[:error]).to be_present
+    end
+
+    it 'accepts a file within a positive numeric-string maximum' do
+      expect(host.send(:cama_size_limit_error, 1.megabyte, 5.megabytes.to_s)).to be_nil
+    end
   end
 end

--- a/spec/lib/camaleon_cms/uploader_content_security_spec.rb
+++ b/spec/lib/camaleon_cms/uploader_content_security_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe CamaleonCms::UploaderContentSecurity do
       end
     end
 
+    context 'with representative event handlers (single-alternation equivalence)' do
+      # The 58 per-stem regexes were folded into one alternation; these span the list and its
+      # `<stem>\w*\s*=` family matching, proving the consolidation kept the same coverage.
+      %w[onclick onerror onload onmouseover onmousedown onfocusin onreadystatechange onwheel].each do |handler|
+        it "rejects #{handler}" do
+          expect(scan(%(<div #{handler}="alert(1)">x</div>))).to be_truthy
+        end
+      end
+
+      it 'still tolerates whitespace between the handler and the equals sign' do
+        expect(scan(%(<div onclick = "alert(1)">x</div>))).to be_truthy
+      end
+
+      it 'does not flag a plain word that merely starts with "on"' do
+        expect(scan('The online onboarding notes are onerous.', ext: '.txt')).to be_falsey
+      end
+    end
+
     context 'with dangerous elements' do
       it 'rejects a meta refresh redirect' do
         expect(scan(%(<meta http-equiv="refresh" content="0;url=//evil.tld">))).to be_truthy

--- a/spec/lib/camaleon_cms/uploader_implementation_parity_spec.rb
+++ b/spec/lib/camaleon_cms/uploader_implementation_parity_spec.rb
@@ -51,12 +51,19 @@ RSpec.describe 'uploader implementation parity' do
       expect(helper.instance_methods + helper.private_instance_methods).not_to include(:cama_upload_url_error)
     end
 
-    it 'keeps the message seam overrides on the helper only' do
-      seam = %i[cama_uploader_ct cama_uploader_t cama_uploader_human_size]
+    it 'keeps the t and human_size seam overrides on the helper only' do
+      seam = %i[cama_uploader_t cama_uploader_human_size]
 
       expect(helper.instance_methods(false) & seam).to match_array(seam)
       expect(concern.instance_methods(false) & seam).to be_empty
       seam.each { |name| expect(concern.instance_method(name).owner).to eq(CamaleonCms::UploaderPipeline) }
+    end
+
+    it 'overrides cama_uploader_ct on both entry points so each can run its own translation hook' do
+      # The helper always routes through ct; the concern routes through ct only when its host
+      # responds to it (the media controllers), falling back to the pipeline I18n default.
+      expect(helper.instance_method(:cama_uploader_ct).owner).to eq(CamaleonCms::UploaderHelper)
+      expect(concern.instance_method(:cama_uploader_ct).owner).to eq(CamaleonCms::RuntimeUploaderConcern)
     end
   end
 

--- a/spec/requests/security/upload_before_upload_rescan_spec.rb
+++ b/spec/requests/security/upload_before_upload_rescan_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# N2: before_upload fires AFTER the content scan and can rebind settings[:uploaded_io], so a
+# handler could launder blocked bytes past the scanner. For an untrusted uploader the pipeline
+# must re-scan the substituted IO. Exercised directly against upload_file through a minimal
+# host, with the trust gate stubbed to model an untrusted vs. permitted uploader.
+RSpec.describe 'Security: before_upload re-scan', type: :request do
+  init_site
+
+  let(:site) { Cama::Site.first }
+
+  let(:host_class) do
+    Class.new do
+      include CamaleonCms::UploaderContentSecurity
+      include CamaleonCms::UploaderPathSecurity
+      include CamaleonCms::UploaderPipeline
+      include CamaleonCms::UploaderImageProcessing
+      include CamaleonCms::UploaderSupport
+
+      attr_accessor :site
+
+      def current_site
+        site
+      end
+
+      def hooks_run(key, params = nil)
+        PluginRoutes.get_anonymous_hooks(key).each { |h| h.call(params) }
+      end
+    end
+  end
+
+  let(:host) { host_class.new.tap { |h| h.site = site.decorate } }
+
+  # A clean source file the initial scan passes.
+  let(:clean_source) do
+    path = File.join(Dir.mktmpdir, 'clean.txt')
+    File.write(path, 'perfectly harmless text')
+    path
+  end
+
+  # Bytes a before_upload handler swaps in after the scan.
+  let(:malicious_bytes) { '<script>alert(document.cookie)</script>' }
+
+  def swap_io_after_hook
+    PluginRoutes.add_anonymous_hook('before_upload', lambda { |settings|
+      evil = Tempfile.new(['rewritten', '.html'])
+      evil.write(malicious_bytes)
+      evil.rewind
+      settings[:uploaded_io] = evil
+    }, 'spec-n2-swap')
+  end
+
+  after { PluginRoutes.remove_anonymous_hook('before_upload', 'spec-n2-swap') }
+
+  context 'when the uploader is untrusted' do
+    before { allow(host).to receive(:cama_trusted_for_unfiltered_upload?).and_return(false) }
+
+    it 'refuses the upload when a handler substitutes blocked bytes' do
+      swap_io_after_hook
+      result = host.upload_file(clean_source, folder: 'spec_n2')
+
+      expect(result[:error]).to match(/malicious/i)
+    end
+
+    it 'never reaches the persistence step for substituted blocked bytes' do
+      swap_io_after_hook
+      expect(host.cama_uploader).not_to receive(:add_file)
+
+      host.upload_file(clean_source, folder: 'spec_n2')
+    end
+
+    it 'stores an upload when no handler substitutes the IO' do
+      result = host.upload_file(clean_source, folder: 'spec_n2')
+
+      expect(result[:error]).to be_nil
+    end
+  end
+
+  context 'when the uploader holds the permission' do
+    before { allow(host).to receive(:cama_trusted_for_unfiltered_upload?).and_return(true) }
+
+    it 'persists the substituted bytes without a re-scan' do
+      swap_io_after_hook
+      result = host.upload_file(clean_source, folder: 'spec_n2')
+
+      expect(result[:error]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` batched the upload-pipeline findings as PR 6, ordered so
the security fix lands first (N2) and the perf refactor rebases over it.

- **N2 (security).** `before_upload` fires *after* the content scan, and the file finally
  persisted is `settings[:uploaded_io]` — which a hook handler may have rebound
  (`camaleon_image_optimizer` rewrites the IO in place, e.g. SVGO on an SVG). So for a caller
  without `media_unfiltered_upload`, the scanned bytes need not be the persisted bytes, letting a
  handler launder a blocked payload past the scanner. The pipeline now captures the IO before the
  hook and, when an untrusted uploader's handler replaced it (object identity across the hook),
  re-scans the substituted bytes and fails closed. An unchanged IO is not re-scanned (the initial
  scan already covered it) and a permission-holder is exempt exactly as before. This implements
  the `security-capability-gating` "content substituted after the check" requirement for uploads.
- **M26.** `cama_size_limit_error` — the single gate every upload path flows through — treated a
  stored `filesystem_max_size` of `0` as a real limit (`0 >= size` is false for any non-empty
  file), so a site with the setting blank or zeroed failed **every** upload and crop with "File
  size exceeded (0 Bytes)". A non-positive maximum now means unlimited. Because this is the shared
  read point, `cama_contact_form`'s own `maximum:` pass-through is covered without touching the
  plugin.
- **M25 (perf).** The content scan matched 58 event-handler regexes in a loop over the full
  buffer; they fold into one alternation (`SUSPICIOUS_PATTERNS` is now three patterns, not sixty),
  matching unchanged and verified by the existing bypass/keep-passing coverage plus
  representative-handler cases.
- **M24.** Media-manager (controller) upload errors never ran the `on_translation` hook — the
  pipeline's `cama_uploader_ct` is a hard `I18n.t` that only `UploaderHelper` overrode.
  `RuntimeUploaderConcern` now routes through `ct` when its host responds to it (the controllers
  do, since #1223 restored `ct` to the chain), falling back to `I18n` for non-controller
  includers. The default no-hook text is identical; this just makes controller upload messages
  plugin-overridable, as #1212's changelog claimed.
- **M28 (docs).** Changelog note that dropping a plugin/theme folder then activating it requires a
  restart now (#1163 behavior).

The `upload-content-security`, `upload-staging-lifecycle`, and `uploader-implementation-parity`
capabilities are amended and archived on the branch.

## Review follow-ups

Two post-review fixes are folded in:

- The size gate's positive comparison now coerces like its non-positive guard: a numeric-string
  `:maximum` (the plugin pass-through case above) previously raised `ArgumentError` instead of
  enforcing the limit. Covered in the size-limit spec and recorded in the
  `upload-staging-lifecycle` capability.
- The pipeline's message-seam comment still described the pre-#1223 world (controllers without
  `ct`); it now matches the M24 override it sits beside. Comment-only.

## User-Visible Impact

An authenticated uploader without the unfiltered-upload permission can no longer use a
`before_upload` handler to store bytes the scanner never saw; a site whose max-file-size setting
is blank or zero can upload and crop again (and a plugin-supplied numeric-string limit is
enforced rather than erroring); media-manager upload errors are plugin-overridable;
and content scans are cheaper on large uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

