### PR TITLE
Fix upload/media and operator-task residuals (L3, L16, L11, L18, L7-doc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 - **Fix:** A failed avatar crop now shows an error instead of silently blanking the saved avatar and
   returning an empty response; the theme generator and the custom-fields/site/cross-site repair rake
-  tasks print their progress to the terminal (they logged only to a file before). Regression audit
+  tasks print their progress to the terminal (they logged only to a file before). Review follow-ups
+  on the same branch (no behavior change): the tasks' terminal reporting moved into a shared
+  `CamaleonCms::TaskReporter` helper and the theme generator lost a dead branch. Regression audit
   L3, L16, L11, L18. [#1244](https://github.com/owen2345/camaleon-cms/pull/1244).
   - **Notes for upgraders:** Post content edited during the 2.9.1–2.9.2 sanitize-on-save era stored
     HTML-escaped entities and may render visibly double-encoded once (e.g. `&amp;` shown literally)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- **Fix:** A failed avatar crop now shows an error instead of silently blanking the saved avatar and
+  returning an empty response; the theme generator and the custom-fields/site/cross-site repair rake
+  tasks print their progress to the terminal (they logged only to a file before). Regression audit
+  L3, L16, L11, L18. [#1244](https://github.com/owen2345/camaleon-cms/pull/1244).
+  - **Notes for upgraders:** Post content edited during the 2.9.1–2.9.2 sanitize-on-save era stored
+    HTML-escaped entities and may render visibly double-encoded once (e.g. `&amp;` shown literally)
+    under the current escape-at-render behavior. There is no repair task — a blanket re-encode
+    cannot tell a legitimately-authored `&amp;` from a sanitize-era artifact — but each affected
+    field self-heals the next time it is edited and saved. Regression audit L7.
+
 - **Security fix:** SVG uploads and `/media/` SVG responses are now matched by extension
   case-insensitively, so an uppercase-extension SVG (`image.SVG`) is scanned by the SVG parser and
   served with the `nosniff` / `script-src 'none'` headers like a lowercase one; the media security

--- a/app/controllers/camaleon_cms/admin/media_controller.rb
+++ b/app/controllers/camaleon_cms/admin/media_controller.rb
@@ -36,6 +36,11 @@ module CamaleonCms
         path_image = tmp[:file_path]
         crop_path = cama_crop_image(path_image, params[:ic_w], params[:ic_h], params[:ic_x], params[:ic_y])
         res = upload_file(crop_path, { remove_source: true })
+        # A failed upload returns { error: ... } with no url. Surface it like the action's other
+        # error paths instead of writing a nil avatar meta and rendering an empty 200 body (which
+        # let the avatar flow store "").
+        return render(plain: helpers.sanitize(res[:error])) if res[:error].present?
+
         CamaleonCms::User.find(params[:saved_avatar]).set_meta('avatar', res['url']) if params[:saved_avatar].present?
         render plain: res['url'].to_s
       end

--- a/lib/camaleon_cms.rb
+++ b/lib/camaleon_cms.rb
@@ -8,6 +8,7 @@ require 'camaleon_cms/uploader_path_security'
 require 'camaleon_cms/uploader_pipeline'
 require 'camaleon_cms/uploader_image_processing'
 require 'camaleon_cms/uploader_support'
+require 'camaleon_cms/task_reporter'
 
 module CamaleonCms
 end

--- a/lib/camaleon_cms/task_reporter.rb
+++ b/lib/camaleon_cms/task_reporter.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  # Output seam for operator-run repair tasks: logs for the record AND prints to
+  # stdout, because an operator runs these from a terminal, where Rails.logger
+  # writes to a file they are not watching — a logger-only task looks like a
+  # no-op. Shared so the reporting rule cannot drift between the repair tasks.
+  module TaskReporter
+    def self.call(msg)
+      Rails.logger.info(msg)
+      puts msg # rubocop:disable Rails/Output -- terminal output for the operator is the point
+    end
+  end
+end

--- a/lib/camaleon_cms/uploader_path_security.rb
+++ b/lib/camaleon_cms/uploader_path_security.rb
@@ -80,7 +80,11 @@ module CamaleonCms
     # in the web-served public/tmp directory. Shared so the cleanup rule cannot drift
     # between RuntimeUploaderConcern and UploaderHelper.
     def cama_upload_failure(error, uploaded_io, settings)
-      return error unless settings[:remove_source]
+      # The first (malicious-content) rejection in upload_file runs before settings are
+      # deep-symbolized, so honor a string-keyed remove_source too — otherwise a rejected upload
+      # owning its staging file leaks it in the web-served public/tmp directory.
+      remove_source = settings[:remove_source] || settings['remove_source']
+      return error unless remove_source
 
       cama_purge_staged_file(uploaded_io.try(:path), File.join(Rails.public_path, 'tmp').to_s)
       error

--- a/lib/generators/camaleon_cms/theme_generator.rb
+++ b/lib/generators/camaleon_cms/theme_generator.rb
@@ -13,17 +13,15 @@ module CamaleonCms
         if behavior == :revoke
           if Dir.exist?(theme_folder)
             FileUtils.rm_rf(theme_folder)
-            Rails.logger.info 'Theme destroyed successfully'
+            say 'Theme destroyed successfully'
           else
-            Rails.logger.info "This theme doesn't exist"
+            say "This theme doesn't exist"
           end
         elsif Dir.exist?(theme_folder)
-          Rails.logger.info 'This theme already exist'
+          say 'This theme already exist'
         else
           theme_folder = Rails.root.join('app', 'apps', 'themes', get_theme_name)
-          if Dir.exist?(theme_folder)
-            return Rails.logger.info "There is already a theme with the same name in: #{theme_folder}"
-          end
+          return say "There is already a theme with the same name in: #{theme_folder}" if Dir.exist?(theme_folder)
 
           # tmp copy
           FileUtils.mkdir_p(theme_folder)
@@ -37,7 +35,7 @@ module CamaleonCms
           # helper
           t = fix_text(File.read(File.join(theme_folder, 'main_helper.rb')))
           File.open(File.join(theme_folder, 'main_helper.rb'), 'w') { |f| f << t }
-          Rails.logger.info "Theme successfully created in: #{theme_folder}"
+          say "Theme successfully created in: #{theme_folder}"
         end
       end
 

--- a/lib/generators/camaleon_cms/theme_generator.rb
+++ b/lib/generators/camaleon_cms/theme_generator.rb
@@ -20,9 +20,6 @@ module CamaleonCms
         elsif Dir.exist?(theme_folder)
           say 'This theme already exist'
         else
-          theme_folder = Rails.root.join('app', 'apps', 'themes', get_theme_name)
-          return say "There is already a theme with the same name in: #{theme_folder}" if Dir.exist?(theme_folder)
-
           # tmp copy
           FileUtils.mkdir_p(theme_folder)
           FileUtils.copy_entry(File.join($camaleon_engine_dir, 'lib', 'generators', 'camaleon_cms', 'theme_template'),

--- a/lib/tasks/cross_site_field_groups.rake
+++ b/lib/tasks/cross_site_field_groups.rake
@@ -10,7 +10,13 @@ namespace :camaleon_cms do
   # the group restores the invariant and surfaces it where an administrator can judge and remove it.
   desc 'Re-home custom field groups whose owning site differs from the site owning their placement'
   task rehome_cross_site_field_groups: :environment do
-    Rails.logger.info 'Re-homing cross-site custom field groups...'
+    # Log for the record AND print to stdout: an operator runs this from a terminal, where
+    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
+    report = lambda do |msg|
+      Rails.logger.info(msg)
+      puts msg
+    end
+    report.call 'Re-homing cross-site custom field groups...'
     rehomed_count = 0
     skipped_count = 0
 
@@ -18,8 +24,8 @@ namespace :camaleon_cms do
       site_id = cama_placement_site_id(group)
 
       if site_id.blank?
-        Rails.logger.info "  Skipped group id=#{group.id} slug=#{group.slug} " \
-                          "(#{group.object_class}/#{group.objectid} does not resolve to a site)"
+        report.call "  Skipped group id=#{group.id} slug=#{group.slug} " \
+                    "(#{group.object_class}/#{group.objectid} does not resolve to a site)"
         skipped_count += 1
         next
       end
@@ -27,21 +33,21 @@ namespace :camaleon_cms do
       next if site_id == group.parent_id
 
       begin
-        Rails.logger.info "✓ Re-homed group id=#{group.id} slug=#{group.slug} " \
-                          "from site_id=#{group.parent_id} to site_id=#{site_id} " \
-                          "(placement #{group.object_class}/#{group.objectid})"
+        report.call "✓ Re-homed group id=#{group.id} slug=#{group.slug} " \
+                    "from site_id=#{group.parent_id} to site_id=#{site_id} " \
+                    "(placement #{group.object_class}/#{group.objectid})"
         group.update_column(:parent_id, site_id) # rubocop:disable Rails/SkipsModelValidations
         rehomed_count += 1
       rescue StandardError => e
-        Rails.logger.info "✗ Failed to re-home group id=#{group.id}: #{e.message}"
+        report.call "✗ Failed to re-home group id=#{group.id}: #{e.message}"
         skipped_count += 1
       end
     end
 
-    Rails.logger.info "\nSummary:"
-    Rails.logger.info "  Re-homed: #{rehomed_count} field groups"
-    Rails.logger.info "  Skipped:  #{skipped_count} field groups"
-    Rails.logger.info "\nDone. Review the field group list of any site that gained a group."
+    report.call "\nSummary:"
+    report.call "  Re-homed: #{rehomed_count} field groups"
+    report.call "  Skipped:  #{skipped_count} field groups"
+    report.call "\nDone. Review the field group list of any site that gained a group."
   end
 end
 
@@ -68,6 +74,8 @@ def cama_placement_site_id(group)
     CamaleonCms::Site.find_by(id: objectid)&.id
   end
 rescue StandardError => e
-  Rails.logger.info "  Could not resolve placement for group id=#{group.id}: #{e.message}"
+  msg = "  Could not resolve placement for group id=#{group.id}: #{e.message}"
+  Rails.logger.info msg
+  puts msg
   nil
 end

--- a/lib/tasks/cross_site_field_groups.rake
+++ b/lib/tasks/cross_site_field_groups.rake
@@ -10,12 +10,7 @@ namespace :camaleon_cms do
   # the group restores the invariant and surfaces it where an administrator can judge and remove it.
   desc 'Re-home custom field groups whose owning site differs from the site owning their placement'
   task rehome_cross_site_field_groups: :environment do
-    # Log for the record AND print to stdout: an operator runs this from a terminal, where
-    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
-    report = lambda do |msg|
-      Rails.logger.info(msg)
-      puts msg
-    end
+    report = CamaleonCms::TaskReporter
     report.call 'Re-homing cross-site custom field groups...'
     rehomed_count = 0
     skipped_count = 0
@@ -74,8 +69,6 @@ def cama_placement_site_id(group)
     CamaleonCms::Site.find_by(id: objectid)&.id
   end
 rescue StandardError => e
-  msg = "  Could not resolve placement for group id=#{group.id}: #{e.message}"
-  Rails.logger.info msg
-  puts msg
+  CamaleonCms::TaskReporter.call "  Could not resolve placement for group id=#{group.id}: #{e.message}"
   nil
 end

--- a/lib/tasks/custom_fields_roles.rake
+++ b/lib/tasks/custom_fields_roles.rake
@@ -1,7 +1,13 @@
 namespace :camaleon_cms do
   desc 'Backfill user roles to include custom_fields manager permission'
   task backfill_custom_fields_permission: :environment do
-    Rails.logger.info 'Backfilling custom_fields manager permission for existing user roles...'
+    # Log for the record AND print to stdout: an operator runs this from a terminal, where
+    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
+    report = lambda do |msg|
+      Rails.logger.info(msg)
+      puts msg
+    end
+    report.call 'Backfilling custom_fields manager permission for existing user roles...'
     CamaleonCms::UserRole.find_each do |role|
       key = "_manager_#{role.parent_id}"
       begin
@@ -10,20 +16,24 @@ namespace :camaleon_cms do
         if current_role.blank? || (!current_role.is_a?(Hash) || current_role['custom_fields'].blank?)
           current_role = (current_role.is_a?(Hash) ? current_role : {}).merge!('custom_fields' => 1)
           role.set_meta(key, current_role)
-          Rails.logger.info "Updated role=#{role.slug} site_id=#{role.parent_id}"
+          report.call "Updated role=#{role.slug} site_id=#{role.parent_id}"
         else
-          Rails.logger.info "Skipped role=#{role.slug} site_id=#{role.parent_id} (already has custom_fields)"
+          report.call "Skipped role=#{role.slug} site_id=#{role.parent_id} (already has custom_fields)"
         end
       rescue StandardError => e
-        Rails.logger.info "Failed to update role=#{role.slug}: #{e.message}"
+        report.call "Failed to update role=#{role.slug}: #{e.message}"
       end
     end
-    Rails.logger.info 'Done.'
+    report.call 'Done.'
   end
 
   desc 'Backfill admin user roles to include select_eval permission'
   task backfill_select_eval_permission: :environment do
-    Rails.logger.info 'Backfilling select_eval permission for admin roles...'
+    report = lambda do |msg|
+      Rails.logger.info(msg)
+      puts msg
+    end
+    report.call 'Backfilling select_eval permission for admin roles...'
     updated_count = 0
     skipped_count = 0
 
@@ -37,20 +47,20 @@ namespace :camaleon_cms do
         if !current_meta[:select_eval]
           updated_meta = current_meta.merge(select_eval: 1)
           role.set_meta(key, updated_meta)
-          Rails.logger.info "✓ Updated admin role site_id=#{site_id}"
+          report.call "✓ Updated admin role site_id=#{site_id}"
           updated_count += 1
         else
-          Rails.logger.info "  Skipped admin role site_id=#{site_id} (already has select_eval)"
+          report.call "  Skipped admin role site_id=#{site_id} (already has select_eval)"
           skipped_count += 1
         end
       rescue StandardError => e
-        Rails.logger.info "✗ Failed to update admin role site_id=#{site_id}: #{e.message}"
+        report.call "✗ Failed to update admin role site_id=#{site_id}: #{e.message}"
       end
     end
 
-    Rails.logger.info "\nSummary:"
-    Rails.logger.info "  Updated: #{updated_count} admin roles"
-    Rails.logger.info "  Skipped: #{skipped_count} admin roles"
-    Rails.logger.info "\nDone! All admin roles now have select_eval permission."
+    report.call "\nSummary:"
+    report.call "  Updated: #{updated_count} admin roles"
+    report.call "  Skipped: #{skipped_count} admin roles"
+    report.call "\nDone! All admin roles now have select_eval permission."
   end
 end

--- a/lib/tasks/custom_fields_roles.rake
+++ b/lib/tasks/custom_fields_roles.rake
@@ -1,12 +1,7 @@
 namespace :camaleon_cms do
   desc 'Backfill user roles to include custom_fields manager permission'
   task backfill_custom_fields_permission: :environment do
-    # Log for the record AND print to stdout: an operator runs this from a terminal, where
-    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
-    report = lambda do |msg|
-      Rails.logger.info(msg)
-      puts msg
-    end
+    report = CamaleonCms::TaskReporter
     report.call 'Backfilling custom_fields manager permission for existing user roles...'
     CamaleonCms::UserRole.find_each do |role|
       key = "_manager_#{role.parent_id}"
@@ -29,10 +24,7 @@ namespace :camaleon_cms do
 
   desc 'Backfill admin user roles to include select_eval permission'
   task backfill_select_eval_permission: :environment do
-    report = lambda do |msg|
-      Rails.logger.info(msg)
-      puts msg
-    end
+    report = CamaleonCms::TaskReporter
     report.call 'Backfilling select_eval permission for admin roles...'
     updated_count = 0
     skipped_count = 0

--- a/lib/tasks/site_custom_field_groups.rake
+++ b/lib/tasks/site_custom_field_groups.rake
@@ -6,12 +6,7 @@ namespace :camaleon_cms do
   # they should always have had: the site that owns them.
   desc 'Backfill objectid for site custom field groups that were saved without one'
   task backfill_site_field_group_objectid: :environment do
-    # Log for the record AND print to stdout: an operator runs this from a terminal, where
-    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
-    report = lambda do |msg|
-      Rails.logger.info(msg)
-      puts msg
-    end
+    report = CamaleonCms::TaskReporter
     report.call 'Backfilling objectid for site custom field groups...'
     updated_count = 0
     skipped_count = 0

--- a/lib/tasks/site_custom_field_groups.rake
+++ b/lib/tasks/site_custom_field_groups.rake
@@ -6,30 +6,36 @@ namespace :camaleon_cms do
   # they should always have had: the site that owns them.
   desc 'Backfill objectid for site custom field groups that were saved without one'
   task backfill_site_field_group_objectid: :environment do
-    Rails.logger.info 'Backfilling objectid for site custom field groups...'
+    # Log for the record AND print to stdout: an operator runs this from a terminal, where
+    # Rails.logger writes to a file they are not watching, so a logger-only task looks like a no-op.
+    report = lambda do |msg|
+      Rails.logger.info(msg)
+      puts msg
+    end
+    report.call 'Backfilling objectid for site custom field groups...'
     updated_count = 0
     skipped_count = 0
 
     CamaleonCms::CustomField.unscoped.where(object_class: 'Site', objectid: nil).find_each do |group|
       if group.parent_id.blank?
-        Rails.logger.info "  Skipped group id=#{group.id} slug=#{group.slug} (no owning site)"
+        report.call "  Skipped group id=#{group.id} slug=#{group.slug} (no owning site)"
         skipped_count += 1
         next
       end
 
       begin
         group.update_column(:objectid, group.parent_id) # rubocop:disable Rails/SkipsModelValidations
-        Rails.logger.info "✓ Updated group id=#{group.id} slug=#{group.slug} site_id=#{group.parent_id}"
+        report.call "✓ Updated group id=#{group.id} slug=#{group.slug} site_id=#{group.parent_id}"
         updated_count += 1
       rescue StandardError => e
-        Rails.logger.info "✗ Failed to update group id=#{group.id}: #{e.message}"
+        report.call "✗ Failed to update group id=#{group.id}: #{e.message}"
         skipped_count += 1
       end
     end
 
-    Rails.logger.info "\nSummary:"
-    Rails.logger.info "  Updated: #{updated_count} field groups"
-    Rails.logger.info "  Skipped: #{skipped_count} field groups"
-    Rails.logger.info "\nDone."
+    report.call "\nSummary:"
+    report.call "  Updated: #{updated_count} field groups"
+    report.call "  Skipped: #{skipped_count} field groups"
+    report.call "\nDone."
   end
 end

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/design.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/design.md
@@ -41,9 +41,11 @@ facts:
    rather than symbolizing earlier in `upload_file`. The seam is the shared invariant; hardening it
    fixes every caller, present and future, in one place. Rejected: moving the symbolize call above
    the first scan (fixes only that one call site, leaves the seam fragile).
-3. **L11: `report` lambda (log + puts) in tasks; `say` in the generator.** Keeps the log record
-   (matching `orphaned_comments`) while giving the operator console output; the generator is a Thor
-   generator, whose idiomatic operator output is `say`.
+3. **L11: shared `CamaleonCms::TaskReporter` (log + puts) in tasks; `say` in the generator.** Keeps
+   the log record (matching `orphaned_comments`) while giving the operator console output; the
+   generator is a Thor generator, whose idiomatic operator output is `say`. First landed as a
+   per-task `report` lambda; the on-branch review pass extracted the shared module so the reporting
+   rule cannot drift between the repair tasks (call sites keep the `report.call` form).
 4. **L18: request-level guard.** A record with a cached `.jpg` thumb and only an on-disk `.png` is
    rendered; the spec asserts the page contains the `.png` and NOT the `.jpg`, so a regression that
    stops the in-place mutation reaching the view fails the suite.

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/design.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/design.md
@@ -1,0 +1,61 @@
+# Design — fix-upload-and-task-residuals
+
+## Context
+
+Five independent regression-audit lows, batched as the uploads/tasks residual PR. Load-bearing
+facts:
+
+- `upload_file` returns the parsed file hash (with `url`) on success and `{ error: ... }` (no
+  `url`) on failure. `crop` was the only caller reading `res['url']` without an error guard.
+- `cama_upload_failure` is the shared cleanup seam (RuntimeUploaderConcern + UploaderHelper). It is
+  first called at the malicious-content check, which runs BEFORE `settings.to_h.deep_symbolize_keys`
+  — so at that call site the settings keys are whatever the caller passed.
+- The three repair rake tasks and the theme generator predate the `orphaned_comments` precedent
+  (#1224), which logs a summary AND `puts` it so a terminal operator sees the result.
+- The M27 page seam (#1242) mutates the loaded relation page in place; the view iterates the same
+  page. This was verified at review but had no committed end-to-end guard (unit specs pass `.to_a`).
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Make `crop` fail like its sibling error paths (visible message, no nil avatar write).
+- Make staged-file cleanup independent of the caller's key form.
+- Make operator-run tasks/generators print to the console.
+- Guard the M27 rendered-thumb behavior end to end.
+
+**Non-Goals**
+
+- No repair task for L7's double-encoded rows: a blanket re-encode cannot tell a user's literal
+  `&amp;` from a sanitize-era artifact, is not idempotent, and each row self-heals on resave.
+  Document only (maintainer decision).
+- No change to the crop success response shape or status codes — `crop` keeps its plain-text 200
+  convention (its other error paths already render a plain-text message).
+
+## Decisions
+
+1. **L3: guard `res[:error]` before the avatar write.** Matches the two existing error returns in the
+   same action (`render plain: helpers.sanitize(...)`), so the avatar flow gets a message instead of
+   an empty body, and the saved avatar meta is left untouched on failure.
+2. **L16: read both key forms in the seam** (`settings[:remove_source] || settings['remove_source']`)
+   rather than symbolizing earlier in `upload_file`. The seam is the shared invariant; hardening it
+   fixes every caller, present and future, in one place. Rejected: moving the symbolize call above
+   the first scan (fixes only that one call site, leaves the seam fragile).
+3. **L11: `report` lambda (log + puts) in tasks; `say` in the generator.** Keeps the log record
+   (matching `orphaned_comments`) while giving the operator console output; the generator is a Thor
+   generator, whose idiomatic operator output is `say`.
+4. **L18: request-level guard.** A record with a cached `.jpg` thumb and only an on-disk `.png` is
+   rendered; the spec asserts the page contains the `.png` and NOT the `.jpg`, so a regression that
+   stops the in-place mutation reaching the view fails the suite.
+
+## Risks / Trade-offs
+
+- [L3 returns a 200 with the error message] → consistent with the action's other error paths; the
+  avatar flow already handles a plain-text response there.
+- [L11 prints per-row lines to stdout] → these are manual repair/generator runs, where console
+  output is the point; automated callers do not run them.
+
+## Migration Plan
+
+Code + specs + a changelog note; no schema or data changes. Deploy normally; rollback = revert the
+commits.

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/proposal.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/proposal.md
@@ -25,8 +25,8 @@ L11, plus the L18 test gap and the L7 documentation note.
   sanitized message) and skips the avatar meta write.
 - **L16**: `cama_upload_failure` honors a string-keyed `remove_source` too, so the staged file is
   purged on the pre-symbolize failure path.
-- **L11**: operator output goes to stdout as well as the log (a `report` lambda in the tasks, Thor's
-  `say` in the generator).
+- **L11**: operator output goes to stdout as well as the log (a shared `CamaleonCms::TaskReporter`
+  in the tasks, Thor's `say` in the generator).
 - **L18**: a request spec asserts the repaired `.png` thumbnail URL appears in the rendered page.
 - **L7**: a CHANGELOG upgraders note.
 
@@ -46,7 +46,8 @@ L11, plus the L18 test gap and the L7 documentation note.
 
 - `app/controllers/camaleon_cms/admin/media_controller.rb` (L3),
   `lib/camaleon_cms/uploader_path_security.rb` (L16),
-  `lib/tasks/{custom_fields_roles,site_custom_field_groups,cross_site_field_groups}.rake` and
+  `lib/tasks/{custom_fields_roles,site_custom_field_groups,cross_site_field_groups}.rake`,
+  `lib/camaleon_cms/task_reporter.rb` (new shared reporting seam) and
   `lib/generators/camaleon_cms/theme_generator.rb` (L11), `CHANGELOG.md` (L7).
 - Specs: crop request spec (L3), `uploader_helper_spec` (L16), the three rake-task specs (L11
   stdout), media `index` request spec (L18).

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/proposal.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Regression-audit lows in the uploads/media and operator-task surfaces (post-2.9.2 review): L3, L16,
+L11, plus the L18 test gap and the L7 documentation note.
+
+- **L3** — `Admin::MediaController#crop` renders `res['url'].to_s` and writes
+  `set_meta('avatar', res['url'])` without checking whether `upload_file` failed. A failed upload
+  returns `{ error: ... }` with no `url`, so the action rendered an empty 200 body (the avatar flow
+  stored `""`) and overwrote the saved avatar meta with nil.
+- **L16** — `cama_upload_failure` reads `settings[:remove_source]` (symbol only), but the first
+  (malicious-content) rejection in `upload_file` runs *before* settings are deep-symbolized. A
+  caller passing a string-keyed `remove_source` therefore left its staged file behind in the
+  web-served `public/tmp`.
+- **L11** — the theme generator and three repair rake tasks wrote operator output only to
+  `Rails.logger`, so an operator running them from a terminal saw nothing (the log goes to a file).
+- **L18** — the M27 media-pagination fix (#1242) had no end-to-end test proving the legacy-thumb
+  repair reaches the rendered page; the unit specs only exercised the `.to_a` array path.
+- **L7** — rows edited during the 2.9.1–2.9.2 sanitize-on-save era stored HTML-escaped entities
+  and render visibly double-encoded once under the escape-at-render era; no repair task
+  (document-only, per maintainer decision — each row self-heals on edit-and-resave).
+
+## What Changes
+
+- **L3**: `crop` surfaces an `upload_file` error like its other error paths (`render plain:`
+  sanitized message) and skips the avatar meta write.
+- **L16**: `cama_upload_failure` honors a string-keyed `remove_source` too, so the staged file is
+  purged on the pre-symbolize failure path.
+- **L11**: operator output goes to stdout as well as the log (a `report` lambda in the tasks, Thor's
+  `say` in the generator).
+- **L18**: a request spec asserts the repaired `.png` thumbnail URL appears in the rendered page.
+- **L7**: a CHANGELOG upgraders note.
+
+## Capabilities
+
+### New Capabilities
+
+- `media-crop-error-response`: the crop action surfaces upload failures instead of an empty success,
+  and never writes a nil avatar meta on failure.
+
+### Modified Capabilities
+
+- `upload-staging-lifecycle`: staged-file cleanup on failure honors a string-keyed `remove_source`,
+  covering the pre-symbolize (malicious-content) rejection path.
+
+## Impact
+
+- `app/controllers/camaleon_cms/admin/media_controller.rb` (L3),
+  `lib/camaleon_cms/uploader_path_security.rb` (L16),
+  `lib/tasks/{custom_fields_roles,site_custom_field_groups,cross_site_field_groups}.rake` and
+  `lib/generators/camaleon_cms/theme_generator.rb` (L11), `CHANGELOG.md` (L7).
+- Specs: crop request spec (L3), `uploader_helper_spec` (L16), the three rake-task specs (L11
+  stdout), media `index` request spec (L18).
+- No routes or schema changes.

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/specs/media-crop-error-response/spec.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/specs/media-crop-error-response/spec.md
@@ -1,0 +1,27 @@
+## Purpose
+
+Define how `Admin::MediaController#crop` responds when the underlying upload fails, so a failure is
+visible to the caller and never corrupts the saved avatar.
+
+## ADDED Requirements
+
+### Requirement: The crop action surfaces an upload failure instead of an empty success
+
+When `upload_file` returns an error (a result carrying `:error` and no `url`), the crop action SHALL
+render the sanitized error message as its response body rather than an empty body, so a consumer of
+the endpoint (the avatar flow) cannot store an empty string as the cropped URL.
+
+#### Scenario: A failed crop upload returns the error message
+
+- **WHEN** `crop` is invoked and `upload_file` returns `{ error: <message> }`
+- **THEN** the response body is the sanitized error message, not empty
+
+### Requirement: A failed crop does not overwrite the saved avatar
+
+When the crop upload fails, the action SHALL NOT write the user's `avatar` meta, so a failed crop
+leaves any previously saved avatar intact rather than replacing it with a nil URL.
+
+#### Scenario: The saved avatar is untouched on a failed crop
+
+- **WHEN** `crop` is invoked with a `saved_avatar` user id and `upload_file` returns an error
+- **THEN** that user's `avatar` meta is unchanged

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/specs/upload-staging-lifecycle/spec.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/specs/upload-staging-lifecycle/spec.md
@@ -1,0 +1,15 @@
+## ADDED Requirements
+
+### Requirement: Cleanup honors a string-keyed remove_source on the pre-symbolize failure path
+
+The staged-file cleanup seam (`cama_upload_failure`) SHALL purge an uploader-owned staged file when
+`remove_source` is set under either a symbol or a string key. The first (malicious-content)
+rejection in `upload_file` runs before settings are deep-symbolized, so a caller passing a
+string-keyed `remove_source` MUST NOT leave its staged file behind in the web-served staging root.
+
+#### Scenario: A rejected upload with a string-keyed remove_source is purged
+
+- **WHEN** an untrusted upload of malicious content is submitted with `{ 'remove_source' => true }`
+  (a string key), triggering the pre-symbolize content rejection
+- **THEN** the upload is rejected with an error
+- **AND** the uploader-owned staged file is removed from the staging root

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/tasks.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/tasks.md
@@ -37,3 +37,13 @@
       change (no `[skip ci]` — heads the first push).
 - [x] 7.2 Push, open the PR (What and Why + User-Visible Impact).
 - [x] 7.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.
+
+## 8. Code-review follow-ups (same branch, post-archive; no behavior change)
+
+- [x] 8.1 Extract the per-task `report` lambda into a shared `CamaleonCms::TaskReporter` (log +
+      puts), required from `lib/camaleon_cms.rb`; call sites keep the `report.call` form.
+- [x] 8.2 Remove the dead duplicate-theme guard in the theme generator (its condition re-checked
+      the same deterministic path the `elsif` above had already ruled out).
+- [x] 8.3 Harden the L18 spec cleanup: remove the whole per-site media root in `ensure`,
+      nil-guarded so a setup failure is not masked by the cleanup.
+- [x] 8.4 Sync the OpenSpec artifacts, PR description, and changelog entry with the follow-ups.

--- a/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/tasks.md
+++ b/openspec/changes/archive/2026-08-10-fix-upload-and-task-residuals/tasks.md
@@ -1,0 +1,39 @@
+## 1. L3 — crop surfaces upload failures (commit 1)
+
+- [x] 1.1 Red-first: crop request spec — a failing `upload_file` returns the sanitized error body
+      (not an empty 200) and leaves the saved avatar meta untouched.
+- [x] 1.2 `Admin::MediaController#crop`: guard `res[:error]` before the avatar write.
+
+## 2. L16 — staged-file cleanup honors a string-keyed remove_source (commit 2)
+
+- [x] 2.1 Red-first: `uploader_helper_spec` — a malicious upload with `{ 'remove_source' => true }`
+      (string key, pre-symbolize failure path) purges the staged file.
+- [x] 2.2 `cama_upload_failure`: `settings[:remove_source] || settings['remove_source']`.
+
+## 3. L11 — operator task/generator output reaches the console (commit 3)
+
+- [x] 3.1 The three repair rake tasks use a `report` lambda (Rails.logger + puts); the theme
+      generator uses Thor `say`.
+- [x] 3.2 Each rake-task spec asserts the summary/start line on stdout.
+
+## 4. L18 — end-to-end media legacy-thumb spec (commit 4)
+
+- [x] 4.1 Media `index` request spec: a cached `.jpg` thumb with only an on-disk `.png` renders the
+      repaired `.png` URL (and not the `.jpg`) in the page body.
+
+## 5. L7 — document the double-encoded legacy rows (commit 5, docs-only, [skip ci])
+
+- [x] 5.1 CHANGELOG upgraders note: rows edited in the 2.9.1–2.9.2 sanitize-on-save era render
+      double-encoded once and self-heal on resave; no repair task.
+
+## 6. Verification and CI parity
+
+- [x] 6.1 Touched specs green; rubocop clean on touched files; brakeman clean; zeitwerk clean.
+
+## 7. OpenSpec + PR protocol
+
+- [x] 7.1 `openspec validate fix-upload-and-task-residuals --strict` passes; archive on-branch
+      (adds `media-crop-error-response`, syncs `upload-staging-lifecycle`); commit the archived
+      change (no `[skip ci]` — heads the first push).
+- [x] 7.2 Push, open the PR (What and Why + User-Visible Impact).
+- [x] 7.3 Commit the short changelog entry referencing the PR with `[skip ci]` and push.

--- a/openspec/specs/media-crop-error-response/spec.md
+++ b/openspec/specs/media-crop-error-response/spec.md
@@ -1,0 +1,27 @@
+# media-crop-error-response Specification
+
+## Purpose
+Define how `Admin::MediaController#crop` responds when the underlying upload fails, so a failure is
+visible to the caller and never corrupts the saved avatar.
+## Requirements
+### Requirement: The crop action surfaces an upload failure instead of an empty success
+
+When `upload_file` returns an error (a result carrying `:error` and no `url`), the crop action SHALL
+render the sanitized error message as its response body rather than an empty body, so a consumer of
+the endpoint (the avatar flow) cannot store an empty string as the cropped URL.
+
+#### Scenario: A failed crop upload returns the error message
+
+- **WHEN** `crop` is invoked and `upload_file` returns `{ error: <message> }`
+- **THEN** the response body is the sanitized error message, not empty
+
+### Requirement: A failed crop does not overwrite the saved avatar
+
+When the crop upload fails, the action SHALL NOT write the user's `avatar` meta, so a failed crop
+leaves any previously saved avatar intact rather than replacing it with a nil URL.
+
+#### Scenario: The saved avatar is untouched on a failed crop
+
+- **WHEN** `crop` is invoked with a `saved_avatar` user id and `upload_file` returns an error
+- **THEN** that user's `avatar` meta is unchanged
+

--- a/openspec/specs/upload-staging-lifecycle/spec.md
+++ b/openspec/specs/upload-staging-lifecycle/spec.md
@@ -135,3 +135,17 @@ error.
   that value
 - **THEN** a size error is returned
 
+### Requirement: Cleanup honors a string-keyed remove_source on the pre-symbolize failure path
+
+The staged-file cleanup seam (`cama_upload_failure`) SHALL purge an uploader-owned staged file when
+`remove_source` is set under either a symbol or a string key. The first (malicious-content)
+rejection in `upload_file` runs before settings are deep-symbolized, so a caller passing a
+string-keyed `remove_source` MUST NOT leave its staged file behind in the web-served staging root.
+
+#### Scenario: A rejected upload with a string-keyed remove_source is purged
+
+- **WHEN** an untrusted upload of malicious content is submitted with `{ 'remove_source' => true }`
+  (a string key), triggering the pre-symbolize content rejection
+- **THEN** the upload is rejected with an error
+- **AND** the uploader-owned staged file is removed from the staging root
+

--- a/spec/helpers/uploader_helper_spec.rb
+++ b/spec/helpers/uploader_helper_spec.rb
@@ -69,6 +69,16 @@ describe CamaleonCms::UploaderHelper do
       expect(upload_file(File.open(staged), { folder: '../escape', remove_source: true }).key?(:error)).to be(true)
       expect(File.exist?(staged)).to be(false)
     end
+
+    it 'removes an uploader-owned staged source on the pre-symbolize failure path with a string key' do
+      # The malicious-content rejection runs before settings are symbolized, so a string-keyed
+      # remove_source must still purge the staged file rather than leak it in public/tmp.
+      staged = File.join(tmp_path, 'string_key_source.html')
+      File.write(staged, '<html><script>alert(1)</script></html>')
+
+      expect(upload_file(File.open(staged), { 'remove_source' => true }).key?(:error)).to be(true)
+      expect(File.exist?(staged)).to be(false)
+    end
   end
 
   describe 'staging name source' do

--- a/spec/lib/tasks/cross_site_field_groups_rake_spec.rb
+++ b/spec/lib/tasks/cross_site_field_groups_rake_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'cross_site_field_groups Rake task', type: :task do
 
     before { task.reenable }
 
+    it 'reports a summary on stdout for the operator running it' do
+      expect { task.invoke }.to output(/Summary:/).to_stdout
+    end
+
     def injected_group(object_class, objectid, slug)
       owner_site.custom_field_groups.create!(
         name: "Injected #{slug}", slug: slug, object_class: object_class, objectid: objectid

--- a/spec/lib/tasks/custom_fields_roles_rake_spec.rb
+++ b/spec/lib/tasks/custom_fields_roles_rake_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
 
     before { task.reenable }
 
+    it 'reports progress on stdout for the operator running it' do
+      expect { task.invoke }.to output(/Backfilling custom_fields manager permission/).to_stdout
+    end
+
     it 'adds custom_fields permission when manager meta is missing' do
       site = create(:site)
       role = site.user_roles.create!(name: 'Needs Backfill', slug: 'needs_backfill')
@@ -78,6 +82,10 @@ RSpec.describe 'custum_fields_roles Rake task', type: :task do
     let(:task) { Rake::Task[task_name] }
 
     before { task.reenable }
+
+    it 'reports a summary on stdout for the operator running it' do
+      expect { task.invoke }.to output(/Summary:/).to_stdout
+    end
 
     it 'adds select_eval permission for admin roles with term_group -1' do
       # slugs are unique per parent, so the scenarios below reuse the shared

--- a/spec/lib/tasks/site_custom_field_groups_rake_spec.rb
+++ b/spec/lib/tasks/site_custom_field_groups_rake_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'site_custom_field_groups Rake task', type: :task do
 
     before { task.reenable }
 
+    it 'reports a summary on stdout for the operator running it' do
+      expect { task.invoke }.to output(/Summary:/).to_stdout
+    end
+
     # object_class has a presence validation but objectid does not, so a group with a NULL objectid
     # is constructible. Build it unscoped to keep the spec honest about what it repairs.
     def create_group(attrs)

--- a/spec/requests/admin/media_controller/crop_spec.rb
+++ b/spec/requests/admin/media_controller/crop_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#crop', type: :request do
       expect(response.media_type).to eq('text/plain')
       expect(response.body).to eq('/uploads/<script>alert(1)</script>.jpg')
     end
+
+    it 'surfaces an upload error and leaves the saved avatar untouched instead of an empty body' do
+      allow_any_instance_of(described_class).to receive(:verify_media_authorization).and_return(true)
+      allow_any_instance_of(described_class).to receive(:cama_tmp_upload).and_return(file_path: '/tmp/test.jpg')
+      allow_any_instance_of(described_class).to receive(:cama_crop_image).and_return('/tmp/cropped.jpg')
+      allow_any_instance_of(described_class).to receive(:upload_file)
+        .and_return(error: 'Potentially malicious content found!')
+      admin_user.set_meta('avatar', '/uploads/existing.jpg')
+      sign_in_as(admin_user, site: current_site)
+
+      get '/admin/media/crop', params: { saved_avatar: admin_user.id }
+
+      expect(response.body).to eq('Potentially malicious content found!')
+      expect(admin_user.reload.get_meta('avatar')).to eq('/uploads/existing.jpg')
+    end
   end
 
   context 'when cp_img_path is a server file path (path traversal attempt)' do

--- a/spec/requests/admin/media_controller/index_spec.rb
+++ b/spec/requests/admin/media_controller/index_spec.rb
@@ -22,6 +22,29 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#index', type: :request do
 
       expect(response).to have_http_status(:ok)
     end
+
+    # End-to-end guard for the M27 page seam (#1242): the legacy-thumb repair mutates the record
+    # in place on the paginated relation, and the view iterates the same loaded page. If that
+    # mutation stopped reaching the view (e.g. the seam returned a fresh array), the rendered
+    # <img src> would fall back to the 404ing .jpg. The unit specs only exercise the .to_a path.
+    it 'renders the repaired legacy thumbnail url on the page' do
+      uploader = CamaleonCmsLocalUploader.new(current_site: current_site)
+      thumb_dir = File.join(uploader.instance_variable_get(:@root_folder), 'thumb')
+      FileUtils.mkdir_p(thumb_dir)
+      File.write(File.join(thumb_dir, 'photo-jpg.png'), 'x') # only the legacy .png exists on disk
+      uploader.send(:get_media_collection).create!(
+        name: 'photo.jpg', folder_path: '/', is_folder: false, is_public: false,
+        file_type: 'image', url: '/media/1/photo.jpg', thumb: '/media/1/thumb/photo-jpg.jpg'
+      )
+
+      get '/admin/media'
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('/media/1/thumb/photo-jpg.png')
+      expect(response.body).not_to include('/media/1/thumb/photo-jpg.jpg')
+    ensure
+      FileUtils.rm_rf(thumb_dir)
+    end
   end
 
   context 'when user does NOT have media management permission' do

--- a/spec/requests/admin/media_controller/index_spec.rb
+++ b/spec/requests/admin/media_controller/index_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#index', type: :request do
     # <img src> would fall back to the 404ing .jpg. The unit specs only exercise the .to_a path.
     it 'renders the repaired legacy thumbnail url on the page' do
       uploader = CamaleonCmsLocalUploader.new(current_site: current_site)
-      thumb_dir = File.join(uploader.instance_variable_get(:@root_folder), 'thumb')
+      media_root = uploader.instance_variable_get(:@root_folder)
+      thumb_dir = File.join(media_root, 'thumb')
       FileUtils.mkdir_p(thumb_dir)
       File.write(File.join(thumb_dir, 'photo-jpg.png'), 'x') # only the legacy .png exists on disk
       uploader.send(:get_media_collection).create!(
@@ -43,7 +44,10 @@ RSpec.describe CamaleonCms::Admin::MediaController, '#index', type: :request do
       expect(response.body).to include('/media/1/thumb/photo-jpg.png')
       expect(response.body).not_to include('/media/1/thumb/photo-jpg.jpg')
     ensure
-      FileUtils.rm_rf(thumb_dir)
+      # Disk state outlives the DB transaction: remove the whole per-site media root the setup
+      # created (the uploader constructor mkdir_p's it), not just the thumb subdirectory. The
+      # nil check keeps a setup failure from being masked by an error here.
+      FileUtils.rm_rf(media_root) if media_root
     end
   end
 


### PR DESCRIPTION
## What and Why

Fixes five regression-audit lows on the uploads/media and operator-task surfaces (**L3, L16, L11, L18**, plus the **L7** documentation note). One commit per finding.

- **L3 — crop swallowed upload failures.** `Admin::MediaController#crop` read `res['url']` without checking whether `upload_file` failed. A failed upload returns `{ error: ... }` with no `url`, so the action wrote `set_meta('avatar', nil)` — clobbering a saved avatar — and rendered an empty 200 body, which let the avatar flow store `""`. It now surfaces the sanitized error like its sibling error paths and skips the avatar write.
- **L16 — staged file leaked on a string-keyed `remove_source`.** `cama_upload_failure` read `settings[:remove_source]` (symbol only), but the first malicious-content rejection in `upload_file` runs before settings are deep-symbolized, so a caller passing a string key left its rejected upload staged in the web-served `public/tmp`. The shared cleanup seam now reads both key forms.
- **L11 — operator tasks were silent on the console.** The theme generator and three repair rake tasks wrote only to `Rails.logger`, so an operator running them from a terminal saw nothing. The tasks now report to stdout as well (the `orphaned_comments` precedent); the Thor generator uses `say`.
- **L18 — no end-to-end guard for the M27 thumbnail repair (#1242).** The legacy-thumb repair mutates the loaded relation page in place and the view iterates the same page; the committed specs only exercised the `.to_a` path. A media index request spec now asserts the repaired `.png` URL appears in the rendered page (and the `.jpg` does not).
- **L7 — documentation only** (see the changelog upgraders note): rows edited during the 2.9.1–2.9.2 sanitize-on-save era render double-encoded once and self-heal on resave. No repair task — a blanket re-encode cannot distinguish a user's literal `&amp;` from a sanitize-era artifact and is not idempotent.

## Review follow-ups (same branch)

Three non-behavioral cleanups from the code-review pass. The repair tasks' log-and-print reporting moved into a shared `CamaleonCms::TaskReporter` (it was defined per task, so the reporting rule could drift between tasks; call sites keep the `report.call` form). The theme generator lost a branch that could never execute — its condition re-checked a path the branch above had already ruled out. And the new legacy-thumb spec now cleans up the whole per-site media directory it creates and survives a setup failure without masking the original error.

## User-Visible Impact

A failed avatar crop now shows an error message instead of silently blanking the saved avatar; the theme generator and the custom-fields/site/cross-site repair rake tasks print progress to the terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
