### PR TITLE
Media browser: paginate at the database; document asset-snapshot and theme-lookup behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- **Notes for upgraders (two documented behaviors, no code change):**
+  - **Assets:** the engine's list of plugin/theme asset roots to precompile is a boot-time
+    snapshot. A Sprockets-3 host app that appends its own `config.assets.paths` in an initializer
+    running *after* the engine's will not have those files precompiled in production. Drive
+    precompilation from `manifest.js` (as the maintained host apps do) rather than appending paths
+    after boot. Regression audit M29.
+  - **Template lookup:** an explicit `render prefixes: [...]` whose list is entirely theme-scoped
+    (only `themes/<slug>/views` and/or `camaleon_cms/default_theme`) is looked up in exactly those
+    prefixes — the controller/global prefixes are deliberately not merged, so a theme partial
+    cannot resolve another site's per-site-override or a plugin's views. A render that needs a
+    controller-owned template must include a non-theme prefix in the list. Regression audit M30.
+
 - **Security fix:** An authenticated uploader without the `media_unfiltered_upload` permission
   could use a `before_upload` hook to substitute bytes the content scanner never saw, since the
   hook runs after the scan and the persisted IO is what it leaves behind. The pipeline now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Fix:** The admin media browser paginates at the database again instead of loading a folder's
+  entire media list into memory and re-checking every image's thumbnail on disk per page view;
+  the legacy-thumbnail repair now runs only over the rendered page. Sites with large media folders
+  load the media manager far faster. Regression audit M27.
+  [#1242](https://github.com/owen2345/camaleon-cms/pull/1242).
+
 - **Notes for upgraders (two documented behaviors, no code change):**
   - **Assets:** the engine's list of plugin/theme asset roots to precompile is a boot-time
     snapshot. A Sprockets-3 host app that appends its own `config.assets.paths` in an initializer

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -10,7 +10,7 @@ module CamaleonCms
       # render media section
       def index
         @show_file_actions = true
-        @files = @tree.paginate(page: params[:page], per_page: 100)
+        @files = cama_uploader.cama_prepare_browser_page(@tree.paginate(page: params[:page], per_page: 100))
         @next_page = @files.current_page < @files.total_pages ? @files.current_page + 1 : nil
         add_breadcrumb I18n.t('camaleon_cms.admin.sidebar.media')
       end
@@ -58,7 +58,7 @@ module CamaleonCms
       def ajax
         @show_file_actions = true if current_site.get_option('file_actions_in_modals') == 'yes'
         @tree = cama_uploader.search(params[:search]) if params[:search].present?
-        @files = @tree.paginate(page: params[:page], per_page: 100)
+        @files = cama_uploader.cama_prepare_browser_page(@tree.paginate(page: params[:page], per_page: 100))
         @next_page = @files.current_page < @files.total_pages ? @files.current_page + 1 : nil
         if params[:partial].present?
           render json: { next_page: @next_page,

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -32,18 +32,15 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
     { error: 'File not found' }
   end
 
-  # Lists cached media objects for a folder, transparently fixing legacy thumbnail
-  # URLs (see #cama_compat_legacy_thumb). The cache (media DB records) may still
-  # hold thumb URLs computed from the source extension (sample: ".jpg") while the
-  # on-disk thumbnail is a legacy ".png"; without this the admin media browser
-  # would render 404 thumbnails for such files.
-  def objects(prefix = '/', _sort = 'created_at')
-    res = super
-    return res if res.blank?
-
-    res = res.to_a
-    res.each { |item| cama_fix_legacy_thumb_item(item) }
-    res
+  # Repairs legacy thumbnail URLs (see #cama_compat_legacy_thumb) for one rendered page of
+  # media items. The cache (media DB records) may still hold thumb URLs computed from the
+  # source extension (sample: ".jpg") while the on-disk thumbnail is a legacy ".png"; without
+  # this the admin media browser would render 404 thumbnails for such files. Applied by the
+  # media controller to the paginated page only — #objects stays a lazy relation so the browser
+  # paginates at the database instead of materializing (and stat-ing) the whole folder.
+  def cama_prepare_browser_page(items)
+    items.each { |item| cama_fix_legacy_thumb_item(item) }
+    items
   end
 
   def file_parse(key)

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -38,6 +38,15 @@ class CamaleonCmsUploader
     res
   end
 
+  # Post-process one *rendered page* of media items for display. Base and S3 need nothing;
+  # the local uploader overrides this to repair legacy thumbnail URLs (see its override), so
+  # that per-image filesystem check runs over the paginated page rather than the whole folder.
+  # Kept out of #objects on purpose: #objects must stay a lazy relation so the media browser
+  # paginates at the database.
+  def cama_prepare_browser_page(items)
+    items
+  end
+
   # clean cached of files structure saved into DB
   def clear_cache
     get_media_collection.destroy_all

--- a/config/initializers/action_view.rb
+++ b/config/initializers/action_view.rb
@@ -63,6 +63,13 @@ module ActionView
       # templates), it returns a blank list, signalling the caller to merge
       # `self.prefixes` as before -- this keeps the plugin's own
       # `plugins/<name>/views/...` lookup prefix reachable.
+      #
+      # Known limitation (regression audit M30, deliberately kept): an explicit
+      # `render prefixes:` whose list is *entirely* theme-scoped but whose target
+      # template actually lives under a controller prefix raises MissingTemplate,
+      # because `self.prefixes` are not merged in that case. Merging them would
+      # reopen the per-site-override / cross-theme leak this guard exists to close,
+      # and no stock or ecosystem caller hits it, so the isolation is kept.
       def cama_theme_scoped_prefixes(prefixes)
         theme = CurrentRequest.frontend_current_theme
         slug = theme&.slug

--- a/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-09

--- a/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/design.md
+++ b/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/design.md
@@ -1,0 +1,71 @@
+# Design — harden-media-pagination-and-lookup-docs
+
+## Context
+
+See `proposal.md` — Why. Load-bearing facts:
+
+- The only caller of `cama_uploader.objects` is `Admin::MediaController` (`init_media_vars` sets
+  `@tree`; `index` and `ajax` paginate it). The AWS `bucket.objects` calls are the S3 SDK,
+  unrelated.
+- The base `CamaleonCmsUploader#objects` returns an `ActiveRecord::Relation`
+  (`get_media_collection.where(...)` or `.take.try(:items)`), or whatever an
+  `uploader_list_objects` hook substitutes.
+- The local override exists *only* to run `cama_fix_legacy_thumb_item` (a `File.exist?` per
+  image) over every item; it forces `.to_a`, which also defeats `will_paginate`'s SQL pagination
+  (the controller then uses `will_paginate/array`, in memory).
+- Media browser items are media-collection records carrying `thumb`/`url`/`name`/`folder_path`/
+  `is_folder`/`file_type`; the fixup mutates `item['thumb']` for display only.
+- `cama_prepare_browser_page` runs after pagination, so an AR relation is loaded once and its
+  records are mutated in place; the view then iterates the same loaded page.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Restore DB-level pagination for the media browser and confine the per-image filesystem check to
+  the rendered page.
+- Keep S3/base behavior identical (the seam is a no-op there).
+- Document M29 and M30 accurately; pin the #1183 lookup isolation the maintainer chose to keep.
+
+**Non-Goals**
+
+- No M29 code change — no host app appends `assets.paths` after the engine; both use
+  `manifest.js`. Documentation only.
+- No M30 code change — the maintainer signed off (2026-08-09) on keeping the #1183 isolation:
+  merging controller prefixes into an entirely-theme-scoped explicit render would reopen the
+  cross-theme / per-site-override leak #1183 closed, for zero consumers. Documented, and the
+  isolation is pinned by a spec so it is not silently reverted.
+- No change to the `uploader_list_objects` hook contract — a hook that returns an Array still
+  paginates in memory (its choice); the fix targets the default relation path.
+
+## Decisions
+
+1. **Delete the local `objects` override; add `cama_prepare_browser_page`.** With the fixup moved
+   out, the override is a pure `super` passthrough, so it is removed rather than left calling
+   `super`. The base uploader gains `cama_prepare_browser_page(items) => items`; the local
+   uploader overrides it to run `cama_fix_legacy_thumb_item` per item and return them. The media
+   controller wraps both `@tree.paginate(...)` sites (`index`, `ajax`) with it.
+   - Rejected: paginating inside the uploader (larger surface, changes the controller contract);
+     a controller `case uploader.class` (leaks uploader knowledge into the controller).
+2. **Retarget the existing `#objects` legacy-thumb unit specs to the seam.** The fixup logic is
+   unchanged — only its call site moves — so the three cases now drive
+   `cama_prepare_browser_page`, and a new case asserts `objects` returns a relation
+   (`be_a ActiveRecord::Relation`), pinning the pagination contract.
+3. **M30 = pin the isolation, document the limitation.** A `LookupContext`-level spec asserts that
+   an entirely-theme-scoped explicit prefix list does not merge `self.prefixes`
+   (`cama_theme_scoped_prefixes` returns the scoped list), so the deliberate #1183 behavior is
+   guarded. The changelog states the known limitation for explicit-prefix renders.
+
+## Risks / Trade-offs
+
+- [A hook that returns a non-relation still materializes] → unchanged from today and out of
+  scope; the default path (the real cost) is fixed.
+- [`cama_prepare_browser_page` mutating a loaded relation page] → the page is loaded once by the
+  seam's `each`; the view iterates the cached records, preserving the mutation. Verified by the
+  request-level index behavior plus the unit seam spec.
+- [M30 stays a known limitation] → accepted and signed off; zero consumers, and the alternative
+  reopens a deliberate isolation.
+
+## Migration Plan
+
+Code + docs; no schema or data changes. Deploy normally; rollback = revert the commits.

--- a/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/proposal.md
+++ b/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+The 2026-08 regression audit batched the media/infra residuals as PR 7 (M27, M29-doc, M30-doc) —
+the last of the medium-fix sequence.
+
+- **M27** — the local media browser paginates in memory and stats the filesystem for every image
+  in a folder on every page view. `CamaleonCmsLocalUploader#objects` calls `super`, then
+  `.to_a` (materializing the whole folder's media records) and runs the legacy-thumb fixup —
+  which does a `File.exist?` per image — over **all** of them. The controller then paginates that
+  Array with `will_paginate/array` (in-memory). 2.9.2 returned the relation, so pagination was
+  SQL `LIMIT`/`OFFSET` and the fixup touched only the rendered page. Folders with thousands of
+  files load fully and re-stat every image per page.
+- **M29** (doc) — the engine's assets precompile list is a boot-time snapshot; a Sprockets-3 host
+  app that appends plugin/theme asset roots in its own initializer (after the engine's) loses
+  those files in production. The ecosystem sweep found neither host app does this (both drive
+  precompilation from `manifest.js`), so this is documented, not code-fixed.
+- **M30** (doc) — the #1183 theme-scoped lookup guard deliberately does **not** merge the
+  controller/global prefixes when an explicit `render prefixes:` is entirely theme-scoped, to
+  keep per-site-override and plugin prefixes from leaking into a theme partial. The residual is a
+  `MissingTemplate` for an explicit-prefix render whose template actually lives under a controller
+  prefix. Zero stock and zero ecosystem `render prefixes:` consumers hit this, and the maintainer
+  signed off (2026-08-09) on **keeping the isolation** rather than reopening it — so this is
+  documented as a known limitation, with the deliberate behavior pinned so it is not "fixed" later.
+
+## What Changes
+
+- **M27**: `CamaleonCmsLocalUploader#objects` returns the relation unchanged (the override that
+  materialized and fixed up the whole folder is removed). The legacy-thumb fixup moves to a
+  polymorphic page seam, `cama_prepare_browser_page`, applied by the media controller to the
+  paginated page only (a no-op on the base/S3 uploaders). Pagination is again DB-level
+  (`LIMIT`/`OFFSET`), and the per-image `File.exist?` runs over one page, not the whole folder.
+- **M29**: a changelog note for Sprockets-3 host apps that append asset roots after the engine.
+- **M30**: a changelog note plus a spec pinning the deliberate #1183 isolation (an entirely
+  theme-scoped explicit render does not merge the controller prefixes).
+
+## Capabilities
+
+### New Capabilities
+
+- `local-media-pagination`: `objects` returns a lazy relation so the media browser paginates at
+  the database, and the legacy-thumbnail fixup is applied to the rendered page only (polymorphic,
+  no-op for non-local uploaders).
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `app/uploaders/camaleon_cms_uploader.rb` (base page seam),
+  `app/uploaders/camaleon_cms_local_uploader.rb` (drop the `objects` override, add the seam),
+  `app/controllers/camaleon_cms/admin/media_controller.rb` (apply the seam at the two paginate
+  sites), `CHANGELOG.md`.
+- Specs: `spec/uploaders/local_uploader_spec.rb` (retarget the legacy-thumb `#objects` cases to
+  the page seam, add the lazy-relation assertion), new
+  `spec/initializers/theme_scoped_lookup_spec.rb` (pin the M30 isolation).
+- No routes or schema changes. Behavior deltas: large media folders paginate at the DB and stat
+  only the visible page; documentation gains the M29/M30 notes. The #1183 lookup isolation is
+  unchanged.

--- a/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/specs/local-media-pagination/spec.md
+++ b/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/specs/local-media-pagination/spec.md
@@ -1,0 +1,48 @@
+## Purpose
+
+Keep the admin media browser scalable: list a folder as a lazy database relation so pagination is
+applied at the database, and repair legacy thumbnail URLs only for the page actually rendered —
+not by materializing and stat-ing the whole folder on every view.
+
+## ADDED Requirements
+
+### Requirement: The local uploader lists media as a lazy relation
+
+`CamaleonCmsLocalUploader#objects` SHALL return the media collection as a lazy query relation for
+the normal (no custom-hook) case, not a materialized array, so a caller paginating the result
+retrieves only the requested page from the database (`LIMIT`/`OFFSET`) rather than loading the
+whole folder into memory.
+
+#### Scenario: objects returns a paginable relation
+
+- **WHEN** `objects` is called for a folder with no `uploader_list_objects` hook registered
+- **THEN** the result is an `ActiveRecord::Relation` (it responds to `limit`/`offset`), not an
+  Array
+
+#### Scenario: Pagination retrieves only the requested page
+
+- **WHEN** the media browser paginates the `objects` result to a page size
+- **THEN** the database query is bounded by that page size rather than the folder's total count
+
+### Requirement: Legacy thumbnail repair runs on the rendered page only
+
+The legacy-thumbnail URL fixup (which stats the filesystem per image) SHALL be applied through a
+polymorphic page seam that the media controller invokes on the paginated page, not inside
+`objects` over the whole folder. The seam SHALL be a no-op for uploaders without legacy
+thumbnails (the base and S3 uploaders) and SHALL repair thumbnails for the local uploader.
+
+#### Scenario: The rendered page still gets repaired thumbnails
+
+- **WHEN** the media browser renders a page containing an image whose cached thumb URL points at
+  a missing computed thumbnail while a legacy `.png` sibling exists on disk
+- **THEN** that item's thumb URL on the rendered page is rewritten to the legacy `.png`
+
+#### Scenario: The seam is a no-op for a non-local uploader
+
+- **WHEN** the page seam is invoked on the base (or S3) uploader
+- **THEN** the items are returned unchanged
+
+#### Scenario: The fixup does not run over the whole folder
+
+- **WHEN** `objects` is called for a folder
+- **THEN** the per-image legacy-thumbnail filesystem check is not performed inside `objects`

--- a/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/tasks.md
+++ b/openspec/changes/archive/2026-08-09-harden-media-pagination-and-lookup-docs/tasks.md
@@ -1,0 +1,42 @@
+## 1. M27 — DB-level media pagination + page-scoped thumb fixup (commit 1)
+
+- [x] 1.1 Retarget the three `#objects` legacy-thumb cases in `spec/uploaders/local_uploader_spec.rb`
+      to `cama_prepare_browser_page`, and add a case asserting `objects('/')` returns an
+      `ActiveRecord::Relation` (responds to `limit`) — red on master, where `objects` returns a
+      materialized Array. Add a base/S3 no-op case.
+- [x] 1.2 Base `CamaleonCmsUploader#cama_prepare_browser_page(items) => items`; `CamaleonCmsLocalUploader`
+      drops the `objects` override and overrides `cama_prepare_browser_page` to run the
+      legacy-thumb fixup per item.
+- [x] 1.3 `Admin::MediaController`: wrap the `index` and `ajax` `@tree.paginate(...)` results with
+      `cama_uploader.cama_prepare_browser_page(...)`.
+- [x] 1.4 Spec files green; rubocop clean on touched files; commit M27.
+
+## 2. M30 — pin the #1183 lookup isolation (commit 2)
+
+- [x] 2.1 New `spec/initializers/theme_scoped_lookup_spec.rb`: an entirely theme-scoped explicit
+      prefix list yields `cama_theme_scoped_prefixes == the scoped list` (self.prefixes not
+      merged); a mixed list (theme + plugin prefix) yields nil (merge as before). Pins the
+      deliberate isolation.
+- [x] 2.2 Add a clarifying comment at the guard noting the documented known limitation
+      (explicit-prefix renders resolving to a controller-owned template are not merged — by design).
+
+## 3. M29 + M30 — documentation (commit 3, docs-only, [skip ci])
+
+- [x] 3.1 CHANGELOG: M29 note (Sprockets-3 host apps appending asset roots after the engine lose
+      them in production; use `manifest.js`); M30 note (an explicit `render prefixes:` that is
+      entirely theme-scoped is not merged with controller prefixes — deliberate #1183 isolation).
+
+## 4. Verification and CI parity
+
+- [x] 4.1 Full `bin/rspec` suite green.
+- [x] 4.2 `bin/rubocop` clean, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 5. OpenSpec + PR protocol
+
+- [x] 5.1 `openspec validate harden-media-pagination-and-lookup-docs --strict` passes; archive
+      on-branch (syncs `local-media-pagination`); commit the archived change (no `[skip ci]` —
+      heads the first push).
+- [x] 5.2 Push, open the PR (What and Why + User-Visible Impact; protocol constraints), first
+      push runs CI.
+- [x] 5.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/local-media-pagination/spec.md
+++ b/openspec/specs/local-media-pagination/spec.md
@@ -1,0 +1,48 @@
+# local-media-pagination Specification
+
+## Purpose
+Keep the admin media browser scalable: list a folder as a lazy database relation so pagination is
+applied at the database, and repair legacy thumbnail URLs only for the page actually rendered —
+not by materializing and stat-ing the whole folder on every view.
+## Requirements
+### Requirement: The local uploader lists media as a lazy relation
+
+`CamaleonCmsLocalUploader#objects` SHALL return the media collection as a lazy query relation for
+the normal (no custom-hook) case, not a materialized array, so a caller paginating the result
+retrieves only the requested page from the database (`LIMIT`/`OFFSET`) rather than loading the
+whole folder into memory.
+
+#### Scenario: objects returns a paginable relation
+
+- **WHEN** `objects` is called for a folder with no `uploader_list_objects` hook registered
+- **THEN** the result is an `ActiveRecord::Relation` (it responds to `limit`/`offset`), not an
+  Array
+
+#### Scenario: Pagination retrieves only the requested page
+
+- **WHEN** the media browser paginates the `objects` result to a page size
+- **THEN** the database query is bounded by that page size rather than the folder's total count
+
+### Requirement: Legacy thumbnail repair runs on the rendered page only
+
+The legacy-thumbnail URL fixup (which stats the filesystem per image) SHALL be applied through a
+polymorphic page seam that the media controller invokes on the paginated page, not inside
+`objects` over the whole folder. The seam SHALL be a no-op for uploaders without legacy
+thumbnails (the base and S3 uploaders) and SHALL repair thumbnails for the local uploader.
+
+#### Scenario: The rendered page still gets repaired thumbnails
+
+- **WHEN** the media browser renders a page containing an image whose cached thumb URL points at
+  a missing computed thumbnail while a legacy `.png` sibling exists on disk
+- **THEN** that item's thumb URL on the rendered page is rewritten to the legacy `.png`
+
+#### Scenario: The seam is a no-op for a non-local uploader
+
+- **WHEN** the page seam is invoked on the base (or S3) uploader
+- **THEN** the items are returned unchanged
+
+#### Scenario: The fixup does not run over the whole folder
+
+- **WHEN** `objects` is called for a folder
+- **THEN** the per-image legacy-thumbnail filesystem check is not performed inside `objects`
+

--- a/spec/initializers/theme_scoped_lookup_spec.rb
+++ b/spec/initializers/theme_scoped_lookup_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Pins the deliberate #1183 isolation (regression audit M30, kept by maintainer decision
+# 2026-08-09): when an explicit `render prefixes:` list is ENTIRELY theme-scoped, the lookup is
+# restricted to those prefixes and the controller/global `self.prefixes` are NOT merged, so a
+# theme partial cannot reach another site's per-site-override or a plugin's views. A mixed list
+# (theme + a non-theme prefix) still merges as before. The documented cost is that an
+# explicit-prefix render whose template lives under a controller prefix raises MissingTemplate —
+# this is intentional, not to be "fixed" by reopening the merge.
+RSpec.describe 'ActionView theme-scoped lookup isolation', type: :model do
+  let(:lookup_context) { ActionView::LookupContext.new([]) }
+  let(:theme) { instance_double(CamaleonCms::Theme, slug: 'mytheme') }
+
+  before { CurrentRequest.frontend_current_theme = theme }
+
+  after { CurrentRequest.frontend_current_theme = nil }
+
+  def scoped(prefixes)
+    lookup_context.send(:cama_theme_scoped_prefixes, prefixes)
+  end
+
+  it 'restricts to the theme prefixes when the whole list is theme-scoped' do
+    prefixes = ['themes/mytheme/views', 'camaleon_cms/default_theme']
+
+    expect(scoped(prefixes)).to eq(prefixes)
+  end
+
+  it 'does not scope (merges as before) when a non-theme prefix is present' do
+    prefixes = ['themes/mytheme/views', 'plugins/my_plugin/views']
+
+    expect(scoped(prefixes)).to be_nil
+  end
+
+  it 'does not scope when there is no frontend theme' do
+    CurrentRequest.frontend_current_theme = nil
+
+    expect(scoped(['themes/mytheme/views'])).to be_nil
+  end
+end

--- a/spec/uploaders/local_uploader_spec.rb
+++ b/spec/uploaders/local_uploader_spec.rb
@@ -74,7 +74,21 @@ RSpec.describe CamaleonCmsLocalUploader do
     end
   end
 
-  describe '#objects (legacy thumbnail fallback for cached media records)' do
+  describe '#objects (lazy relation for DB-level pagination)' do
+    let(:collection) { uploader.send(:get_media_collection) }
+
+    it 'returns a lazy ActiveRecord relation, not a materialized array' do
+      collection.create!(name: 'a.jpg', folder_path: '/', is_folder: false, is_public: false,
+                         file_type: 'image', url: '/media/1/a.jpg', thumb: '')
+
+      res = uploader.objects('/')
+
+      expect(res).to be_a(ActiveRecord::Relation)
+      expect(res).to respond_to(:limit)
+    end
+  end
+
+  describe '#cama_prepare_browser_page (legacy thumbnail fallback, applied to the rendered page)' do
     let(:root_folder) { uploader.instance_variable_get(:@root_folder) }
     let(:thumb_dir) { File.join(root_folder, 'thumb') }
     let(:collection) { uploader.send(:get_media_collection) }
@@ -87,20 +101,22 @@ RSpec.describe CamaleonCmsLocalUploader do
                          file_type: 'image', url: '/media/1/photo.jpg', thumb: thumb)
     end
 
+    def prepared(name)
+      uploader.cama_prepare_browser_page(uploader.objects('/').to_a).find { |i| i['name'] == name }
+    end
+
     it 'rewrites cached .jpg thumb urls to the on-disk legacy .png' do
       File.write(File.join(thumb_dir, 'photo-jpg.png'), 'x')
       create_image_media('/media/1/thumb/photo-jpg.jpg')
 
-      item = uploader.objects('/').find { |i| i['name'] == 'photo.jpg' }
-      expect(item['thumb']).to eq('/media/1/thumb/photo-jpg.png')
+      expect(prepared('photo.jpg')['thumb']).to eq('/media/1/thumb/photo-jpg.png')
     end
 
     it 'keeps the cached thumb url when the matching file exists on disk' do
       File.write(File.join(thumb_dir, 'photo-jpg.jpg'), 'x')
       create_image_media('/media/1/thumb/photo-jpg.jpg')
 
-      item = uploader.objects('/').find { |i| i['name'] == 'photo.jpg' }
-      expect(item['thumb']).to eq('/media/1/thumb/photo-jpg.jpg')
+      expect(prepared('photo.jpg')['thumb']).to eq('/media/1/thumb/photo-jpg.jpg')
     end
 
     it 'falls back to the original file url for a cached item with no thumbnail on disk (favicon)' do
@@ -108,8 +124,16 @@ RSpec.describe CamaleonCmsLocalUploader do
                          file_type: 'image', url: '/media/1/favicon.ico',
                          thumb: '/media/1/thumb/favicon-ico.ico')
 
-      item = uploader.objects('/').find { |i| i['name'] == 'favicon.ico' }
-      expect(item['thumb']).to eq('/media/1/favicon.ico')
+      expect(prepared('favicon.ico')['thumb']).to eq('/media/1/favicon.ico')
+    end
+  end
+
+  describe '#cama_prepare_browser_page on the base uploader (no-op)' do
+    it 'returns the items unchanged' do
+      items = [{ 'name' => 'x', 'thumb' => '/computed.jpg' }]
+      base = CamaleonCmsUploader.new(current_site: current_site)
+
+      expect(base.cama_prepare_browser_page(items)).to eq(items)
     end
   end
 end


### PR DESCRIPTION
## What and Why

The regression audit of `2.9.2..master` batched the media/infra residuals as PR 7 — the last of
the medium-fix sequence: one code fix and two documented behaviors.

- **M27 (media pagination).** The local media browser loaded every media record in a folder and
  re-stat'd every image (a `File.exist?` per image, for the legacy-thumbnail fixup) on **every**
  page view: `CamaleonCmsLocalUploader#objects` called `super`, then `.to_a` and ran the fixup
  over the whole folder, and the controller paginated that Array in memory. 2.9.2 returned the
  relation, so pagination was SQL `LIMIT`/`OFFSET` and the fixup touched only the rendered page.
  The `objects` override (which existed only for the fixup) is removed so `objects` stays a lazy
  relation, and the fixup moves to a polymorphic page seam — `cama_prepare_browser_page`, a no-op
  on the base and S3 uploaders — that the controller applies to the paginated page at both the
  index and modal-ajax sites. Large folders now fetch one page from the database and stat only
  the images on it.
- **M29 (documented).** The engine's plugin/theme asset-precompile list is a boot-time snapshot;
  a Sprockets-3 host app that appends its own `assets.paths` in an initializer running after the
  engine's loses those files in production. Neither maintained host app does this (both use
  `manifest.js`), so this is a changelog note, not a code change.
- **M30 (documented, maintainer-approved).** The #1183 lookup guard deliberately does not merge
  the controller/global prefixes when an explicit `render prefixes:` is entirely theme-scoped, so
  a theme partial cannot resolve another site's per-site-override or a plugin's views. The
  residual is a `MissingTemplate` for an explicit-prefix render whose template lives under a
  controller prefix. With zero stock and zero ecosystem `render prefixes:` consumers, and because
  merging would reopen the cross-theme / per-site-override leak the guard exists to close, the
  isolation is kept — pinned by a `LookupContext` spec and documented at the guard and in the
  changelog, rather than reopened.

The `local-media-pagination` capability is archived on the branch.

## User-Visible Impact

Sites with large media folders no longer load the entire folder (and re-stat every image) on each
media-browser page view — pagination is applied at the database and only the visible page's images
are checked; the two documented behaviors (asset precompilation from `manifest.js`, and the
theme-scoped template-lookup isolation) are now stated for upgraders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
