### PR TITLE
Harden SVG serving: case-insensitive extension match + Rack 3 header keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - **Security fix:** SVG uploads and `/media/` SVG responses are now matched by extension
   case-insensitively, so an uppercase-extension SVG (`image.SVG`) is scanned by the SVG parser and
   served with the `nosniff` / `script-src 'none'` headers like a lowercase one; the media security
-  header keys are also emitted lowercase for Rack 3. Regression audit L5, L6.
-  [#1243](https://github.com/owen2345/camaleon-cms/pull/1243).
+  header keys are also emitted lowercase for Rack 3. Review follow-ups on the same branch: the
+  SVG-to-JPG thumb/crop rename is case-insensitive too, so an uppercase `.SVG` now crops and
+  thumbnails to a real JPEG, and a file named exactly `.svg` keeps its SVG-parser routing.
+  Regression audit L5, L6. [#1243](https://github.com/owen2345/camaleon-cms/pull/1243).
 
 - **Fix:** The admin media browser paginates at the database again instead of loading a folder's
   entire media list into memory and re-checking every image's thumbnail on disk per page view;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- **Security fix:** SVG uploads and `/media/` SVG responses are now matched by extension
+  case-insensitively, so an uppercase-extension SVG (`image.SVG`) is scanned by the SVG parser and
+  served with the `nosniff` / `script-src 'none'` headers like a lowercase one; the media security
+  header keys are also emitted lowercase for Rack 3. Regression audit L5, L6.
+  [#1243](https://github.com/owen2345/camaleon-cms/pull/1243).
+
 - **Fix:** The admin media browser paginates at the database again instead of loading a folder's
   entire media list into memory and re-checking every image's thumbnail on disk per page view;
   the legacy-thumbnail repair now runs only over the rendered page. Sites with large media folders

--- a/app/uploaders/camaleon_cms_aws_uploader.rb
+++ b/app/uploaders/camaleon_cms_aws_uploader.rb
@@ -72,9 +72,7 @@ class CamaleonCmsAwsUploader < CamaleonCmsUploader
       'dimension' => ''
     }.with_indifferent_access
     if res['file_type'] == 'image' && File.extname(res['name']).downcase != '.gif'
-      res['thumb'] =
-        version_path(res['url']).sub('.svg',
-                                     '.jpg')
+      res['thumb'] = version_path(res['url']).sub(SVG_EXT_PATTERN, '.jpg')
     end
     res['key'] = File.join(res['folder_path'], res['name'])
     @aws_settings[:aws_file_read_settings].call(res, s3_file)

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -75,8 +75,9 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
                      end
     end
     if res['file_type'] == 'image'
-      res['thumb'].sub! '.svg', '.jpg'
-      res['thumb'] = cama_compat_legacy_thumb(res['thumb'], version_path(key).sub('.svg', '.jpg'), res['url'])
+      res['thumb'].sub!(SVG_EXT_PATTERN, '.jpg')
+      res['thumb'] = cama_compat_legacy_thumb(res['thumb'], version_path(key).sub(SVG_EXT_PATTERN, '.jpg'),
+                                              res['url'])
       im = MiniMagick::Image.open(file_path)
       res['dimension'] = begin
         "#{im[:width]}x#{im[:height]}"

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -1,5 +1,8 @@
 class CamaleonCmsUploader
   PRIVATE_DIRECTORY = 'private'.freeze
+  # Case-insensitive terminal-`.svg` matcher, borrowed from the thumb/crop rename convention it
+  # must stay in lockstep with (defined beside that convention in UploaderImageProcessing).
+  SVG_EXT_PATTERN = CamaleonCms::UploaderImageProcessing::SVG_EXT_PATTERN
 
   attr_accessor :thumb
 

--- a/lib/camaleon_cms/media_security_headers.rb
+++ b/lib/camaleon_cms/media_security_headers.rb
@@ -15,8 +15,10 @@ module CamaleonCms
       status, headers, body = @app.call(env)
 
       if env['REQUEST_METHOD'] == 'GET' && env['PATH_INFO']&.match?(SVG_PATH_PATTERN)
-        headers['X-Content-Type-Options'] = 'nosniff'
-        headers['Content-Security-Policy'] = "script-src 'none'"
+        # Lowercase header keys: the Rack 3 SPEC requires them and Falcon/Rack::Lint reject
+        # mixed case (Puma tolerated it, which hid this).
+        headers['x-content-type-options'] = 'nosniff'
+        headers['content-security-policy'] = "script-src 'none'"
       end
 
       [status, headers, body]

--- a/lib/camaleon_cms/media_security_headers.rb
+++ b/lib/camaleon_cms/media_security_headers.rb
@@ -2,7 +2,10 @@
 
 module CamaleonCms
   class MediaSecurityHeaders
-    SVG_PATH_PATTERN = %r{\A/media/.*\.svg\z}
+    # Case-insensitive: an `evil.SVG` is stored and served verbatim (get_file_format downcases
+    # the extension), so a case-sensitive match left uppercase-extension SVGs served inline
+    # without the protective headers.
+    SVG_PATH_PATTERN = %r{\A/media/.*\.svg\z}i
 
     def initialize(app)
       @app = app

--- a/lib/camaleon_cms/uploader_content_security.rb
+++ b/lib/camaleon_cms/uploader_content_security.rb
@@ -29,7 +29,7 @@ module CamaleonCms
                   else
                     uploaded_io.path
                   end
-      file_path&.end_with?('.svg')
+      cama_svg_extension?(file_path)
     end
 
     # Scans in-memory content. Callers holding decoded bytes (e.g. a base64 data:
@@ -39,8 +39,11 @@ module CamaleonCms
     # Returns a truthy value (the matched pattern, or true for SVG) when unsafe,
     # nil when safe -- matching file_content_unsafe?'s contract.
     def content_unsafe?(content, filename: nil)
-      return true if filename&.end_with?('.svg') && CamaleonCms::SvgContentChecker.unsafe?(content)
-      return nil if filename&.end_with?('.svg')
+      if cama_svg_extension?(filename)
+        return true if CamaleonCms::SvgContentChecker.unsafe?(content)
+
+        return nil
+      end
 
       normalized = CamaleonCms::ContentSecurity.normalize(content)
       CamaleonCms::ContentSecurity::SUSPICIOUS_PATTERNS.each do |pattern|
@@ -67,6 +70,15 @@ module CamaleonCms
       file.rewind if file.respond_to?(:rewind)
 
       content_unsafe?(content, filename: filename)
+    end
+
+    private
+
+    # Case-insensitive `.svg` test. Upload names arrive with whatever case the client sent
+    # (`evil.SVG`); a case-sensitive check routed those past the SVG-specific scanner into the
+    # weaker generic ruleset, so both entry points normalize the extension here.
+    def cama_svg_extension?(name)
+      File.extname(name.to_s).casecmp?('.svg')
     end
   end
 end

--- a/lib/camaleon_cms/uploader_content_security.rb
+++ b/lib/camaleon_cms/uploader_content_security.rb
@@ -76,9 +76,13 @@ module CamaleonCms
 
     # Case-insensitive `.svg` test. Upload names arrive with whatever case the client sent
     # (`evil.SVG`); a case-sensitive check routed those past the SVG-specific scanner into the
-    # weaker generic ruleset, so both entry points normalize the extension here.
+    # weaker generic ruleset, so both entry points normalize the extension here. A name whose
+    # basename is exactly `.svg` (a dotfile, which File.extname reports as having no extension)
+    # is still treated as an SVG: the pre-hardening `end_with?` check matched it, and routing it
+    # to the stricter parser fails closed.
     def cama_svg_extension?(name)
-      File.extname(name.to_s).casecmp?('.svg')
+      base = File.basename(name.to_s)
+      File.extname(base).casecmp?('.svg') || base.casecmp?('.svg')
     end
   end
 end

--- a/lib/camaleon_cms/uploader_image_processing.rb
+++ b/lib/camaleon_cms/uploader_image_processing.rb
@@ -6,6 +6,12 @@ module CamaleonCms
   # CamaleonCms::RuntimeUploaderConcern and CamaleonCms::UploaderHelper, so cropping
   # and resizing behave identically whichever one a caller included.
   module UploaderImageProcessing
+    # Terminal `.svg` extension, any case. The upload pipeline preserves the client's extension
+    # case (`logo.SVG` is stored verbatim), so every site renaming an SVG-derived artifact to
+    # `.jpg` must match case-insensitively or uppercase uploads keep their SVG name and format.
+    # Anchored so the rename never touches an `.svg` occurring mid-path.
+    SVG_EXT_PATTERN = /\.svg\z/i
+
     # generate thumbnail of a existent image
     # key: key of the current file
     # the thumbnail will be saved in my_images/my_img.png => my_images/thumb/my_img.png
@@ -14,8 +20,8 @@ module CamaleonCms
       h = thumb_size.present? ? thumb_size.split('x')[1] : cama_uploader.thumb[:h]
       uploaded_io = File.open(uploaded_io) if uploaded_io.is_a?(String)
       path_thumb = cama_resize_and_crop(uploaded_io.path, w, h)
-      thumb = cama_uploader.add_file(path_thumb, cama_uploader.version_path(key).sub('.svg', '.jpg'), is_thumb: true,
-                                                                                                      same_name: true)
+      thumb = cama_uploader.add_file(path_thumb, cama_uploader.version_path(key).sub(SVG_EXT_PATTERN, '.jpg'),
+                                     is_thumb: true, same_name: true)
       FileUtils.rm_f(path_thumb) if remove_source
       thumb
     end
@@ -66,10 +72,10 @@ module CamaleonCms
     def cama_resize_and_crop(file, w, h, settings = {})
       settings = { gravity: :north_east, overwrite: true, output_name: +'' }.merge!(settings)
       img = MiniMagick::Image.open(file)
-      if file.end_with? '.svg'
+      if file.match?(SVG_EXT_PATTERN)
         img.format 'jpg'
-        file.sub! '.svg', '.jpg'
-        settings[:output_name]&.sub!('.svg', '.jpg')
+        file.sub!(SVG_EXT_PATTERN, '.jpg')
+        settings[:output_name]&.sub!(SVG_EXT_PATTERN, '.jpg')
       end
       w = clamp_to_image_dimension(w, img[:width])
       h = clamp_to_image_dimension(h, img[:height])
@@ -99,12 +105,13 @@ module CamaleonCms
       end
 
       if settings[:overwrite]
-        data[:img].write(file.sub('.svg', '.jpg'))
+        data[:img].write(file.sub(SVG_EXT_PATTERN, '.jpg'))
       elsif settings[:output_name].present?
         data[:img].write(file = File.join(File.dirname(file), settings[:output_name]).to_s)
       else
-        data[:img].write(file = uploader_verify_name(File.join(File.dirname(file),
-                                                               "crop_#{File.basename(file.sub('.svg', '.jpg'))}")))
+        data[:img].write(file = uploader_verify_name(
+          File.join(File.dirname(file), "crop_#{File.basename(file.sub(SVG_EXT_PATTERN, '.jpg'))}")
+        ))
       end
       file
     end

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/design.md
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/design.md
@@ -1,0 +1,59 @@
+# Design — harden-svg-extension-case-and-rack3-headers
+
+## Context
+
+Two independent case-sensitivity defects on the same SVG defense-in-depth path (audit L5, L6):
+
+- Scan time: `UploaderContentSecurity#content_unsafe?` branches on `filename&.end_with?('.svg')`
+  to send SVG bytes to `SvgContentChecker` (which bans `foreignObject`, `handler`, `form`, `meta`,
+  `base`, `style`, `link`, and every `on*` attribute). Non-SVG content goes to the generic
+  `ContentSecurity::SUSPICIOUS_PATTERNS` scan, whose `BLOCKED_ELEMENTS` list does NOT include
+  `foreignObject`/`handler`. So an SVG whose only vector is one of those tags is caught for `.svg`
+  and missed for `.SVG`.
+- Serve time: `MediaSecurityHeaders` matches `%r{\A/media/.*\.svg\z}` and sets mixed-case header
+  keys. Uppercase paths miss the headers; mixed-case keys violate Rack 3.
+
+`self.class.get_file_format` already downcases the extension for format classification, so
+uppercase-extension SVGs are accepted uploads — the case-sensitivity is a real gap, not a
+theoretical one.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Route any-case SVG uploads through the SVG parser.
+- Apply the `/media/` SVG response headers to any-case SVG paths.
+- Emit Rack-3-compliant lowercase header keys.
+
+**Non-Goals**
+
+- No change to WHAT either ruleset blocks — only the case of the extension gate. The two rulesets'
+  contents were already reconciled deliberately (see `SvgContentChecker` comment); this change only
+  ensures the SVG bytes reach the SVG ruleset regardless of extension case.
+- No normalization of stored filenames — files keep the case the client sent.
+
+## Decisions
+
+1. **One case-insensitive seam, `File.extname(name).casecmp?('.svg')`.** Used by both `svg_upload?`
+   and `content_unsafe?`. `File.extname` + `casecmp?` is exact (only the extension, case-folded),
+   avoiding an `end_with?('.svg')` that would also match a file literally suffixed but not extensioned.
+   Rejected: downcasing the whole path (allocates, and would fold case in the directory portion too).
+2. **`SVG_PATH_PATTERN` gains `i` rather than an explicit `[Ss][Vv][Gg]`.** The `i` flag also folds
+   the literal `/media/` segment, which is harmless — at worst it adds inert protective headers to a
+   non-existent `/MEDIA/...` path; it never removes protection.
+3. **Lowercase header keys.** Rack 3 requires them; `Rack::Headers`/ActionDispatch lookup stays
+   case-insensitive, so existing readers (`response.headers['X-Content-Type-Options']`) are
+   unaffected. A unit spec drives the middleware with a plain downstream app to assert the raw key
+   casing, since the framework's case-insensitive lookup hid the defect from the request spec.
+
+## Risks / Trade-offs
+
+- [`i` on the whole path pattern over-matches `/MEDIA/`] → accepted; adding headers to a
+  non-canonical path is inert, and real media URLs are lowercase `/media/`.
+- [Uppercase-extension SVGs now take the SVG-parser path at scan time] → this is the intended
+  hardening; the SVG ruleset is stricter, so nothing that passed before is newly blocked except the
+  SVG-only vectors that were always meant to be blocked.
+
+## Migration Plan
+
+Code + specs; no schema or data changes. Deploy normally; rollback = revert the commits.

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/proposal.md
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Regression-audit lows L5 and L6 (post-2.9.2 review), both in the SVG-serving defense-in-depth path:
+
+- **L5** — the upload content scanner and the response-header middleware both matched the `.svg`
+  extension case-sensitively (`end_with?('.svg')`, `%r{...\.svg\z}`). An `evil.SVG` (uppercase, or
+  any mixed case) is a first-class upload — `get_file_format` downcases the extension, so it is
+  classified as an image, stored, and served verbatim. Two gaps followed: at scan time the file
+  bypassed the SVG-specific parser (`SvgContentChecker`) and fell through to the weaker generic
+  denylist, which does not list SVG-only vectors such as `foreignObject`/`handler`; at serve time
+  the `/media/*.svg` header middleware did not match the uppercase path, so the SVG was served
+  inline without `X-Content-Type-Options: nosniff` or `Content-Security-Policy: script-src 'none'`.
+- **L6** — `MediaSecurityHeaders` set mixed-case header keys (`X-Content-Type-Options`,
+  `Content-Security-Policy`). The Rack 3 SPEC requires lowercase keys; Rack::Lint and Falcon reject
+  mixed case (Puma tolerated it, which hid the defect). The project runs Rack 3.
+
+## What Changes
+
+- **L5**: the `.svg` extension test is now case-insensitive in both places. `content_unsafe?` and
+  `svg_upload?` route on `File.extname(name).casecmp?('.svg')`, so any-case SVG uploads reach the
+  SVG parser; `MediaSecurityHeaders::SVG_PATH_PATTERN` gains the `i` flag, so any-case SVG paths
+  under `/media/` carry the protective headers.
+- **L6**: `MediaSecurityHeaders` emits lowercase header keys.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `upload-content-security`: SVG detection at scan time is case-insensitive, so an uppercase-extension
+  SVG is routed to the SVG parser rather than the generic scan.
+- `media-serving-security`: the header middleware matches SVG paths case-insensitively and emits
+  Rack-3-compliant lowercase header keys.
+
+### New Capabilities
+
+None.
+
+## Impact
+
+- `lib/camaleon_cms/uploader_content_security.rb` (case-insensitive `.svg` seam),
+  `lib/camaleon_cms/media_security_headers.rb` (case-insensitive path + lowercase header keys).
+- Specs: `spec/lib/camaleon_cms/uploader_content_security_spec.rb` (uppercase `.SVG` routing),
+  new `spec/lib/camaleon_cms/media_security_headers_spec.rb` (header-key casing, unit),
+  `spec/requests/media_security_headers_spec.rb` (uppercase `.SVG` served inline).
+- No routes or schema changes. Behavior delta: uppercase-extension SVG uploads are scanned as SVGs
+  and served with the same headers as lowercase ones; response header keys are lowercase.

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/specs/media-serving-security/spec.md
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/specs/media-serving-security/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: SVG path matching is case-insensitive
+
+The system SHALL apply the SVG security headers to `/media/` responses whose path ends in the
+`.svg` extension regardless of the extension's case, so an uppercase-extension SVG (`image.SVG`)
+served inline is protected exactly as a lowercase one.
+
+#### Scenario: Uppercase-extension SVG response carries the headers
+
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.SVG`
+- **THEN** the response includes `X-Content-Type-Options: nosniff`
+- **AND** the response includes `Content-Security-Policy: script-src 'none'`
+
+### Requirement: Response header keys are Rack 3 compliant
+
+The system SHALL emit the SVG security headers with lowercase header-field names, as required by
+the Rack 3 SPEC and enforced by `Rack::Lint` and Falcon.
+
+#### Scenario: Emitted header keys are lowercase
+
+- **WHEN** the middleware adds the SVG security headers to a response
+- **THEN** the emitted header keys are `x-content-type-options` and `content-security-policy`
+- **AND** no mixed-case variant of those keys is emitted

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/specs/upload-content-security/spec.md
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/specs/upload-content-security/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: SVG detection at scan time is case-insensitive
+
+The content scanner SHALL treat an upload whose filename extension is `.svg` in any case as an SVG,
+routing it to the SVG-specific parser (`SvgContentChecker`) rather than the generic denylist scan.
+An uppercase-extension SVG (`evil.SVG`) therefore cannot reach the weaker generic ruleset that does
+not list SVG-only vectors such as `foreignObject`.
+
+#### Scenario: Uppercase-extension SVG is routed to the SVG parser
+
+- **WHEN** `content_unsafe?` is called with a filename ending in `.SVG` (or any other case)
+- **THEN** the content is evaluated by the SVG parser, not the generic pattern scan
+
+#### Scenario: An SVG-only vector is rejected regardless of extension case
+
+- **WHEN** an SVG carrying a `foreignObject` element is scanned as `image.svg` and as `image.SVG`
+- **THEN** both are rejected as unsafe

--- a/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/tasks.md
+++ b/openspec/changes/archive/2026-08-10-harden-svg-extension-case-and-rack3-headers/tasks.md
@@ -1,0 +1,30 @@
+## 1. L5 — case-insensitive SVG extension routing (commit 1)
+
+- [x] 1.1 Red-first: `spec/lib/camaleon_cms/uploader_content_security_spec.rb` — an uppercase `.SVG`
+      carrying an SVG-only banned tag (`foreignObject`) is routed to the SVG parser and rejected;
+      a clean uppercase `.SVG` is accepted through the SVG checker, not the generic scan. Add the
+      uppercase-`.SVG` header cases to the middleware specs (see task 2).
+- [x] 1.2 `UploaderContentSecurity`: `content_unsafe?` and `svg_upload?` branch on a
+      `cama_svg_extension?(name)` seam (`File.extname(name).casecmp?('.svg')`).
+- [x] 1.3 `MediaSecurityHeaders::SVG_PATH_PATTERN` gains the `i` flag.
+
+## 2. L6 — Rack 3 lowercase header keys (commit 1, same file)
+
+- [x] 2.1 Red-first: new `spec/lib/camaleon_cms/media_security_headers_spec.rb` unit-drives the
+      middleware and asserts lowercase header keys + case-insensitive path match;
+      `spec/requests/media_security_headers_spec.rb` gains an uppercase `.SVG` served-inline case.
+- [x] 2.2 `MediaSecurityHeaders` emits `x-content-type-options` / `content-security-policy`.
+
+## 3. Verification and CI parity
+
+- [x] 3.1 Touched specs green; broader upload/security suite green.
+- [x] 3.2 `bin/rubocop` clean on touched files, `bin/brakeman --no-pager` clean,
+      `(cd spec/dummy && bin/rails zeitwerk:check)` clean.
+
+## 4. OpenSpec + PR protocol
+
+- [x] 4.1 `openspec validate harden-svg-extension-case-and-rack3-headers --strict` passes; archive
+      on-branch (syncs `media-serving-security` + `upload-content-security`); commit the archived
+      change (no `[skip ci]` — heads the first push).
+- [x] 4.2 Push, open the PR (What and Why + User-Visible Impact).
+- [x] 4.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/media-serving-security/spec.md
+++ b/openspec/specs/media-serving-security/spec.md
@@ -1,9 +1,7 @@
 ## Purpose
 
 Define the security requirements for serving SVG media files. SVG files served from `/media/` MUST include security headers that prevent inline script execution in the browser.
-
 ## Requirements
-
 ### Requirement: SVG responses include X-Content-Type-Options nosniff
 
 The system SHALL set `X-Content-Type-Options: nosniff` on HTTP responses for SVG files served from the `/media/` URL path.
@@ -48,3 +46,27 @@ from the host stack.
 - **WHEN** the host application boots with `config.public_file_server.enabled = true`
 - **THEN** `CamaleonCms::MediaSecurityHeaders` sits before `ActionDispatch::Static`, so SVG
   responses served statically still carry the security headers
+
+### Requirement: SVG path matching is case-insensitive
+
+The system SHALL apply the SVG security headers to `/media/` responses whose path ends in the
+`.svg` extension regardless of the extension's case, so an uppercase-extension SVG (`image.SVG`)
+served inline is protected exactly as a lowercase one.
+
+#### Scenario: Uppercase-extension SVG response carries the headers
+
+- **WHEN** a browser requests an SVG file at `/media/{site_id}/image.SVG`
+- **THEN** the response includes `X-Content-Type-Options: nosniff`
+- **AND** the response includes `Content-Security-Policy: script-src 'none'`
+
+### Requirement: Response header keys are Rack 3 compliant
+
+The system SHALL emit the SVG security headers with lowercase header-field names, as required by
+the Rack 3 SPEC and enforced by `Rack::Lint` and Falcon.
+
+#### Scenario: Emitted header keys are lowercase
+
+- **WHEN** the middleware adds the SVG security headers to a response
+- **THEN** the emitted header keys are `x-content-type-options` and `content-security-policy`
+- **AND** no mixed-case variant of those keys is emitted
+

--- a/openspec/specs/upload-content-security/spec.md
+++ b/openspec/specs/upload-content-security/spec.md
@@ -236,7 +236,9 @@ substitute bytes the scanner never saw. It implements the `security-capability-g
 The content scanner SHALL treat an upload whose filename extension is `.svg` in any case as an SVG,
 routing it to the SVG-specific parser (`SvgContentChecker`) rather than the generic denylist scan.
 An uppercase-extension SVG (`evil.SVG`) therefore cannot reach the weaker generic ruleset that does
-not list SVG-only vectors such as `foreignObject`.
+not list SVG-only vectors such as `foreignObject`. A filename whose basename is exactly `.svg` (a
+dotfile, which `File.extname` reports as having no extension) SHALL be treated as an SVG as well,
+preserving the fail-closed routing of the suffix check this requirement replaced.
 
 #### Scenario: Uppercase-extension SVG is routed to the SVG parser
 
@@ -247,4 +249,9 @@ not list SVG-only vectors such as `foreignObject`.
 
 - **WHEN** an SVG carrying a `foreignObject` element is scanned as `image.svg` and as `image.SVG`
 - **THEN** both are rejected as unsafe
+
+#### Scenario: A bare `.svg` dotfile name keeps SVG routing
+
+- **WHEN** `content_unsafe?` is called with a filename whose basename is exactly `.svg`, in any case
+- **THEN** the content is evaluated by the SVG parser, not the generic pattern scan
 

--- a/openspec/specs/upload-content-security/spec.md
+++ b/openspec/specs/upload-content-security/spec.md
@@ -231,3 +231,20 @@ substitute bytes the scanner never saw. It implements the `security-capability-g
   replaces `settings[:uploaded_io]`
 - **THEN** the pipeline does not scan the content a second time after the hook
 
+### Requirement: SVG detection at scan time is case-insensitive
+
+The content scanner SHALL treat an upload whose filename extension is `.svg` in any case as an SVG,
+routing it to the SVG-specific parser (`SvgContentChecker`) rather than the generic denylist scan.
+An uppercase-extension SVG (`evil.SVG`) therefore cannot reach the weaker generic ruleset that does
+not list SVG-only vectors such as `foreignObject`.
+
+#### Scenario: Uppercase-extension SVG is routed to the SVG parser
+
+- **WHEN** `content_unsafe?` is called with a filename ending in `.SVG` (or any other case)
+- **THEN** the content is evaluated by the SVG parser, not the generic pattern scan
+
+#### Scenario: An SVG-only vector is rejected regardless of extension case
+
+- **WHEN** an SVG carrying a `foreignObject` element is scanned as `image.svg` and as `image.SVG`
+- **THEN** both are rejected as unsafe
+

--- a/spec/lib/camaleon_cms/media_security_headers_spec.rb
+++ b/spec/lib/camaleon_cms/media_security_headers_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-drives the middleware with a plain downstream app so the emitted header-key casing is
+# asserted exactly (Rack 3 / Falcon require lowercase keys; Puma tolerates mixed case, which is
+# why the request-level spec did not catch the mixed-case regression). Also pins the
+# case-insensitive `/media/....svg` path match.
+RSpec.describe CamaleonCms::MediaSecurityHeaders do
+  subject(:middleware) { described_class.new(downstream) }
+
+  let(:downstream) { ->(_env) { [200, {}, ['body']] } }
+
+  def call(path, method: 'GET')
+    middleware.call('REQUEST_METHOD' => method, 'PATH_INFO' => path)
+  end
+
+  it 'emits lowercase header keys for an SVG response' do
+    _status, headers, _body = call('/media/1/x.svg')
+
+    expect(headers.keys).to include('x-content-type-options', 'content-security-policy')
+    expect(headers.keys).not_to include('X-Content-Type-Options', 'Content-Security-Policy')
+    expect(headers['x-content-type-options']).to eq('nosniff')
+    expect(headers['content-security-policy']).to eq("script-src 'none'")
+  end
+
+  it 'protects an uppercase .SVG path (case-insensitive match)' do
+    _status, headers, _body = call('/media/1/x.SVG')
+
+    expect(headers['content-security-policy']).to eq("script-src 'none'")
+  end
+
+  it 'leaves non-SVG responses untouched' do
+    _status, headers, _body = call('/media/1/x.png')
+
+    expect(headers).to be_empty
+  end
+
+  it 'ignores non-GET requests' do
+    _status, headers, _body = call('/media/1/x.svg', method: 'POST')
+
+    expect(headers).to be_empty
+  end
+end

--- a/spec/lib/camaleon_cms/uploader_content_security_spec.rb
+++ b/spec/lib/camaleon_cms/uploader_content_security_spec.rb
@@ -191,6 +191,25 @@ RSpec.describe CamaleonCms::UploaderContentSecurity do
       end
     end
 
+    # File.extname reports no extension for a dotfile, so an extname-based test alone would
+    # route a file named exactly `.svg` to the generic scanner — weaker than the SVG parser
+    # the pre-hardening `end_with?` check sent it to. Routing must stay fail-closed.
+    context 'with a filename that is exactly ".svg" (dotfile)' do
+      let(:svg_only_payload) { %(<svg xmlns="http://www.w3.org/2000/svg"><foreignObject/></svg>) }
+
+      it 'still routes the name to the SVG scanner' do
+        expect(scanner.content_unsafe?(svg_only_payload, filename: '.svg')).to be(true)
+      end
+
+      it 'routes an uppercase ".SVG" dotfile the same way' do
+        expect(scanner.content_unsafe?(svg_only_payload, filename: '.SVG')).to be(true)
+      end
+
+      it 'routes a path whose basename is ".svg" the same way' do
+        expect(scanner.content_unsafe?(svg_only_payload, filename: 'tmp/.svg')).to be(true)
+      end
+    end
+
     it 'handles binary content without raising' do
       binary = File.binread("#{CAMALEON_CMS_ROOT}/spec/support/fixtures/rails.png")
       expect { scanner.content_unsafe?(binary, filename: 'rails.png') }.not_to raise_error

--- a/spec/lib/camaleon_cms/uploader_content_security_spec.rb
+++ b/spec/lib/camaleon_cms/uploader_content_security_spec.rb
@@ -169,6 +169,28 @@ RSpec.describe CamaleonCms::UploaderContentSecurity do
       expect(scanner.content_unsafe?(svg, filename: 'x.svg')).to be_nil
     end
 
+    # A bare <foreignObject> is a banned SVG tag (SvgContentChecker::BANNED_TAGS) that the generic
+    # element denylist (ContentSecurity::BLOCKED_ELEMENTS) does not list, so it is rejected only
+    # when the upload is routed through the SVG-specific scanner. A case-sensitive `.svg` check
+    # sent `evil.SVG` down the weaker generic path where the payload passed.
+    context 'with an uppercase .SVG extension' do
+      let(:svg_only_payload) { %(<svg xmlns="http://www.w3.org/2000/svg"><foreignObject/></svg>) }
+
+      it 'is caught by the SVG scanner for a lowercase .svg' do
+        expect(scanner.content_unsafe?(svg_only_payload, filename: 'x.svg')).to be(true)
+      end
+
+      it 'is caught by the SVG scanner for an uppercase .SVG too' do
+        expect(scanner.content_unsafe?(svg_only_payload, filename: 'x.SVG')).to be(true)
+      end
+
+      it 'accepts a clean uppercase .SVG (routed through the SVG checker, not the generic scan)' do
+        clean = %(<svg xmlns="http://www.w3.org/2000/svg"><rect width="10" height="10"/></svg>)
+        expect(CamaleonCms::SvgContentChecker).to receive(:unsafe?).with(clean).and_call_original
+        expect(scanner.content_unsafe?(clean, filename: 'x.SVG')).to be_nil
+      end
+    end
+
     it 'handles binary content without raising' do
       binary = File.binread("#{CAMALEON_CMS_ROOT}/spec/support/fixtures/rails.png")
       expect { scanner.content_unsafe?(binary, filename: 'rails.png') }.not_to raise_error

--- a/spec/lib/camaleon_cms/uploader_image_processing_spec.rb
+++ b/spec/lib/camaleon_cms/uploader_image_processing_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Unit-drives the SVG→JPG rename convention with real ImageMagick conversions (CI installs
+# ImageMagick). The upload pipeline preserves the client's extension case, so an uppercase
+# `logo.SVG` must take the same convert-to-JPEG path as `logo.svg`; the previous case-sensitive
+# guard skipped the conversion and wrote an SVG-format artifact back to the `.SVG` path.
+RSpec.describe CamaleonCms::UploaderImageProcessing do
+  let(:host_class) do
+    Class.new do
+      include CamaleonCms::UploaderImageProcessing
+
+      attr_accessor :cama_uploader
+
+      def hooks_run(*_args); end
+
+      def uploader_verify_name(path)
+        path
+      end
+    end
+  end
+  let(:host) { host_class.new }
+  let(:fixture_svg) { File.read("#{CAMALEON_CMS_ROOT}/spec/support/fixtures/svg-safe.svg") }
+
+  around do |example|
+    Dir.mktmpdir('cama-svg-crop') do |dir|
+      @tmpdir = dir
+      example.run
+    end
+  end
+
+  # cama_resize_and_crop renames the path in place (sub!), so hand it a mutable copy.
+  def stage_svg(name)
+    path = File.join(@tmpdir, name)
+    File.write(path, fixture_svg)
+    path
+  end
+
+  describe '#cama_resize_and_crop' do
+    it 'converts an uppercase .SVG to a JPEG artifact (case-insensitive rename)' do
+      res = host.cama_resize_and_crop(stage_svg('logo.SVG'), '50', '50')
+
+      expect(res).to end_with('logo.jpg')
+      expect(File.binread(res, 3)).to eq("\xFF\xD8\xFF".b)
+    end
+
+    it 'converts a lowercase .svg the same way' do
+      res = host.cama_resize_and_crop(stage_svg('logo.svg'), '50', '50')
+
+      expect(res).to end_with('logo.jpg')
+      expect(File.binread(res, 3)).to eq("\xFF\xD8\xFF".b)
+    end
+
+    it 'leaves a non-SVG path un-renamed' do
+      png = File.join(@tmpdir, 'photo.png')
+      FileUtils.cp("#{CAMALEON_CMS_ROOT}/spec/support/fixtures/rails.png", png)
+
+      expect(host.cama_resize_and_crop(png, '10', '10')).to end_with('photo.png')
+    end
+  end
+
+  describe '#cama_uploader_generate_thumbnail' do
+    it 'derives a .jpg thumb key from an uppercase .SVG source' do
+      uploader = instance_double(CamaleonCmsLocalUploader)
+      allow(uploader).to receive(:version_path).with('/media/1/logo.SVG')
+                                               .and_return('/media/1/thumb/logo-svg.SVG')
+      host.cama_uploader = uploader
+
+      expect(uploader).to receive(:add_file)
+        .with(kind_of(String), '/media/1/thumb/logo-svg.jpg', hash_including(is_thumb: true, same_name: true))
+
+      host.cama_uploader_generate_thumbnail(stage_svg('logo.SVG'), '/media/1/logo.SVG', '40x40')
+    end
+  end
+end

--- a/spec/requests/media_security_headers_spec.rb
+++ b/spec/requests/media_security_headers_spec.rb
@@ -7,16 +7,19 @@ RSpec.describe CamaleonCms::MediaSecurityHeaders, type: :request do
 
   let(:svg_path) { '/media/1/test.svg' }
   let(:png_path) { '/media/1/test.png' }
+  let(:upper_svg_path) { '/media/1/upper.SVG' }
 
   before do
     FileUtils.mkdir_p(Rails.public_path.join('media/1'))
     File.write(Rails.public_path.join('media/1/test.svg'), '<svg xmlns="http://www.w3.org/2000/svg"/>')
     File.write(Rails.public_path.join('media/1/test.png'), 'fake-png')
+    File.write(Rails.public_path.join('media/1/upper.SVG'), '<svg xmlns="http://www.w3.org/2000/svg"/>')
   end
 
   after do
     FileUtils.rm_f(Rails.public_path.join('media/1/test.svg'))
     FileUtils.rm_f(Rails.public_path.join('media/1/test.png'))
+    FileUtils.rm_f(Rails.public_path.join('media/1/upper.SVG'))
   end
 
   it 'adds X-Content-Type-Options nosniff to SVG responses under /media/' do
@@ -32,5 +35,11 @@ RSpec.describe CamaleonCms::MediaSecurityHeaders, type: :request do
   it 'does not add security headers to non-SVG responses under /media/' do
     get png_path
     expect(response.headers['Content-Security-Policy']).to be_nil
+  end
+
+  it 'protects an uppercase .SVG served inline under /media/' do
+    get upper_svg_path
+    expect(response.headers['X-Content-Type-Options']).to eq('nosniff')
+    expect(response.headers['Content-Security-Policy']).to eq("script-src 'none'")
   end
 end

--- a/spec/uploaders/aws_uploader_spec.rb
+++ b/spec/uploaders/aws_uploader_spec.rb
@@ -66,6 +66,17 @@ RSpec.describe CamaleonCmsAwsUploader do
     end
   end
 
+  describe '#file_parse thumb naming for an uppercase .SVG source' do
+    let(:s3_file) do
+      instance_double(Aws::S3::Object, key: 'media/1/logo.SVG', size: 123.4, last_modified: Time.zone.now,
+                                       public_url: 'https://s3.example.com/media/1/logo.SVG')
+    end
+
+    it 'computes the .jpg thumb url (case-insensitive svg-to-jpg rename)' do
+      expect(uploader.file_parse(s3_file)['thumb']).to end_with('/thumb/logo-svg.jpg')
+    end
+  end
+
   context 'with a valid file path' do
     describe '#add_file' do
       let(:s3_file) { instance_double(Aws::S3::Object) }

--- a/spec/uploaders/local_uploader_spec.rb
+++ b/spec/uploaders/local_uploader_spec.rb
@@ -74,6 +74,27 @@ RSpec.describe CamaleonCmsLocalUploader do
     end
   end
 
+  describe '#file_parse thumb naming for an uppercase .SVG source' do
+    let(:root_folder) { uploader.instance_variable_get(:@root_folder) }
+
+    before do
+      FileUtils.mkdir_p(File.join(root_folder, 'thumb'))
+      File.write(File.join(root_folder, 'logo.SVG'), '<svg xmlns="http://www.w3.org/2000/svg"/>')
+      # The generated thumb is a JPEG regardless of the source extension's case; stage it so
+      # file_parse's on-disk check confirms the computed name instead of falling back.
+      File.write(File.join(root_folder, 'thumb', 'logo-svg.jpg'), 'x')
+    end
+
+    after do
+      FileUtils.rm_f(File.join(root_folder, 'logo.SVG'))
+      FileUtils.rm_rf(File.join(root_folder, 'thumb'))
+    end
+
+    it 'computes the .jpg thumb url (case-insensitive svg-to-jpg rename)' do
+      expect(uploader.file_parse('/logo.SVG')['thumb']).to end_with('/thumb/logo-svg.jpg')
+    end
+  end
+
   describe '#objects (lazy relation for DB-level pagination)' do
     let(:collection) { uploader.send(:get_media_collection) }
 


### PR DESCRIPTION
## What and Why

Fixes four case-sensitivity defects on the SVG upload/serving path. They share one premise: the upload pipeline preserves the client's extension case (`get_file_format` downcases only for classification), so an uppercase-extension SVG (`evil.SVG`) is a first-class upload — classified as an image, stored, and served verbatim — while several `.svg` comparisons matched case-sensitively. The first two were surfaced by the post-2.9.2 regression audit (lows **L5** and **L6**); reviewing this branch surfaced two more of the same class, fixed here as well.

**L5 — case-sensitive `.svg` matching at scan and serve time.** At scan time an `evil.SVG` bypassed the SVG-specific parser (`SvgContentChecker`) and fell through to the weaker generic denylist, which does not list SVG-only vectors such as `foreignObject`/`handler`. At serve time the `/media/` response-header middleware did not match the uppercase path, so the SVG was served inline without `X-Content-Type-Options: nosniff` or `Content-Security-Policy: script-src 'none'`. The extension test is now case-insensitive in both places.

**L6 — non-Rack-3 header keys.** `MediaSecurityHeaders` emitted mixed-case header keys. The Rack 3 SPEC requires lowercase field names, and `Rack::Lint` / Falcon reject mixed case (Puma tolerated it, which hid the defect). The project runs Rack 3. Keys are now lowercase.

**Thumb/crop rename.** The SVG-to-JPG conversion convention — the crop guard, the thumb-key derivation, and the local/AWS thumb-URL rewrites — also matched `.svg` case-sensitively, so an uppercase `.SVG` skipped JPEG conversion and its computed thumb URL missed the stored artifact. Every rename site now shares one anchored case-insensitive pattern, kept in lockstep between the writer and the readers of the convention. Functional only: the scanner and serving headers above already cover uppercase SVGs.

**Dotfile routing.** `File.extname` reports no extension for a file named exactly `.svg`, so the extname-based scan-routing fix dropped the one name the old suffix check also matched. Not exploitable (such a name is parameterized before storage), but scan routing must fail closed, so the basename now counts for the SVG test; the upload-content-security spec records the behavior.

The SVG bytes were always meant to reach the SVG ruleset and the SVG paths were always meant to carry the headers — this change removes the case gap, changing nothing about *what* either ruleset blocks.

## User-Visible Impact

None for well-formed lowercase-extension SVGs. Uppercase-extension SVG uploads are now scanned as SVGs, served with the same security headers as lowercase ones, and their crops and thumbnails convert to real JPEGs; HTTP response header keys for `/media/` SVG responses are lowercase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
