### PR TITLE
Security: gate the installer and stop shipping a default admin password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Security fix:** The installer no longer publishes a default administrator password and can no
+  longer be run by an anonymous visitor on a fresh deploy (audit finding C1). New sites mint the
+  `admin` account with a random password shown once on the installer confirmation page — now reachable
+  only by the operator who just installed — and require a password change on first sign-in. The
+  first-run installer is gated by a setup token, read from `CAMALEON_SETUP_TOKEN` or a generated
+  `tmp/camaleon_setup_token` file. See [docs/installation.md](docs/installation.md) and
+  [docs/upgrading-to-2.9.3.md](docs/upgrading-to-2.9.3.md).
+  [#XXXX](https://github.com/owen2345/camaleon-cms/pulls).
+  - **Notes for upgraders:**
+    - **Scripted installs must now supply `CAMALEON_SETUP_TOKEN`.**
+    - **Existing installs are not rewritten.** An administrator still using the historical default
+      password should be rotated (admin profile screen or a `rails console` reset); the credential
+      disclosure on the installer page is closed for all installs regardless.
+
 - **Fix:** The captcha tag now honors a caller-supplied image style and string-keyed input
   attributes, and the admin "no categories/tags created" message shows a properly translated,
   localized label instead of the raw taxonomy slug; an internal shortcode-asset helper was realigned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   first-run installer is gated by a setup token, read from `CAMALEON_SETUP_TOKEN` or a generated
   `tmp/camaleon_setup_token` file. See [docs/installation.md](docs/installation.md) and
   [docs/upgrading-to-2.9.3.md](docs/upgrading-to-2.9.3.md).
-  [#XXXX](https://github.com/owen2345/camaleon-cms/pulls).
+  [#1246](https://github.com/owen2345/camaleon-cms/pull/1246).
   - **Notes for upgraders:**
     - **Scripted installs must now supply `CAMALEON_SETUP_TOKEN`.**
     - **Existing installs are not rewritten.** An administrator still using the historical default

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -430,7 +430,7 @@ GEM
     sassc-embedded (1.80.9)
       sass-embedded (~> 1.80)
     securerandom (0.4.1)
-    selenium-webdriver (4.45.0)
+    selenium-webdriver (4.47.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)

--- a/app/controllers/camaleon_cms/admin/installers_controller.rb
+++ b/app/controllers/camaleon_cms/admin/installers_controller.rb
@@ -5,9 +5,13 @@ module CamaleonCms
       skip_before_action :cama_before_actions
       skip_after_action :cama_after_actions
       before_action :installer_verification, except: :welcome
+      before_action :require_setup_token, only: :save
       layout 'camaleon_cms/login'
 
       def index
+        # Ensure the setup token exists (and is logged) so a remote operator can read it and enter it
+        # below. Local installs are exempt (require_setup_token), so no token is generated for them.
+        CamaleonCms::SetupToken.value if CamaleonCms::SetupToken.required? && !request.local?
         @site ||= CamaleonCms::Site.new
         @site.slug = request.original_url.to_s.parse_domain
         render 'form'
@@ -17,6 +21,10 @@ module CamaleonCms
         @site = CamaleonCms::Site.new(params[:site].permit(:slug, :name)).decorate
         if @site.save
           site_after_install(@site, params[:theme])
+          CamaleonCms::SetupToken.clear! # single-use: the installer is closed now that a site exists
+          # Carry the generated admin password to the welcome page for a single, session-scoped display.
+          flash[:generated_admin_password] = @site.generated_admin_password
+          session[:cama_installer_welcome] = true
           flash[:notice] = t('camaleon_cms.admin.sites.message.created')
           redirect_to action: :welcome
         else
@@ -24,10 +32,33 @@ module CamaleonCms
         end
       end
 
-      def welcome; end
+      def welcome
+        # Only the operator who just completed setup may see the credentials; the marker is one-time.
+        return redirect_to cama_admin_login_url unless session.delete(:cama_installer_welcome)
+
+        @generated_admin_password = flash[:generated_admin_password]
+      end
 
       def installer_verification
         redirect_to cama_root_url unless CamaleonCms::Site.count == 0
+      end
+
+      # Refuse to provision unless the request carries the setup token (readable only from the server's
+      # environment or filesystem). Only enforced while no site exists; afterwards installer_verification
+      # has already closed the installer.
+      def require_setup_token
+        return unless CamaleonCms::SetupToken.required?
+        # Loopback requests (a local console/dev install, or an SSH tunnel) already prove host access,
+        # so the token is required only for remote requests. request.local? is true only when the
+        # computed client IP is loopback, so a real remote client behind a proxy that forwards
+        # X-Forwarded-For is still gated. See harden-installer-default-admin.
+        return if request.local?
+        return if CamaleonCms::SetupToken.valid?(params[:setup_token])
+
+        flash[:error] = t('camaleon_cms.admin.installer.invalid_setup_token',
+                          default: 'A valid setup token is required to install. See the server log or ' \
+                                   'tmp/camaleon_setup_token.')
+        redirect_to cama_admin_installers_path
       end
     end
   end

--- a/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/sites_controller.rb
@@ -47,7 +47,7 @@ module CamaleonCms
           if @site.save
             save_metas(@site)
             site_after_install(@site, @site.get_theme_slug)
-            flash[:notice] = t('camaleon_cms.admin.sites.message.created')
+            flash[:notice] = site_created_notice(@site)
             redirect_to action: :index
           else
             new
@@ -86,6 +86,29 @@ module CamaleonCms
 
         def site_params
           params.require(:site).permit(:name, :slug, :description)
+        end
+
+        # When creating an additional site provisions a fresh administrator (only when users are not
+        # shared across sites), surface its generated password once to the authenticated creator, with
+        # a copy control. Otherwise a plain confirmation. See harden-installer-default-admin.
+        def site_created_notice(site)
+          password = site.generated_admin_password
+          return t('camaleon_cms.admin.sites.message.created') if password.blank?
+
+          # rubocop:disable Style/FormatStringToken -- Rails i18n interpolation requires %{...} syntax
+          message = t(
+            'camaleon_cms.admin.sites.message.created_with_admin',
+            password: password,
+            default: 'Site created. New administrator password: %{password}. Change it after signing in.'
+          )
+          # rubocop:enable Style/FormatStringToken
+          copy = helpers.tag.button(
+            t('camaleon_cms.admin.installer.copy', default: 'Copy'),
+            type: 'button',
+            class: 'btn btn-xs btn-default',
+            onclick: "navigator.clipboard&&navigator.clipboard.writeText('#{password}')"
+          )
+          helpers.safe_join([message, ' ', copy])
         end
       end
     end

--- a/app/controllers/camaleon_cms/admin/users_controller.rb
+++ b/app/controllers/camaleon_cms/admin/users_controller.rb
@@ -70,6 +70,10 @@ module CamaleonCms
 
         return render plain: @user.errors.full_messages.join(', '), status: :unprocessable_entity if @user.errors.any?
 
+        # A newly provisioned admin (see harden-installer-default-admin) owes a password change; clearing
+        # the marker on a real change lets them past the enforce_password_change gate.
+        @user.delete_meta('must_change_password') if @user.saved_change_to_password_digest?
+
         # keep user logged in when changing their own password
         update_auth_token_in_cookie @user.auth_token if update_session && @user.saved_change_to_password_digest?
       rescue ActiveRecord::RecordNotFound

--- a/app/controllers/camaleon_cms/admin_controller.rb
+++ b/app/controllers/camaleon_cms/admin_controller.rb
@@ -8,6 +8,7 @@ module CamaleonCms
     before_action :cama_authenticate
     before_action :keep_request_attrs
     before_action :admin_init_actions
+    before_action :enforce_password_change
     before_action :admin_logged_actions
     before_action :admin_before_hooks
     after_action :admin_after_hooks
@@ -75,6 +76,24 @@ module CamaleonCms
     end
 
     private
+
+    # Actions reachable while an administrator still owes a password change: the profile screen, its
+    # submit, and the AJAX password-change endpoint. Everything else in the admin panel is redirected
+    # to the change-password screen until the marker is cleared. Sign-out lives on SessionsController
+    # (not an AdminController subclass), so it is out of this gate's reach and always reachable.
+    PASSWORD_CHANGE_EXEMPT = { 'camaleon_cms/admin/users' => %w[profile profile_edit update updated_ajax] }.freeze
+
+    # Force a newly provisioned administrator (minted with a generated password, see
+    # harden-installer-default-admin) to set their own password before using the admin panel.
+    def enforce_password_change
+      return if cama_current_user.blank?
+      return if cama_current_user.get_meta('must_change_password').blank?
+      return if PASSWORD_CHANGE_EXEMPT[controller_path]&.include?(action_name)
+
+      flash[:alert] = t('camaleon_cms.admin.users.message.must_change_password',
+                        default: 'Please choose a new password before continuing.')
+      redirect_to cama_admin_profile_edit_path
+    end
 
     # initialize all vars and methods for admin panel
     def admin_init_actions

--- a/app/models/camaleon_cms/site.rb
+++ b/app/models/camaleon_cms/site.rb
@@ -7,6 +7,12 @@ module CamaleonCms
     # attrs: [name, description, slug]
     attr_accessor :site_domain
 
+    # Transient (never persisted): when default_settings auto-provisions the
+    # administrator, it stashes the randomly generated plaintext password here so
+    # the provisioning controller can surface it once. nil when no admin was minted
+    # (e.g. a shared admin already existed). See harden-installer-default-admin.
+    attr_accessor :generated_admin_password
+
     has_many :post_types, class_name: 'CamaleonCms::PostType', foreign_key: :parent_id, dependent: :destroy,
                           inverse_of: :site
     has_many :nav_menus, class_name: 'CamaleonCms::NavMenu', foreign_key: :parent_id, dependent: :destroy,

--- a/app/models/camaleon_record.rb
+++ b/app/models/camaleon_record.rb
@@ -64,6 +64,8 @@ class CamaleonRecord < ActiveRecord::Base # rubocop:disable Rails/ApplicationRec
 
   # remove cache value for this key
   def cama_remove_cache(key)
+    return unless @cama_cache_vars
+
     @cama_cache_vars.delete(cama_build_cache_key(key))
   end
 

--- a/app/models/concerns/camaleon_cms/site_default_settings.rb
+++ b/app/models/concerns/camaleon_cms/site_default_settings.rb
@@ -112,8 +112,16 @@ module CamaleonCms
           end
           user = users.admin_scope.first
           if user.blank?
-            user = users.admin_scope.create({ email: 'admin@local.com', username: 'admin', password: 'admin123',
-                                              password_confirmation: 'admin123', first_name: 'Administrator' })
+            # Never mint a known default password. Generate a random one, force a change on first
+            # login, and stash the plaintext transiently so the provisioning controller can surface
+            # it once. See harden-installer-default-admin.
+            generated_password = SecureRandom.alphanumeric(16)
+            user = users.admin_scope.create({ email: 'admin@local.com', username: 'admin',
+                                              password: generated_password,
+                                              password_confirmation: generated_password,
+                                              first_name: 'Administrator' })
+            user.set_meta('must_change_password', true)
+            self.generated_admin_password = generated_password
           end
           post = pt.add_post({ title: title, slug: slug, content: content, user_id: user.id, status: 'published' })
           @nav_menu.append_menu_item({ label: title, type: 'post', link: post.id })

--- a/app/views/camaleon_cms/admin/installers/form.html.erb
+++ b/app/views/camaleon_cms/admin/installers/form.html.erb
@@ -14,6 +14,11 @@
         <%= select_tag :theme, options_for_select(PluginRoutes.all_themes.map{|theme| [theme["name"], theme["key"]] }), :class => "form-control required" %>
     </div>
     <div class="form-group">
+        <%= label_tag :setup_token, t('camaleon_cms.admin.installer.setup_token', default: 'Setup token') %><br>
+        <%= text_field_tag :setup_token, nil, class: "form-control", autocomplete: "off" %>
+        <small style="color: #999;"><%= t('camaleon_cms.admin.installer.setup_token_hint', default: 'Required for remote installations; leave blank when installing locally. Printed in the server log and saved to tmp/camaleon_setup_token on first run.') %></small>
+    </div>
+    <div class="form-group">
         <button class="btn btn-primary pull-right" type="submit"><%= t('camaleon_cms.admin.button.submit') %></button>
     </div>
 <% end %>

--- a/app/views/camaleon_cms/admin/installers/welcome.html.erb
+++ b/app/views/camaleon_cms/admin/installers/welcome.html.erb
@@ -1,8 +1,32 @@
 <div class="well">
-    <h3>Your site was created successfully.</h3>
+    <h3><%= t('camaleon_cms.admin.installer.welcome_title', default: 'Your site was created successfully.') %></h3>
     <hr>
-    <p>Vist Frontend: <%= link_to("Here.", cama_root_url, target: "_blank") %></p>
-    <p>Visit Admin panel <%= link_to("Here.", cama_admin_login_url, target: "_blank") %></p>
-    <p>user: admin</p>
-    <p>pass: admin123</p>
+    <p><%= t('camaleon_cms.admin.installer.visit_frontend', default: 'Visit Frontend:') %> <%= link_to(t('camaleon_cms.admin.installer.here', default: 'Here.'), cama_root_url, target: "_blank") %></p>
+    <p><%= t('camaleon_cms.admin.installer.visit_admin', default: 'Visit Admin panel') %> <%= link_to(t('camaleon_cms.admin.installer.here', default: 'Here.'), cama_admin_login_url, target: "_blank") %></p>
+    <hr>
+    <p><%= t('camaleon_cms.admin.installer.user_label', default: 'User:') %> <strong>admin</strong></p>
+    <% if @generated_admin_password.present? %>
+        <p>
+            <%= t('camaleon_cms.admin.installer.password_label', default: 'Password:') %>
+            <strong><span id="cama_generated_password"><%= @generated_admin_password %></span></strong>
+            <button type="button" class="btn btn-xs btn-default" onclick="cama_copy_generated_password(this)">
+                <%= t('camaleon_cms.admin.installer.copy', default: 'Copy') %>
+            </button>
+        </p>
+        <p style="color: #c0392b;"><%= t('camaleon_cms.admin.installer.must_change_notice', default: 'Save this password now — it is shown only once. You will be asked to change it when you first sign in.') %></p>
+        <script>
+            function cama_copy_generated_password(btn) {
+                var node = document.getElementById('cama_generated_password');
+                var done = function () { btn.textContent = '<%= j t('camaleon_cms.admin.installer.copied', default: 'Copied!') %>'; };
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    navigator.clipboard.writeText(node.textContent).then(done, function () {});
+                } else {
+                    var range = document.createRange(); range.selectNode(node);
+                    var sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(range);
+                    try { document.execCommand('copy'); done(); } catch (e) {}
+                    sel.removeAllRanges();
+                }
+            }
+        </script>
+    <% end %>
 </div>

--- a/config/locales/camaleon_cms/admin/en.yml
+++ b/config/locales/camaleon_cms/admin/en.yml
@@ -488,10 +488,24 @@ en:
         message:
           error: 'Not found site'
           created: 'The site has been created.'
+          created_with_admin: 'Site created. New administrator password: %{password}. Change it after signing in.'
           updated: 'The site has been updated.'
           deleted: 'Correct Deleted'
           enter_key_domain: 'Enter a key or a domain'
           enter_key_domain_empty: 'Enter a key (site2) or a domain (my_domain.com). Key will be the name of your subdomain.'
+      installer:
+        setup_token: 'Setup token'
+        setup_token_hint: 'Required for remote installations; leave blank when installing locally. Printed in the server log and saved to tmp/camaleon_setup_token on first run.'
+        invalid_setup_token: 'A valid setup token is required to install. See the server log or tmp/camaleon_setup_token.'
+        welcome_title: 'Your site was created successfully.'
+        visit_frontend: 'Visit Frontend:'
+        visit_admin: 'Visit Admin panel'
+        here: 'Here.'
+        user_label: 'User:'
+        password_label: 'Password:'
+        copy: 'Copy'
+        copied: 'Copied!'
+        must_change_notice: 'Save this password now — it is shown only once. You will be asked to change it when you first sign in.'
       signin:
         message:
           enter_username_password: 'You must enter a username and/or password'
@@ -629,6 +643,7 @@ en:
           created: 'The user has been created.'
           updated: 'The user has been updated.'
           deleted: 'The user has been deleted.'
+          must_change_password: 'Please choose a new password before continuing.'
           incorrect_old_password: 'Incorrect old password'
           rol_error: 'Not found group user.'
           rol_created: 'The user role has been created.'

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,107 @@
+# Installing Camaleon CMS
+
+These are the current installation steps for Camaleon CMS. (The "updated installation steps" link on
+camaleon.website points here.)
+
+## Requirements
+
+- Ruby and Rails versions per the project's `.tool-versions` and `Gemfile`.
+- ImageMagick (for media processing).
+
+## Steps
+
+1. **Create your Rails project** (skip if you already have one):
+
+   ```bash
+   rails new my_project
+   cd my_project
+   ```
+
+2. **Add the gem** to your `Gemfile`:
+
+   ```ruby
+   gem "camaleon_cms"
+   # or the latest development version:
+   # gem "camaleon_cms", github: "owen2345/camaleon-cms"
+   ```
+
+3. **Install dependencies:**
+
+   ```bash
+   bundle install
+   ```
+
+4. **Run the Camaleon installer generator:**
+
+   ```bash
+   rails generate camaleon_cms:install
+   ```
+
+5. *(Optional)* Configure your CMS in `config/system.json` before continuing (see
+   [config/system.json](../config/system.json) for the full settings). `users_share_sites` in
+   particular can only be changed before installation.
+
+6. **Create the database structure:**
+
+   ```bash
+   rake camaleon_cms:generate_migrations
+   # you can customize the copied migration files before running them
+   rake db:migrate
+   ```
+
+7. **Start your server:**
+
+   ```bash
+   rails server
+   ```
+
+8. **Complete the web installer.** Visit `http://localhost:3000/`. With no site yet, Camaleon shows the
+   installer form asking for a domain/key, a site name, a theme — **and a setup token**.
+
+   ### The setup token
+
+   On a fresh deploy the installer is gated by a setup token, so that a random visitor who reaches a
+   public deployment first cannot complete setup. **Local installs do not need it:** a request from the
+   local host (installing on `localhost`, or over an `ssh -L` tunnel) is exempt, because local access
+   already proves you are on the server. Leave the token field blank in that case.
+
+   Only a **remote** request needs the token. Provide it one of two ways:
+
+   - Set `CAMALEON_SETUP_TOKEN` in the server environment before booting, and enter that value; or
+   - Leave it unset — Camaleon generates a token on first access, writes it to
+     `tmp/camaleon_setup_token` (mode `0600`), and logs its location. Read it from that file or the
+     server log and enter it in the form.
+
+   The token stops working once a site exists. (The loopback exemption relies on your reverse proxy, if
+   any, forwarding the real client IP via `X-Forwarded-For` — standard nginx/Apache configuration; a
+   proxy that strips it would let a remote request appear local.)
+
+9. **Save your administrator password.** The installer creates an `admin` account with a **randomly
+   generated password**, shown **once** on the confirmation page (with a copy button). Save it now — it
+   is not stored anywhere you can read later. When you first sign in you will be required to change it.
+
+   If you miss the one-time display, reset the password from a Rails console on the server:
+
+   ```bash
+   rails console
+   ```
+   ```ruby
+   u = CamaleonCms::User.find_by(username: "admin")
+   u.update(password: "your-new-password", password_confirmation: "your-new-password")
+   u.delete_meta("must_change_password") # optional: skip the forced-change prompt
+   ```
+
+## Production notes
+
+- Serve compiled assets and precompile them:
+
+  ```bash
+  RAILS_ENV=production rake assets:precompile
+  ```
+
+- Provide `SECRET_KEY_BASE` via the environment (do not commit secrets).
+
+## Support
+
+- Issues: https://github.com/owen2345/camaleon-cms/issues
+- Site: https://camaleon.website/

--- a/docs/upgrading-to-2.9.3.md
+++ b/docs/upgrading-to-2.9.3.md
@@ -1,0 +1,60 @@
+# Upgrading to 2.9.3
+
+Version `2.9.3` hardens the installer and the auto-provisioned administrator account (audit finding
+C1). It introduces one breaking change for automated installs and one action for operators of existing
+installs.
+
+## Installer setup token (BREAKING for scripted installs)
+
+The first-run web installer now requires a **setup token** for **remote** requests, so it cannot be
+completed by an anonymous visitor who reaches a freshly deployed app before the operator does.
+
+- **Local installs are exempt** — a request from the local host (installing on `localhost`, or over an
+  `ssh -L` tunnel) needs no token, because local access already proves host access.
+- For a remote install, provide the token via `CAMALEON_SETUP_TOKEN` in the environment, or read the
+  auto-generated value from `tmp/camaleon_setup_token` (also logged on first access) and enter it in the
+  installer form.
+- Automated or scripted **remote** installs that drive the installer must now supply
+  `CAMALEON_SETUP_TOKEN`.
+- The token is required only while no site exists; once installed, the installer is closed as before.
+- The loopback exemption uses `request.local?`, which trusts your reverse proxy (if any) to forward the
+  real client IP via `X-Forwarded-For` — standard configuration. A proxy that strips it would let a
+  remote request appear local, so set `CAMALEON_SETUP_TOKEN` in that case as defense in depth.
+
+See [docs/installation.md](installation.md) for the full flow.
+
+## Default administrator no longer uses a known password
+
+Previously a new site was provisioned with the administrator `admin` / `admin123`, and the installer's
+confirmation page displayed those credentials to anyone who visited it.
+
+### What changed
+
+- New installs mint the `admin` account with a **randomly generated password**, shown **once** on the
+  installer confirmation page (with a copy button) and never persisted where it can be read back.
+- The confirmation page is now reachable only by the operator who just completed setup, not by anonymous
+  visitors.
+- A newly provisioned administrator is required to change its password on first sign-in.
+
+### Recommended action for existing installs
+
+Upgrading does **not** rewrite existing accounts. If your site was installed before this release and its
+administrator still uses the default password, **rotate it now** — either from the admin profile screen,
+or from a Rails console on the server:
+
+```bash
+rails console
+```
+```ruby
+u = CamaleonCms::User.find_by(username: "admin")
+u.update(password: "your-new-password", password_confirmation: "your-new-password")
+```
+
+The disclosure itself (the credentials showing on the installer's confirmation page) is closed for all
+installs by this release, regardless of whether you rotate.
+
+## Recommended rollout
+
+1. Upgrade to `2.9.3`.
+2. For scripted installs, set `CAMALEON_SETUP_TOKEN` before running the installer.
+3. On existing installs, rotate any administrator still using the historical default password.

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -25,6 +25,7 @@ end
 
 $camaleon_engine_dir = File.expand_path('../..', __dir__)
 require File.join($camaleon_engine_dir, 'lib', 'plugin_routes').to_s
+require File.join($camaleon_engine_dir, 'lib', 'camaleon_cms', 'setup_token').to_s
 Dir[File.join($camaleon_engine_dir, 'lib', 'ext', '**', '*.rb')].sort.each { |f| require f }
 require 'draper'
 

--- a/lib/camaleon_cms/setup_token.rb
+++ b/lib/camaleon_cms/setup_token.rb
@@ -7,7 +7,7 @@ module CamaleonCms
   # deploy (audit finding C1, vector 2). The expected token comes from ENV['CAMALEON_SETUP_TOKEN']
   # when set, otherwise from a generated 0600 file under tmp/; generating it logs its location once so
   # the operator can read it. It is required only while no site exists, and is cleared once one does.
-  # See openspec/changes/harden-installer-default-admin.
+  # See openspec/specs/installer-access-control/spec.md.
   module SetupToken
     ENV_KEY = 'CAMALEON_SETUP_TOKEN'.freeze
 

--- a/lib/camaleon_cms/setup_token.rb
+++ b/lib/camaleon_cms/setup_token.rb
@@ -1,0 +1,65 @@
+require 'securerandom'
+require 'fileutils'
+
+module CamaleonCms
+  # Gates the first-run installer so setup can be completed only by someone with access to the
+  # server's environment or filesystem — not by any anonymous visitor who reaches the app on a fresh
+  # deploy (audit finding C1, vector 2). The expected token comes from ENV['CAMALEON_SETUP_TOKEN']
+  # when set, otherwise from a generated 0600 file under tmp/; generating it logs its location once so
+  # the operator can read it. It is required only while no site exists, and is cleared once one does.
+  # See openspec/changes/harden-installer-default-admin.
+  module SetupToken
+    ENV_KEY = 'CAMALEON_SETUP_TOKEN'.freeze
+
+    module_function
+
+    # The installer is gated only until the first site exists; afterwards it is closed anyway.
+    def required?
+      CamaleonCms::Site.count == 0
+    rescue StandardError
+      false
+    end
+
+    # The expected token: an explicit ENV override wins; otherwise a generated file (created on first
+    # read). Returns nil only if no ENV value is set and the file cannot be created.
+    def value
+      env = ENV[ENV_KEY].to_s
+      return env if env.present?
+
+      read_or_generate_file
+    end
+
+    # Constant-time comparison; false for a blank candidate or when no expected token is available.
+    def valid?(candidate)
+      candidate = candidate.to_s
+      expected = value.to_s
+      return false if candidate.empty? || expected.empty?
+
+      ActiveSupport::SecurityUtils.secure_compare(candidate, expected)
+    end
+
+    # Invalidate the generated token once setup has completed (the ENV override, if any, is untouched).
+    def clear!
+      File.delete(file_path) if File.exist?(file_path)
+    rescue StandardError
+      nil
+    end
+
+    def file_path
+      Rails.root.join('tmp/camaleon_setup_token').to_s
+    end
+
+    def read_or_generate_file
+      return File.read(file_path).strip if File.exist?(file_path)
+
+      token = SecureRandom.hex(32)
+      FileUtils.mkdir_p(File.dirname(file_path))
+      File.write(file_path, token)
+      File.chmod(0o600, file_path)
+      Rails.logger.info("Camaleon CMS: setup token written to #{file_path} — required to run the installer.")
+      token
+    rescue StandardError
+      nil
+    end
+  end
+end

--- a/lib/camaleon_cms/setup_token.rb
+++ b/lib/camaleon_cms/setup_token.rb
@@ -54,10 +54,14 @@ module CamaleonCms
 
       token = SecureRandom.hex(32)
       FileUtils.mkdir_p(File.dirname(file_path))
-      File.write(file_path, token)
-      File.chmod(0o600, file_path)
+      # 0600 from the first byte (write-then-chmod would leave a world-readable window at default
+      # umask), EXCL so a concurrent generator cannot clobber a token already handed to an operator.
+      File.open(file_path, File::WRONLY | File::CREAT | File::EXCL, 0o600) { |f| f.write(token) }
       Rails.logger.info("Camaleon CMS: setup token written to #{file_path} — required to run the installer.")
       token
+    rescue Errno::EEXIST
+      # Lost the creation race between the exist? check and the open: adopt the winner's token.
+      read_or_generate_file
     rescue StandardError
       nil
     end

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/design.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/design.md
@@ -1,0 +1,163 @@
+## Context
+
+See proposal.md — Why. The relevant current-state facts that shape the approach:
+
+- The auto-provisioned admin is minted in one place, `Site#default_settings`
+  (`site_default_settings.rb:113-117`), fired by `Site` `after_create`. Both the installer
+  (`InstallersController#save`) and `Admin::Settings::SitesController#create` reach it through
+  `Site#save`, so a single change to that method covers every provisioning path.
+- `InstallersController` (`installers_controller.rb`) skips authentication entirely and gates only on
+  `Site.count == 0`, with `welcome` exempted from even that.
+- `User` includes `CamaleonCms::Metas`, so a per-account flag can be stored without a schema change.
+- `AdminController` runs a `before_action` chain (`cama_authenticate` first); a new gate slots in
+  after authentication resolves `cama_current_user`.
+- Password reset is currently non-functional (the `has_secure_password` `password_reset_token` method
+  shadows the same-named DB column the controller queries) and is being fixed under a separate change,
+  so this change does not depend on it. Fresh installs also frequently have no SMTP configured, so
+  email recovery cannot be assumed as the fallback for a missed one-time password display — hence the
+  file safeguard (D2).
+- The installer UI today is a single three-field form (`installers/form.html.erb`: domain, name,
+  theme) whose submit lands on `installers/welcome.html.erb`. That is the entire surface this change
+  touches.
+
+## Goals / Non-Goals
+
+**Goals:**
+- No provisioning path ever creates an administrator with a password an attacker could know.
+- The generated password is recoverable by the legitimate operator (who has host access) but never
+  disclosed to an anonymous caller — with a one-click copy control so it is usable in practice.
+- Closing both C1 vectors — the public `welcome` disclosure and the unauthenticated installer.
+- Shipping updated installation and 2.9.3 migration docs, and giving the camaleon.website "updated
+  installation steps" link a maintained in-repo target.
+
+**Non-Goals:**
+- Retroactively rotating the password of admins on already-installed sites (force-change applies to
+  newly minted accounts only; the disclosure is closed for existing installs by the `welcome` gate).
+- Reworking the installer UI beyond its two touch-points: the setup-token field on the form and the
+  welcome page's password display with its copy-to-clipboard control. No multi-step wizard, no in-form
+  collection of admin credentials, no theme preview — the surface stays minimal.
+- Fixing the broken password-reset flow — tracked as a separate change; this change only avoids
+  depending on it (recovery leans on the file safeguard and a console reset instead).
+
+## Decisions
+
+### D1 — Setup token: `ENV` override, else a generated operator-readable file
+On boot, when `Site.count == 0`, the app ensures a setup token exists: it uses
+`ENV['CAMALEON_SETUP_TOKEN']` if set, otherwise generates a high-entropy token and writes it to an
+operator-readable file under the app's writable state (default `tmp/camaleon_setup_token`), logging
+its location once. The installer requires a matching token to provision, and the generated file is
+removed once a site exists.
+- *Why:* possession proves host access, which is exactly the line between the real operator and a web
+  visitor — the same model Jenkins/GitLab use for their initial secret. The `ENV` override handles
+  read-only or ephemeral filesystems (e.g. Heroku); the generated file handles the common case with
+  zero pre-configuration.
+- *Alternatives:* bind-the-installer-to-the-first-requester (rejected: racy, and the attacker may be
+  first); store the token in the DB (rejected: awkward when `Site.count == 0` and no better than a
+  file); require a rake/console step to install (rejected: heavier operator burden, larger UX change).
+
+### D2 — Keep minting in `Site#default_settings`; surface the plaintext to the caller transiently
+Provisioning stays in `default_settings` (single source of truth). It generates the password, assigns
+it, and exposes the plaintext to the caller through a transient in-memory accessor on the `Site`
+instance (not persisted, not logged). The installer reads it after `save` to stash for the one-time
+welcome display; the settings controller reads it to surface once to the creating admin. The plaintext
+is deliberately **never** written to a log or file — that would reintroduce the credential-disclosure
+class this change exists to close (cf. audit finding M9), and the setup-token file is deleted on
+install completion anyway. An operator who misses the one-time display recovers through a `rails
+console` password reset (documented in the install guide), and through the email reset flow once the
+sibling fix lands.
+- *Why:* moving minting into the installer would either duplicate logic into the settings path or
+  leave secondary-site provisioning (under `users_share_sites: false`) still minting a known password
+  or no admin at all — both regressions. One method, surfaced per entry point, keeps it complete.
+- *Alternative:* return the created user + plaintext up the call stack explicitly (rejected: the
+  `after_create` callback boundary makes a transient accessor cleaner than threading a return value).
+
+### D3 — Store the must-change marker in user meta, not a column
+The "must change password" flag lives in user meta (`set_meta`/`get_meta`).
+- *Why:* the engine ships a fixed schema; a new column would force downstream apps to regenerate
+  `schema.rb`. Meta is the project's established place for per-record flags and needs no migration.
+- *Trade-off:* a meta lookup per gated request rather than a column read — negligible, and cacheable.
+
+### D4 — Force-change applies to newly minted accounts only
+The marker is set at provisioning time. Existing installs are not detected or force-rotated.
+- *Why:* the operator chose this scope. Retroactive detection would either bake the literal default
+  password into a login-time check or require an operator-run remediation task; both were declined.
+  The acute disclosure is already closed for existing installs by the `welcome` gate (D6), leaving
+  only "an old install may still use a weak known password," which the CHANGELOG upgrade note
+  addresses by instructing operators to rotate.
+
+### D5 — The must-change gate is a `before_action` on `AdminController`, reusing the existing change path
+A gate runs after `cama_authenticate`. If `cama_current_user` carries the marker, it redirects to the
+existing password-change screen, exempting that screen, the password-change submit action, and
+sign-out (and non-HTML/asset requests) to avoid a redirect loop. Completing the change clears the
+marker.
+- *Why:* reusing `users_controller`'s existing change-password path avoids a new screen and keeps the
+  surface small.
+
+### D6 — Welcome gating via a one-time session marker set at `save`
+`save` records a one-time in-session indication on success and redirects to `welcome`; `welcome`
+requires it, shows the credentials, and clears it. `save` also redirects to the admin login (not the
+frontend root) so the operator lands where they sign in. The `Site.count == 0` gate is *not* extended
+to `welcome` (that would make it unreachable immediately after install — the reason the original code
+exempted it); the session marker is what replaces the missing gate.
+- *Why:* `Site.count` answers "may anyone still install?" (a global fact); `welcome` needs "did *you*
+  just install?" (a per-request fact). Only a per-session marker can answer the latter.
+
+### D7 — Installation and migration docs in `docs/`, matching the 2.9.2 pattern
+`docs/installation.md` carries the updated install steps (the README sequence plus the setup-token step
+and the first-login password change). `docs/upgrading-to-2.9.3.md` follows the structure of
+`docs/upgrading-to-2.9.2.md` (breaking-changes list, per-change sections, recommended rollout), and the
+CHANGELOG "Unreleased" entry links both.
+- *Why:* the project already versions upgrade guides under `docs/`; the installation doc gives the
+  camaleon.website "updated installation steps" link a maintained in-repo target (its current href is a
+  relative-path typo that 404s).
+- *Note:* the docs are authored during apply, against the shipped behavior, so they cannot drift from
+  what actually ships.
+
+### D8 — Loopback requests are exempt from the setup token (on by default)
+The token is required only for **remote** requests; a request from the local host (`request.local?`)
+provisions without one. The setup-token field on the installer form is therefore client-side optional
+(server-enforced for remote only).
+- *Why:* the token exists to stop an anonymous *remote* visitor from installing on a public fresh
+  deploy. Local access already proves host access — the same thing the token demonstrates — so a local
+  operator installing on `localhost` or over an `ssh -L` tunnel gains nothing from typing it. Auto-*fetching*
+  the token in the app was rejected as self-defeating: the app always holds the file, so validating it
+  against itself authorizes everyone, including the remote attacker. A "who" must be attached, and
+  loopback is that "who".
+- *Trade-off:* `request.local?` uses the computed client IP, so a real remote client is gated **as long
+  as** the reverse proxy forwards `X-Forwarded-For` (standard). A proxy that strips it would let a remote
+  request appear local; operators in that situation set `CAMALEON_SETUP_TOKEN` as defense in depth. This
+  is the same `XFF` trust Rails places everywhere, deemed acceptable for the default.
+
+## Risks / Trade-offs
+
+- **Operator misses the one-time welcome display and the password is random** → recovery is a
+  documented `rails console` password reset (the operator already has host access — that is how they
+  read the setup token), with the email reset path added once the sibling fix lands. The plaintext is
+  never persisted (D2). Called out in the install guide and upgrade notes.
+- **Setup token on a clustered / read-only deploy** → `ENV['CAMALEON_SETUP_TOKEN']` override (D1);
+  boot-time file generation is idempotent (only when absent) so multiple workers converge.
+- **Gate causes a redirect loop or locks the operator out of the change screen** → the change screen,
+  its submit action, and logout are explicitly exempted; covered by a feature spec.
+- **Scripted/automated installs break** (BREAKING) → documented; automation supplies
+  `CAMALEON_SETUP_TOKEN`.
+
+## Migration Plan
+
+- **Deploy:** set `CAMALEON_SETUP_TOKEN` for scripted installs, or read the generated token from the
+  logged file path for a manual first-run install.
+- **Existing installs:** no automatic change; the upgrade note instructs operators whose admin still
+  uses the historical default password to rotate it.
+- **Rollback:** revert the change; the setup token and must-change marker are additive (meta + a file)
+  and leave no schema residue.
+
+## Resolved During Implementation
+
+- The forced change reuses the existing profile-edit screen (`users#profile_edit`), whose
+  "Change Password" modal already posts to `users#updated_ajax`. The gate exempts `profile`,
+  `profile_edit`, `update`, and `updated_ajax`, so a marked admin has a working, non-dead-end path.
+- Task 2.4 (persist the generated password as a lockout safeguard) was dropped: writing the plaintext
+  to a log or file reintroduces the disclosure class this change closes, and the setup-token file is
+  deleted on install completion. Recovery is a documented `rails console` reset (see D2).
+- A latent bug surfaced and was fixed: `CamaleonRecord#cama_remove_cache` dereferenced `@cama_cache_vars`
+  without the `||= {}` guard its siblings use, so `delete_meta` (used to clear the marker) crashed on a
+  cold instance.

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/design.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/design.md
@@ -42,10 +42,10 @@ See proposal.md — Why. The relevant current-state facts that shape the approac
 ## Decisions
 
 ### D1 — Setup token: `ENV` override, else a generated operator-readable file
-On boot, when `Site.count == 0`, the app ensures a setup token exists: it uses
-`ENV['CAMALEON_SETUP_TOKEN']` if set, otherwise generates a high-entropy token and writes it to an
-operator-readable file under the app's writable state (default `tmp/camaleon_setup_token`), logging
-its location once. The installer requires a matching token to provision, and the generated file is
+On the first remote installer access while `Site.count == 0`, the app ensures a setup token exists:
+it uses `ENV['CAMALEON_SETUP_TOKEN']` if set, otherwise generates a high-entropy token and writes it
+to an operator-readable file under the app's writable state (default `tmp/camaleon_setup_token`),
+logging its location once. Local installs never need — and never generate — the token. The installer requires a matching token to provision, and the generated file is
 removed once a site exists.
 - *Why:* possession proves host access, which is exactly the line between the real operator and a web
   visitor — the same model Jenkins/GitLab use for their initial secret. The `ENV` override handles
@@ -135,7 +135,7 @@ provisions without one. The setup-token field on the installer form is therefore
   read the setup token), with the email reset path added once the sibling fix lands. The plaintext is
   never persisted (D2). Called out in the install guide and upgrade notes.
 - **Setup token on a clustered / read-only deploy** → `ENV['CAMALEON_SETUP_TOKEN']` override (D1);
-  boot-time file generation is idempotent (only when absent) so multiple workers converge.
+  the lazy file generation is idempotent (only when absent) so multiple workers converge.
 - **Gate causes a redirect loop or locks the operator out of the change screen** → the change screen,
   its submit action, and logout are explicitly exempted; covered by a feature spec.
 - **Scripted/automated installs break** (BREAKING) → documented; automation supplies

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/proposal.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/proposal.md
@@ -62,8 +62,8 @@ password is minted on secondary sites created through the settings UI when `user
   change-password path the gate must exempt).
 - **Models:** `concerns/camaleon_cms/site_default_settings.rb` (random password + must-change marker;
   expose the generated plaintext transiently to the caller).
-- **New:** boot-time setup-token provisioning (generated when `Site.count == 0`), read from
-  `ENV['CAMALEON_SETUP_TOKEN']` or a generated file.
+- **New:** lazy setup-token provisioning (generated on first remote installer access while
+  `Site.count == 0`), read from `ENV['CAMALEON_SETUP_TOKEN']` or a generated file.
 - **Views / locales:** `installers/form` (setup-token field), `installers/welcome` (show generated
   password + copy-to-clipboard control), new strings.
 - **Docs:** new `docs/installation.md` and `docs/upgrading-to-2.9.3.md`; CHANGELOG entry.

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/proposal.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+A fresh Camaleon install auto-creates a superadmin (`role: 'admin'`) with the hardcoded password
+`admin123`, and `GET /admin/installers/welcome` prints those credentials to anonymous visitors. That
+page is the one action exempted from the installer's own `Site.count == 0` gate, so it stays
+reachable **forever** on a fully installed site — an unauthenticated path to full administrative
+control. Separately, on a brand-new deploy (`Site.count == 0`) the installer's `save` action is
+itself unauthenticated, so whoever reaches the app first can provision it and own the resulting
+superadmin.
+
+The credentials-minting happens in a single place — `Site#default_settings`
+(`site_default_settings.rb:113-117`) — which fires for **every** site creation, so the same known
+password is minted on secondary sites created through the settings UI when `users_share_sites` is
+`false`, not just through the installer.
+
+## What Changes
+
+- **The auto-provisioned administrator is never created with a known password.** `Site#default_settings`
+  generates a random password and records a "must change password" marker on the account, replacing
+  the hardcoded `admin123`. This covers every provisioning path, not only the installer.
+- **The generated password is surfaced exactly once, only to the operator who provisioned the site.**
+  The installer `welcome` page shows it and is reachable only via a one-time session marker set by
+  `save`; it is no longer world-readable. Sites provisioned through the settings UI surface the
+  password once to the authenticated administrator who created them.
+- **The generated password carries a copy-to-clipboard control.** The operator copies it with one
+  click rather than hand-selecting a random string, on both the welcome page and the settings surface.
+- **A newly provisioned administrator must change its password before reaching the admin panel.**
+  A gate redirects an account still carrying the must-change marker to the change-password screen,
+  allowing only that screen and logout through. Applies to newly minted accounts; existing installs
+  are not force-rotated (their credential leak is already closed by the `welcome` gating above).
+- **The installer cannot be run by an unauthenticated party on a fresh deploy.** A setup token,
+  readable only from the server's environment or filesystem, is required to run the installer and is
+  consumed once setup completes. **BREAKING** for automated/scripted installs: the installer now
+  requires a setup token.
+- **Docs:** a new `docs/installation.md` (the updated install steps, now including the setup-token
+  step and the first-login password change), a `docs/upgrading-to-2.9.3.md` migration guide following
+  the `upgrading-to-2.9.2.md` template, and a CHANGELOG entry with upgrade notes — including an
+  explicit instruction for operators of existing installs to rotate an admin still using the default
+  password. This also gives the dangling "updated installation steps" link on camaleon.website
+  (a relative-href typo pointing at the GitHub repo) a real, maintained target in the repo.
+
+## Capabilities
+
+### New Capabilities
+- `installer-access-control`: who may run the site installer and view its output — the setup-token
+  requirement gating the installer on a fresh deploy, and the restriction of the `welcome` page to
+  the operator who just completed setup rather than to anonymous visitors.
+- `default-admin-credential-safety`: the credential lifecycle of the auto-provisioned administrator —
+  minted with a random password (never a known default) on every provisioning path, surfaced once to
+  the provisioner (with a copy-to-clipboard control), and required to be changed before the account is
+  used to access the admin panel.
+
+### Modified Capabilities
+<!-- None. No existing capability specifies installer access or the default admin's credentials;
+     both areas are introduced fresh by this change. -->
+
+## Impact
+
+- **Controllers:** `admin/installers_controller.rb` (setup-token gate, one-time `welcome` marker,
+  redirect target), `admin_controller.rb` (must-change gate), `admin/settings/sites_controller.rb`
+  (surface the generated password to the creating admin), `admin/users_controller.rb` (the
+  change-password path the gate must exempt).
+- **Models:** `concerns/camaleon_cms/site_default_settings.rb` (random password + must-change marker;
+  expose the generated plaintext transiently to the caller).
+- **New:** boot-time setup-token provisioning (generated when `Site.count == 0`), read from
+  `ENV['CAMALEON_SETUP_TOKEN']` or a generated file.
+- **Views / locales:** `installers/form` (setup-token field), `installers/welcome` (show generated
+  password + copy-to-clipboard control), new strings.
+- **Docs:** new `docs/installation.md` and `docs/upgrading-to-2.9.3.md`; CHANGELOG entry.
+- **Storage:** the must-change marker is stored in user meta — no migration (the engine ships a fixed
+  schema and a data column would force downstream `schema.rb` regeneration).
+- **Compatibility:** scripted installs must now supply a setup token; the `welcome` page no longer
+  serves credentials to anonymous callers.
+- **Tests:** feature specs that reproduce both C1 vectors (public `welcome` disclosure; unauthenticated
+  `save`) and assert the hardened behavior, per the security-fix testing requirement in AGENTS.md.

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/specs/default-admin-credential-safety/spec.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/specs/default-admin-credential-safety/spec.md
@@ -1,0 +1,65 @@
+## Purpose
+
+Governs the credential lifecycle of the administrator that Camaleon provisions automatically when a
+site is created, so that such an account never exists with a password an attacker could know or
+guess, and cannot be used to reach the admin panel until its password has been set by its operator.
+
+## ADDED Requirements
+
+### Requirement: Auto-provisioned administrators never receive a known password
+
+Whenever site provisioning creates an administrator automatically, that account SHALL be assigned a
+randomly generated, high-entropy password rather than a fixed or predictable default. This SHALL hold
+for every provisioning path, including the first-run installer and the creation of additional sites
+through the settings interface.
+
+#### Scenario: The installer provisions an admin with a random password
+- **WHEN** the first site is provisioned through the installer
+- **THEN** the created administrator's password is a randomly generated value, not a shared default
+
+#### Scenario: A settings-created site provisions an admin with a random password
+- **WHEN** an authenticated administrator creates an additional site through the settings interface and that path provisions a new administrator
+- **THEN** the created administrator's password is a randomly generated value, not a shared default
+
+### Requirement: The generated password is surfaced exactly once, to its provisioner
+
+Because the generated password is random, it SHALL be surfaced to the operator who provisioned the
+site so they can sign in — and SHALL be surfaced at most once, only to that operator, never to an
+unauthenticated third party.
+
+#### Scenario: The installer operator receives the generated password once
+- **WHEN** the installer completes and redirects the operator to the welcome page
+- **THEN** the generated password is displayed to that operator a single time
+
+#### Scenario: The settings creator receives the generated password once
+- **WHEN** an authenticated administrator creates an additional site that provisions a new administrator
+- **THEN** the generated password is surfaced once to that authenticated administrator
+
+#### Scenario: The displayed password can be copied with one action
+- **WHEN** the generated password is displayed to its provisioner
+- **THEN** a copy-to-clipboard control is offered alongside it so the value need not be selected by hand
+
+### Requirement: A newly provisioned administrator must change its password before using the admin panel
+
+An administrator provisioned with a generated password SHALL be marked as requiring a password
+change. While the marker is set, requests to the admin panel SHALL be redirected to the
+change-password screen; only that screen and signing out SHALL remain reachable. Completing the
+password change SHALL clear the marker and restore normal access. Accounts that predate this behavior
+and carry no marker SHALL NOT be forced to change their password.
+
+#### Scenario: A marked administrator is redirected to change its password
+- **WHEN** an administrator carrying the must-change marker requests any admin-panel action other than the change-password screen or sign-out
+- **THEN** the request is redirected to the change-password screen
+
+#### Scenario: The change-password screen and sign-out remain reachable while marked
+- **WHEN** a marked administrator requests the change-password screen or signs out
+- **THEN** the request is allowed to proceed
+
+#### Scenario: Changing the password restores access
+- **WHEN** a marked administrator completes a password change
+- **THEN** the marker is cleared
+- **AND** subsequent admin-panel requests are no longer redirected
+
+#### Scenario: Pre-existing administrators are not force-rotated
+- **WHEN** an administrator account that carries no must-change marker signs in
+- **THEN** it reaches the admin panel without being required to change its password

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/specs/installer-access-control/spec.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/specs/installer-access-control/spec.md
@@ -1,0 +1,60 @@
+## Purpose
+
+Controls who may run the first-run site installer and who may view the credentials it produces, so
+that provisioning a Camaleon install cannot be performed, or observed, by an unauthenticated party
+who merely reaches the application over the web.
+
+## ADDED Requirements
+
+### Requirement: Installer requires a setup token for remote requests on a fresh deploy
+
+While no site exists (a fresh deploy), the installer SHALL refuse to provision a site in response to a
+remote request unless that request supplies a valid setup token. The setup token SHALL be obtainable
+only from the server's environment or filesystem, never from the web surface, so that possession of it
+demonstrates operator-level access to the host. A request originating from the local host (loopback)
+is exempt, because local access already demonstrates that same operator-level access. The token SHALL
+be single-use for provisioning: once a site is successfully created, the token SHALL no longer be
+accepted.
+
+#### Scenario: A remote request without a valid token is refused
+- **WHEN** a remote request submits the installer's create action on a fresh deploy with no setup token, or an incorrect one
+- **THEN** no site is created
+- **AND** the response does not provision an administrator or disclose any credentials
+
+#### Scenario: A remote request with the valid token succeeds
+- **WHEN** a remote request submits the installer's create action on a fresh deploy with the correct setup token
+- **THEN** the site is provisioned
+
+#### Scenario: A local request may provision without a token
+- **WHEN** a request from the local host submits the installer's create action on a fresh deploy without a setup token
+- **THEN** the site is provisioned
+
+#### Scenario: The token cannot be replayed after setup completes
+- **WHEN** a site already exists and a request submits the installer's create action with the previously valid setup token
+- **THEN** the request is refused and no second provisioning occurs
+
+### Requirement: The installer is closed once a site exists
+
+Once at least one site exists, the installer's provisioning actions SHALL NOT be reachable, and SHALL
+redirect away rather than render.
+
+#### Scenario: Installer entry is closed after installation
+- **WHEN** any party requests the installer index or create action and at least one site already exists
+- **THEN** the request is redirected away without provisioning
+
+### Requirement: The welcome page is restricted to the operator who just completed setup
+
+The post-install welcome page — which discloses the newly provisioned administrator's credentials —
+SHALL be viewable only via a one-time indication established when that same session completed setup.
+It SHALL NOT be reachable by an anonymous visitor, and SHALL NOT remain reachable after a site
+exists. The one-time indication SHALL be cleared when the welcome page is shown, so the credentials
+are disclosed at most once.
+
+#### Scenario: Anonymous visitor cannot read the welcome page
+- **WHEN** a visitor requests the welcome page without having completed setup in the current session
+- **THEN** the page is not served and no credentials are disclosed
+
+#### Scenario: The operator sees the welcome page once
+- **WHEN** the operator who just completed setup is redirected to the welcome page
+- **THEN** the page is served and the generated credentials are shown
+- **AND** a subsequent request for the welcome page no longer discloses the credentials

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/tasks.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/tasks.md
@@ -1,0 +1,55 @@
+## 1. Branch and reproducing specs
+
+- [x] 1.1 Create a `security/harden-installer-default-admin` branch off `master`.
+- [x] 1.2 Add a feature spec reproducing the public disclosure: `GET /admin/installers/welcome` on an installed site must NOT render the admin credentials (fails against current code).
+- [x] 1.3 Add a feature spec reproducing the unauthenticated install: on a fresh deploy (`Site.count == 0`), the installer create action without a setup token must NOT provision a site (fails against current code).
+- [x] 1.4 Add a spec asserting an auto-provisioned admin is never created with the historical default password, on both the installer and settings paths.
+
+## 2. Default-admin credential minting
+
+- [x] 2.1 In `site_default_settings.rb` (~113-117), replace the fixed `admin123` with a high-entropy generated password (`SecureRandom`) for the auto-created administrator.
+- [x] 2.2 Set the "must change password" marker in the new admin's meta at creation time.
+- [x] 2.3 Expose the generated plaintext transiently on the `Site` instance (in-memory accessor, not persisted) for the caller to read after `save`.
+- [x] 2.4 Do NOT persist the generated password (log/file) — that reintroduces the disclosure class this change closes (design D2, revised). Recovery for a missed one-time display is a documented `rails console` reset, covered by the install guide (task 7.2).
+
+## 3. Setup-token gate (vector 2)
+
+- [x] 3.1 Add boot-time setup-token provisioning: when `Site.count == 0`, use `ENV['CAMALEON_SETUP_TOKEN']` if set, else generate and write `tmp/camaleon_setup_token` (0600) idempotently, logging its path once.
+- [x] 3.2 Add a `before_action` to `InstallersController` requiring a matching setup token on `save` for remote requests while no site exists; refuse provisioning otherwise. Loopback requests (`request.local?`) are exempt — local access already proves host access (design D8).
+- [x] 3.3 Consume the token: remove the generated file once a site exists so it cannot be replayed.
+- [x] 3.4 Add the setup-token field to the installer form view (client-side optional; server-enforced for remote only).
+
+## 4. Welcome-page gating, password display, copy control
+
+- [x] 4.1 In `InstallersController#save`, set a one-time in-session marker on success and redirect to the admin login path (not the frontend root).
+- [x] 4.2 Gate `welcome` on the one-time marker: render only when present, then clear it; redirect away otherwise. Remove the `except: :welcome` exemption's role as the only guard.
+- [x] 4.3 Update `installers/welcome.html.erb` to display the generated password from the marker instead of the hardcoded `admin123`.
+- [x] 4.4 Add a copy-to-clipboard control next to the displayed password (self-contained JS, no new dependency).
+
+## 5. Force-change gate
+
+- [x] 5.1 Add a `before_action` to `AdminController` that redirects a `cama_current_user` carrying the must-change marker to the change-password screen.
+- [x] 5.2 Exempt the change-password screen, its submit action (`users#updated_ajax`), and sign-out from the gate to avoid a redirect loop.
+- [x] 5.3 Clear the marker when the password change completes.
+- [x] 5.4 Verify a pre-existing admin with no marker is unaffected (no forced change).
+
+## 6. Settings-path surfacing
+
+- [x] 6.1 In `Admin::Settings::SitesController#create`, surface the generated password once to the authenticated creating administrator (flash) when that path provisions a new admin.
+- [x] 6.2 Render that surfaced password with the same copy-to-clipboard control.
+
+## 7. Views, locales, docs
+
+- [x] 7.1 Add locale strings for the setup-token field, the welcome password display and copy control, and the must-change screen messaging.
+- [x] 7.2 Write `docs/installation.md`: the updated install steps (the README sequence) plus the setup-token step and the first-login password change; make it the target the camaleon.website "updated installation steps" link should point at.
+- [x] 7.3 Write `docs/upgrading-to-2.9.3.md` following the `upgrading-to-2.9.2.md` structure: breaking-changes list (setup-token requirement for scripted installs), per-change sections, recommended rollout, and the explicit instruction to rotate an existing install's admin still using the default password.
+- [x] 7.4 Add a CHANGELOG "Unreleased" entry (lead paragraph + upgrader notes) linking both docs.
+
+## 8. Verification
+
+- [x] 8.1 Confirm the section-1 reproducing specs now pass, and add any missing coverage for the must-change gate exemptions and the setup-token lifecycle.
+- [x] 8.2 `bin/rubocop -A` on touched files (lint before specs).
+- [x] 8.3 `bin/rspec` green (1237 non-feature + 8 new security examples pass; feature specs pass individually — the lone `site_settings_custom_fields:22` failure is a pre-existing Capybara flake that fails identically on master).
+- [x] 8.4 `bin/brakeman --no-pager` clean.
+- [x] 8.5 `(cd spec/dummy && bin/rails zeitwerk:check)` passes.
+- [x] 8.6 Archive this change (`/opsx:archive`) on the branch before merge, as part of the PR.

--- a/openspec/changes/archive/2026-08-10-harden-installer-default-admin/tasks.md
+++ b/openspec/changes/archive/2026-08-10-harden-installer-default-admin/tasks.md
@@ -14,7 +14,7 @@
 
 ## 3. Setup-token gate (vector 2)
 
-- [x] 3.1 Add boot-time setup-token provisioning: when `Site.count == 0`, use `ENV['CAMALEON_SETUP_TOKEN']` if set, else generate and write `tmp/camaleon_setup_token` (0600) idempotently, logging its path once.
+- [x] 3.1 Add lazy setup-token provisioning: on first remote installer access while `Site.count == 0`, use `ENV['CAMALEON_SETUP_TOKEN']` if set, else generate and write `tmp/camaleon_setup_token` (0600) idempotently, logging its path once.
 - [x] 3.2 Add a `before_action` to `InstallersController` requiring a matching setup token on `save` for remote requests while no site exists; refuse provisioning otherwise. Loopback requests (`request.local?`) are exempt — local access already proves host access (design D8).
 - [x] 3.3 Consume the token: remove the generated file once a site exists so it cannot be replayed.
 - [x] 3.4 Add the setup-token field to the installer form view (client-side optional; server-enforced for remote only).

--- a/openspec/specs/default-admin-credential-safety/spec.md
+++ b/openspec/specs/default-admin-credential-safety/spec.md
@@ -1,0 +1,65 @@
+## Purpose
+
+Governs the credential lifecycle of the administrator that Camaleon provisions automatically when a
+site is created, so that such an account never exists with a password an attacker could know or
+guess, and cannot be used to reach the admin panel until its password has been set by its operator.
+
+## Requirements
+
+### Requirement: Auto-provisioned administrators never receive a known password
+
+Whenever site provisioning creates an administrator automatically, that account SHALL be assigned a
+randomly generated, high-entropy password rather than a fixed or predictable default. This SHALL hold
+for every provisioning path, including the first-run installer and the creation of additional sites
+through the settings interface.
+
+#### Scenario: The installer provisions an admin with a random password
+- **WHEN** the first site is provisioned through the installer
+- **THEN** the created administrator's password is a randomly generated value, not a shared default
+
+#### Scenario: A settings-created site provisions an admin with a random password
+- **WHEN** an authenticated administrator creates an additional site through the settings interface and that path provisions a new administrator
+- **THEN** the created administrator's password is a randomly generated value, not a shared default
+
+### Requirement: The generated password is surfaced exactly once, to its provisioner
+
+Because the generated password is random, it SHALL be surfaced to the operator who provisioned the
+site so they can sign in — and SHALL be surfaced at most once, only to that operator, never to an
+unauthenticated third party.
+
+#### Scenario: The installer operator receives the generated password once
+- **WHEN** the installer completes and redirects the operator to the welcome page
+- **THEN** the generated password is displayed to that operator a single time
+
+#### Scenario: The settings creator receives the generated password once
+- **WHEN** an authenticated administrator creates an additional site that provisions a new administrator
+- **THEN** the generated password is surfaced once to that authenticated administrator
+
+#### Scenario: The displayed password can be copied with one action
+- **WHEN** the generated password is displayed to its provisioner
+- **THEN** a copy-to-clipboard control is offered alongside it so the value need not be selected by hand
+
+### Requirement: A newly provisioned administrator must change its password before using the admin panel
+
+An administrator provisioned with a generated password SHALL be marked as requiring a password
+change. While the marker is set, requests to the admin panel SHALL be redirected to the
+change-password screen; only that screen and signing out SHALL remain reachable. Completing the
+password change SHALL clear the marker and restore normal access. Accounts that predate this behavior
+and carry no marker SHALL NOT be forced to change their password.
+
+#### Scenario: A marked administrator is redirected to change its password
+- **WHEN** an administrator carrying the must-change marker requests any admin-panel action other than the change-password screen or sign-out
+- **THEN** the request is redirected to the change-password screen
+
+#### Scenario: The change-password screen and sign-out remain reachable while marked
+- **WHEN** a marked administrator requests the change-password screen or signs out
+- **THEN** the request is allowed to proceed
+
+#### Scenario: Changing the password restores access
+- **WHEN** a marked administrator completes a password change
+- **THEN** the marker is cleared
+- **AND** subsequent admin-panel requests are no longer redirected
+
+#### Scenario: Pre-existing administrators are not force-rotated
+- **WHEN** an administrator account that carries no must-change marker signs in
+- **THEN** it reaches the admin panel without being required to change its password

--- a/openspec/specs/installer-access-control/spec.md
+++ b/openspec/specs/installer-access-control/spec.md
@@ -1,0 +1,60 @@
+## Purpose
+
+Controls who may run the first-run site installer and who may view the credentials it produces, so
+that provisioning a Camaleon install cannot be performed, or observed, by an unauthenticated party
+who merely reaches the application over the web.
+
+## Requirements
+
+### Requirement: Installer requires a setup token for remote requests on a fresh deploy
+
+While no site exists (a fresh deploy), the installer SHALL refuse to provision a site in response to a
+remote request unless that request supplies a valid setup token. The setup token SHALL be obtainable
+only from the server's environment or filesystem, never from the web surface, so that possession of it
+demonstrates operator-level access to the host. A request originating from the local host (loopback)
+is exempt, because local access already demonstrates that same operator-level access. The token SHALL
+be single-use for provisioning: once a site is successfully created, the token SHALL no longer be
+accepted.
+
+#### Scenario: A remote request without a valid token is refused
+- **WHEN** a remote request submits the installer's create action on a fresh deploy with no setup token, or an incorrect one
+- **THEN** no site is created
+- **AND** the response does not provision an administrator or disclose any credentials
+
+#### Scenario: A remote request with the valid token succeeds
+- **WHEN** a remote request submits the installer's create action on a fresh deploy with the correct setup token
+- **THEN** the site is provisioned
+
+#### Scenario: A local request may provision without a token
+- **WHEN** a request from the local host submits the installer's create action on a fresh deploy without a setup token
+- **THEN** the site is provisioned
+
+#### Scenario: The token cannot be replayed after setup completes
+- **WHEN** a site already exists and a request submits the installer's create action with the previously valid setup token
+- **THEN** the request is refused and no second provisioning occurs
+
+### Requirement: The installer is closed once a site exists
+
+Once at least one site exists, the installer's provisioning actions SHALL NOT be reachable, and SHALL
+redirect away rather than render.
+
+#### Scenario: Installer entry is closed after installation
+- **WHEN** any party requests the installer index or create action and at least one site already exists
+- **THEN** the request is redirected away without provisioning
+
+### Requirement: The welcome page is restricted to the operator who just completed setup
+
+The post-install welcome page — which discloses the newly provisioned administrator's credentials —
+SHALL be viewable only via a one-time indication established when that same session completed setup.
+It SHALL NOT be reachable by an anonymous visitor, and SHALL NOT remain reachable after a site
+exists. The one-time indication SHALL be cleared when the welcome page is shown, so the credentials
+are disclosed at most once.
+
+#### Scenario: Anonymous visitor cannot read the welcome page
+- **WHEN** a visitor requests the welcome page without having completed setup in the current session
+- **THEN** the page is not served and no credentials are disclosed
+
+#### Scenario: The operator sees the welcome page once
+- **WHEN** the operator who just completed setup is redirected to the welcome page
+- **THEN** the page is served and the generated credentials are shown
+- **AND** a subsequent request for the welcome page no longer discloses the credentials

--- a/spec/factories/site.rb
+++ b/spec/factories/site.rb
@@ -25,6 +25,15 @@ FactoryBot.define do
       CurrentRequest.site = site.decorate
       site_after_install(site, evaluator.theme)
       site.set_option('save_intro', true) if evaluator.skip_intro
+      # harden-installer-default-admin: production mints a random admin password and forces a change
+      # on first login. Reset the shared admin to the well-known credentials the suite signs in with
+      # (admin/admin123) and clear the must-change marker so existing specs are unaffected. Specs that
+      # exercise the new provisioning behavior create sites through the model directly, bypassing this.
+      admin = site.users.where(role: 'admin').first
+      if admin
+        admin.update(password: 'admin123', password_confirmation: 'admin123')
+        admin.delete_meta('must_change_password')
+      end
     ensure
       CurrentRequest.site = previous_site
     end

--- a/spec/lib/camaleon_cms/setup_token_spec.rb
+++ b/spec/lib/camaleon_cms/setup_token_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# File-based token semantics for the installer gate: created with 0600 permissions from the first
+# byte, adopted (not clobbered) when losing a creation race, and removed once setup completes.
+# See openspec/specs/installer-access-control/spec.md.
+RSpec.describe CamaleonCms::SetupToken do
+  around do |example|
+    previous = ENV.delete('CAMALEON_SETUP_TOKEN')
+    FileUtils.rm_f(described_class.file_path)
+    example.run
+  ensure
+    ENV['CAMALEON_SETUP_TOKEN'] = previous if previous
+    FileUtils.rm_f(described_class.file_path)
+  end
+
+  it 'creates the token file with 0600 permissions from the first byte' do
+    token = described_class.value
+
+    expect(token).to match(/\A\h{64}\z/)
+    expect(File.stat(described_class.file_path).mode & 0o777).to eq(0o600)
+    expect(File.read(described_class.file_path)).to eq(token)
+  end
+
+  it 'adopts the already-written token when it loses the creation race' do
+    File.write(described_class.file_path, 'winner-token')
+    # Simulate the race: the exist? check misses the file another request is writing concurrently,
+    # so the EXCL open raises EEXIST and the loser must converge on the winner's token.
+    allow(File).to receive(:exist?).and_call_original
+    allow(File).to receive(:exist?).with(described_class.file_path).and_return(false, true)
+
+    expect(described_class.value).to eq('winner-token')
+    expect(File.read(described_class.file_path)).to eq('winner-token')
+  end
+
+  it 'removes the generated file on clear! so the token cannot be replayed' do
+    described_class.value
+    described_class.clear!
+
+    expect(File.exist?(described_class.file_path)).to be(false)
+  end
+end

--- a/spec/requests/security/additional_site_admin_password_spec.rb
+++ b/spec/requests/security/additional_site_admin_password_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# When creating an additional site provisions a fresh administrator (users not shared across
+# sites), the generated password must be surfaced exactly once to the authenticated creator —
+# and never invented when no admin was minted. The shipped test config shares users across
+# sites, so the minting branch is reachable only with users_share_sites stubbed off.
+# See openspec/specs/default-admin-credential-safety/spec.md.
+RSpec.describe 'Additional-site admin password surfacing', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    sign_in_as(admin, site: current_site)
+  end
+
+  context 'when users are not shared across sites (the new site mints its own admin)' do
+    before do
+      allow(PluginRoutes).to receive(:system_info)
+        .and_return(PluginRoutes.system_info.merge('users_share_sites' => false))
+    end
+
+    it 'surfaces the generated password once to the creating administrator, with a copy control' do
+      post cama_admin_settings_sites_path, params: { site: { name: 'Second Site', slug: 'second-site' } }
+
+      expect(response).to have_http_status(:redirect)
+      notice = flash[:notice]
+      password = notice.to_s[/New administrator password: ([A-Za-z0-9]{16})/, 1]
+      expect(password).to be_present
+      expect(notice).to be_html_safe
+      expect(notice).to include('navigator.clipboard')
+
+      new_site = CamaleonCms::Site.find_by!(slug: 'second-site')
+      minted = CamaleonCms::User.where(site_id: new_site.id, role: 'admin').first
+      expect(minted).to be_present
+      expect(minted.authenticate(password)).to be_truthy
+      expect(minted.get_meta('must_change_password')).to be_present
+    end
+  end
+
+  context 'when users are shared across sites (no admin is minted)' do
+    it 'shows the plain confirmation without any password' do
+      post cama_admin_settings_sites_path, params: { site: { name: 'Third Site', slug: 'third-site' } }
+
+      expect(response).to have_http_status(:redirect)
+      expect(flash[:notice]).to eq(I18n.t('camaleon_cms.admin.sites.message.created'))
+      expect(flash[:notice].to_s).not_to match(/password/i)
+    end
+  end
+end

--- a/spec/requests/security/force_password_change_spec.rb
+++ b/spec/requests/security/force_password_change_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# A newly provisioned administrator is minted with a random password and a must-change marker
+# (see harden-installer-default-admin). The admin panel must funnel such an account to the
+# change-password screen until it sets its own password.
+RSpec.describe 'Forced password change for a newly provisioned admin', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { current_site.users.where(role: 'admin').first }
+
+  def marker_for(user)
+    CamaleonCms::User.find(user.id).get_meta('must_change_password')
+  end
+
+  context 'when the admin still owes a password change' do
+    before do
+      admin.set_meta('must_change_password', true)
+      sign_in_as(admin, site: current_site)
+    end
+
+    it 'redirects other admin-panel requests to the change-password screen' do
+      get cama_admin_dashboard_path
+      expect(response).to redirect_to(cama_admin_profile_edit_path)
+    end
+
+    it 'lets the change-password screen through' do
+      get cama_admin_profile_edit_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'clears the marker and restores access once the password is changed' do
+      patch cama_admin_user_updated_ajax_path(user_id: admin.id),
+            params: { password: { password: 'NewStrongPass9', password_confirmation: 'NewStrongPass9' } }
+
+      expect(marker_for(admin)).to be_blank
+
+      get cama_admin_dashboard_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  context 'when a pre-existing admin carries no marker' do
+    before { sign_in_as(admin, site: current_site) }
+
+    it 'reaches the admin panel without being forced to change anything' do
+      get cama_admin_dashboard_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/security/installer_default_admin_hardening_spec.rb
+++ b/spec/requests/security/installer_default_admin_hardening_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Reproduces audit finding C1: the installer publishes a known default admin
+# password on a permanently public page, and the installer itself is
+# unauthenticated on a fresh deploy. See
+# openspec/changes/harden-installer-default-admin.
+RSpec.describe 'Installer and default-admin hardening', type: :request do
+  describe 'GET /admin/installers/welcome on an already-installed site' do
+    init_site # a site already exists
+
+    it 'does not disclose the default admin credentials to a visitor who did not just install' do
+      get welcome_cama_admin_installers_path
+
+      expect(response.body).not_to include('admin123')
+    end
+  end
+
+  describe 'POST /admin/installers/save on a fresh deploy' do
+    # Site.count == 0 and no shared admin (users are global when users_share_sites is true).
+    before { [CamaleonCms::Site, CamaleonCms::User].each(&:delete_all) }
+
+    context 'when the request is remote' do
+      before { allow_any_instance_of(ActionDispatch::Request).to receive(:local?).and_return(false) }
+
+      it 'refuses to provision a site without a setup token' do
+        expect do
+          post save_cama_admin_installers_path, params: { site: { name: 'Attacker Site', slug: 'attacker' } }
+        end.not_to change(CamaleonCms::Site, :count).from(0)
+      end
+    end
+
+    context 'when the request is local (loopback)' do
+      it 'provisions without a setup token, since local access already proves host access' do
+        expect do
+          post save_cama_admin_installers_path, params: { site: { name: 'Local Install', slug: 'local' } }
+        end.to change(CamaleonCms::Site, :count).by(1)
+      end
+    end
+  end
+
+  describe 'the auto-provisioned administrator' do
+    before { [CamaleonCms::Site, CamaleonCms::User].each(&:delete_all) }
+
+    it 'is not created with the historical default password, and must change it' do
+      CamaleonCms::Site.create!(name: 'Repro', slug: 'repro-site')
+      admin = CamaleonCms::User.where(role: 'admin').last
+
+      expect(admin).to be_present
+      expect(admin.authenticate('admin123')).to be_falsey
+      expect(admin.get_meta('must_change_password')).to be_present
+    end
+  end
+
+  describe 'installing from a remote request with a valid setup token' do
+    around do |example|
+      ENV['CAMALEON_SETUP_TOKEN'] = 'valid-setup-token'
+      [CamaleonCms::Site, CamaleonCms::User].each(&:delete_all)
+      example.run
+    ensure
+      ENV.delete('CAMALEON_SETUP_TOKEN')
+    end
+
+    before { allow_any_instance_of(ActionDispatch::Request).to receive(:local?).and_return(false) }
+
+    it 'provisions the site and shows the generated password once to the installing operator' do
+      expect do
+        post save_cama_admin_installers_path,
+             params: { site: { name: 'Legit', slug: 'legit' }, setup_token: 'valid-setup-token' }
+      end.to change(CamaleonCms::Site, :count).by(1)
+
+      follow_redirect! # the welcome page, in the same session that just installed
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('cama_generated_password')
+
+      # the one-time marker is consumed: a second visit no longer discloses anything
+      get welcome_cama_admin_installers_path
+      expect(response).to redirect_to(cama_admin_login_url)
+    end
+  end
+end

--- a/spec/requests/security/installer_default_admin_hardening_spec.rb
+++ b/spec/requests/security/installer_default_admin_hardening_spec.rb
@@ -5,7 +5,8 @@ require 'rails_helper'
 # Reproduces audit finding C1: the installer publishes a known default admin
 # password on a permanently public page, and the installer itself is
 # unauthenticated on a fresh deploy. See
-# openspec/changes/harden-installer-default-admin.
+# openspec/specs/installer-access-control/spec.md and
+# openspec/specs/default-admin-credential-safety/spec.md.
 RSpec.describe 'Installer and default-admin hardening', type: :request do
   describe 'GET /admin/installers/welcome on an already-installed site' do
     init_site # a site already exists

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,12 @@ end
 # Capybara.javascript_driver = :selenium_chrome125
 Capybara.javascript_driver = :selenium_chrome_headless125
 
+# Selenium's native `element.clear` does not reliably empty a pre-filled input on macOS headless
+# Chrome, so `fill_in` types onto the existing value instead of replacing it (e.g. a site name saves
+# as "Old NameNew Name"). Clearing via backspace is reliable on both macOS and the Linux CI. See PR
+# #1246.
+Capybara.default_set_options = { clear: :backspace }
+
 # Next 2 are FireFox drivers
 # Capybara.javascript_driver = :selenium
 # Capybara.javascript_driver = :selenium_headless


### PR DESCRIPTION
## What and Why

The installer shipped a hardcoded default administrator (`admin`/`admin123`) and printed those
credentials on a `welcome` page that stayed publicly reachable forever — an unauthenticated path to
full administrative control. The installer's create action was also unauthenticated on a fresh
deploy, so whoever reached a new deployment first could provision it and own the resulting admin
(audit finding C1).

This change:

- Mints the auto-provisioned administrator with a random password, surfaced once (with a copy
  control) on the confirmation page, which is now reachable only by the operator who just completed
  setup — not by anonymous visitors.
- Requires that administrator to change its password before using the admin panel.
- Gates the installer with a setup token for remote requests on a fresh deploy, read from
  `CAMALEON_SETUP_TOKEN` or a generated `tmp/camaleon_setup_token` file. Loopback installs are
  exempt, since local access already demonstrates host access.

Also included: a `selenium-webdriver` bump for Chrome 151 support (test infrastructure).

## User-Visible Impact

New installs receive a random administrator password shown once on the installer confirmation page
and must change it on first sign-in; scripted remote installs must now supply `CAMALEON_SETUP_TOKEN`.

## Upgrade notes

Existing installs are not rewritten — an administrator still using the historical default password
should be rotated. See `docs/upgrading-to-2.9.3.md` and `docs/installation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
