### PR TITLE
Fix administrator password reset token shadowing (Rails 6.1-8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - **Fix:** Administrator password reset is working again. On Rails 7.1+ `has_secure_password` generates
   a `password_reset_token` method that shadowed Camaleon's same-named column, so the emailed reset link
   never matched the account lookup and every reset dead-ended on "URL incorrect". Reset links now
-  resolve, expire, are single-use, confined to the account's own site, and reject a blank password.
+  resolve, expire, are single-use, confined to the account's own site, and reject a blank or
+  malformed password.
   [#1248](https://github.com/owen2345/camaleon-cms/pull/1248).
   - **Notes for upgraders:** any password-reset links already outstanding at upgrade time are
     invalidated and must be re-requested (they were non-functional in practice). No schema change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- **Fix:** Administrator password reset is working again. On Rails 7.1+ `has_secure_password` generates
+  a `password_reset_token` method that shadowed Camaleon's same-named column, so the emailed reset link
+  never matched the account lookup and every reset dead-ended on "URL incorrect". Reset links now
+  resolve, expire, are single-use, confined to the account's own site, and reject a blank password.
+  [#1248](https://github.com/owen2345/camaleon-cms/pull/1248).
+  - **Notes for upgraders:** any password-reset links already outstanding at upgrade time are
+    invalidated and must be re-requested (they were non-functional in practice). No schema change.
+
 - **Security fix:** The installer no longer publishes a default administrator password and can no
   longer be run by an anonymous visitor on a fresh deploy (audit finding C1). New sites mint the
   `admin` account with a random password shown once on the installer confirmation page — now reachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
   a `password_reset_token` method that shadowed Camaleon's same-named column, so the emailed reset link
   never matched the account lookup and every reset dead-ended on "URL incorrect". Reset links now
   resolve, expire, are single-use, confined to the account's own site, and reject a blank or
-  malformed password.
+  malformed password. The session endpoints (login, registration, password reset) also no longer
+  raise a 500 on a malformed `user` parameter.
   [#1248](https://github.com/owen2345/camaleon-cms/pull/1248).
   - **Notes for upgraders:** any password-reset links already outstanding at upgrade time are
     invalidated and must be re-requested (they were non-functional in practice). No schema change.

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -86,7 +86,8 @@ module CamaleonCms
             # Blank-check the *permitted* password: permit drops a non-scalar value (e.g.
             # `user[password][]=x`), and has_secure_password only validates presence on create —
             # either way `update` would be a silent no-op reported as success, consuming the token.
-            reset_params = params[:user].permit(:password, :password_confirmation)
+            # A scalar `user` param (`?user=foo`) has no .permit: treat it as an empty submission.
+            reset_params = params[:user].try(:permit, :password, :password_confirmation) || {}
             if reset_params[:password].blank?
               flash[:error] = t('camaleon_cms.admin.login.message.reset_password_error')
             elsif @user.update(reset_params)

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -124,7 +124,8 @@ module CamaleonCms
 
       def register
         @user ||= current_site.users.new
-        if params[:user].present?
+        # A scalar `user` param has no .permit — only a form-shaped submission enters this branch.
+        if params[:user].respond_to?(:permit)
           params[:user][:role] = PluginRoutes.system_info['default_user_role']
           params[:user][:is_valid_email] = false if current_site.need_validate_email?
           user_data = user_permit_data
@@ -201,8 +202,12 @@ module CamaleonCms
       end
 
       def user_permit_data
-        params.require(:user)
-              .permit(:first_name, :last_name, :email, :username, :password, :password_confirmation, :is_valid_email)
+        user_params = params.require(:user)
+        # A scalar `user` param (`?user=foo`) has no .permit: treat it as an empty submission.
+        return {} unless user_params.respond_to?(:permit)
+
+        user_params.permit(:first_name, :last_name, :email, :username, :password, :password_confirmation,
+                           :is_valid_email)
       end
     end
   end

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -83,11 +83,13 @@ module CamaleonCms
           end
 
           if params[:user].present?
-            if params[:user][:password].blank?
-              # has_secure_password only validates presence on create, so a blank password on this
-              # update path is a silent no-op that would otherwise report success.
+            # Blank-check the *permitted* password: permit drops a non-scalar value (e.g.
+            # `user[password][]=x`), and has_secure_password only validates presence on create —
+            # either way `update` would be a silent no-op reported as success, consuming the token.
+            reset_params = params[:user].permit(:password, :password_confirmation)
+            if reset_params[:password].blank?
               flash[:error] = t('camaleon_cms.admin.login.message.reset_password_error')
-            elsif @user.update(params[:user].permit(:password, :password_confirmation))
+            elsif @user.update(reset_params)
               # Single-use: clear the token so the same link cannot be replayed.
               @user.update_columns(password_reset_token: nil, password_reset_sent_at: nil) # rubocop:disable Rails/SkipsModelValidations
               flash[:notice] = t('camaleon_cms.admin.login.message.reset_password_succes')

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -67,30 +67,37 @@ module CamaleonCms
       def forgot
         @user = current_site.users.new
         # get form reset password
-        if params[:h]
+        if params[:h].present?
+          # Look up by the DB column (a `where` clause is never shadowed by the Rails 7.1+
+          # has_secure_password method), scoped to the current site so a token cannot be redeemed
+          # against a site that does not own the account.
           @user = current_site.users.where(password_reset_token: params[:h]).first
           if @user.nil?
             flash[:error] = t('camaleon_cms.admin.login.message.forgot_url_incorrect')
-            redirect_to cama_admin_forgot_path
-            return
-          elsif @user.password_reset_sent_at < 2.hours.ago
-            flash[:error] = t('camaleon_cms.admin.login.message.forgot_expired')
-            redirect_to cama_admin_login_path
-          else
-            # saved new password
-            if params[:user].present?
-              if @user.update(params[:user].permit(:password, :password_confirmation))
-                flash[:notice] = t('camaleon_cms.admin.login.message.reset_password_succes')
-                redirect_to cama_admin_login_path
-                return
-              else
-                flash[:error] = t('camaleon_cms.admin.login.message.reset_password_error')
-              end
-            end
-            @form_reset = true
-            render 'forgot'
-            return
+            return redirect_to cama_admin_forgot_path
           end
+          # nil timestamp (or one past the window) is expired, not a NoMethodError.
+          if @user.password_reset_sent_at.blank? || @user.password_reset_sent_at < 2.hours.ago
+            flash[:error] = t('camaleon_cms.admin.login.message.forgot_expired')
+            return redirect_to cama_admin_login_path
+          end
+
+          if params[:user].present?
+            if params[:user][:password].blank?
+              # has_secure_password only validates presence on create, so a blank password on this
+              # update path is a silent no-op that would otherwise report success.
+              flash[:error] = t('camaleon_cms.admin.login.message.reset_password_error')
+            elsif @user.update(params[:user].permit(:password, :password_confirmation))
+              # Single-use: clear the token so the same link cannot be replayed.
+              @user.update_columns(password_reset_token: nil, password_reset_sent_at: nil) # rubocop:disable Rails/SkipsModelValidations
+              flash[:notice] = t('camaleon_cms.admin.login.message.reset_password_succes')
+              return redirect_to cama_admin_login_path
+            else
+              flash[:error] = t('camaleon_cms.admin.login.message.reset_password_error')
+            end
+          end
+          @form_reset = true
+          return render 'forgot'
         end
 
         # TODO: Move this out of the controller

--- a/app/helpers/camaleon_cms/email_helper.rb
+++ b/app/helpers/camaleon_cms/email_helper.rb
@@ -43,7 +43,10 @@ module CamaleonCms
 
     def send_password_reset_email(user_to_send)
       user_to_send.send_password_reset
-      reset_url = cama_admin_forgot_url({ h: user_to_send.password_reset_token })
+      # Read the column, not the same-named method has_secure_password generates on Rails 7.1+ (which
+      # shadows it with a signed token the controller's column lookup never matches). read_attribute
+      # returns the stored column on every supported Rails version (6.1–8.1).
+      reset_url = cama_admin_forgot_url({ h: user_to_send.read_attribute(:password_reset_token) })
       extra_data = {
         url: reset_url,
         fullname: user_to_send.fullname,

--- a/docs/upgrading-to-2.9.3.md
+++ b/docs/upgrading-to-2.9.3.md
@@ -53,8 +53,22 @@ u.update(password: "your-new-password", password_confirmation: "your-new-passwor
 The disclosure itself (the credentials showing on the installer's confirmation page) is closed for all
 installs by this release, regardless of whether you rotate.
 
+## Administrator password reset restored
+
+On Rails 7.1+, `has_secure_password` generates a `password_reset_token` method that shadowed
+Camaleon's same-named database column: the mailer emailed one value while the reset lookup matched
+the other, so every emailed reset link dead-ended on "URL incorrect" even though the user was told
+the email was sent. This release aligns both sides on the stored column (which behaves identically on
+Rails 6.1–8.1), and makes reset links single-use, time-bounded, and confined to the account's own
+site.
+
+- **Any reset links already outstanding at upgrade time are invalidated** and must be re-requested —
+  they were non-functional in practice anyway.
+- No schema change; no action beyond re-requesting a reset if one was in flight.
+
 ## Recommended rollout
 
 1. Upgrade to `2.9.3`.
 2. For scripted installs, set `CAMALEON_SETUP_TOKEN` before running the installer.
 3. On existing installs, rotate any administrator still using the historical default password.
+4. Re-request any administrator password-reset link that was outstanding at upgrade time.

--- a/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-10

--- a/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/design.md
+++ b/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/design.md
@@ -1,0 +1,89 @@
+## Context
+
+See proposal.md — Why. The mechanics that shape the fix:
+
+- `CamaleonCms::User` uses `has_secure_password`. On **Rails 7.1+** that generates a
+  `password_reset_token` instance method (source: `activemodel/secure_password.rb`) which shadows the
+  model's same-named database column. Verified on Rails 8.1: `user.password_reset_token` returns a
+  signed, 15-minute token while `user.read_attribute(:password_reset_token)` returns the column. On
+  **Rails ≤ 7.0 the method does not exist**, so the same read returns the column and the flow works.
+- `email_helper.rb` builds the reset URL from `user_to_send.password_reset_token` — i.e. the shadowing
+  method's signed token on 7.1+.
+- `sessions_controller.rb#forgot` (line 71) resolves the account with
+  `current_site.users.where(password_reset_token: params[:h]).first` — a SQL query on the column
+  (`where` is never shadowed). On 7.1+ the email token and the lookup key are two different values, so
+  the lookup always misses.
+- The action also checks `password_reset_sent_at < 2.hours.ago` (which raises when the column is nil),
+  never clears the token after a successful reset (replayable), and `ActiveModel`'s `password=` is a
+  no-op for `""` so a blank submission "succeeds" without changing anything.
+
+**Version constraint (updated 2026-08-10): the engine supports Rails 6.1 → 8.1.** The framework
+generated-token finder (`find_by_password_reset_token`, `generates_token_for`) exists only on 7.1+, so
+it cannot be the fix. The fix must use the DB column explicitly on both sides — which behaves
+identically on every supported version.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A legitimate emailed reset link resolves to its account and lets the user set a new password.
+- Reset links are single-use, time-bounded, and confined to the account's own site.
+
+**Non-Goals:**
+- Dropping the legacy `password_reset_token` / `password_reset_sent_at` columns (a migration); they are
+  left vestigial.
+- Reworking the forgot/reset views or the email delivery mechanism beyond the token value.
+
+## Decisions
+
+### D1 — Align both sides on the DB column, read explicitly to dodge the shadow (Rails 6.1–8.1)
+Emit and look up the **column** value on both sides. The controller's `where(password_reset_token:
+params[:h])` already queries the column correctly (a `where` clause is never shadowed); the only wrong
+side is the mailer, which reads the shadowing method. Change the mailer to read the column via
+`read_attribute(:password_reset_token)`, so on 7.1+ it emits the stored column token (matching the
+lookup) and on ≤ 7.0 it reads the same column as before — one behavior across all supported versions.
+- *Why:* this is the only approach that works on Rails 6.1 → 8.1. The framework generated-token finder
+  (`find_by_password_reset_token`) — the originally-planned fix — does not exist before 7.1, so it
+  would break the older half of the support range.
+- *Consequence:* expiry and single-use are not free (the generated token gave them); they are provided
+  explicitly (D3, D4), which also works on every version.
+- *Alternative (rejected):* the 7.1+ generated-token finder — cleaner and self-expiring, but 7.1+ only.
+
+### D2 — Preserve site scoping
+Keep the lookup scoped to `current_site.users`, so a token cannot be redeemed against a site that does
+not own the account.
+- *Why:* under `users_share_sites: false` a token must not be redeemable against a foreign site. The
+  column lookup is already an association query on `current_site.users`, so the boundary is intrinsic.
+
+### D3 — Reject blank-password resets
+Guard the update so an empty password does not report success. `has_secure_password` only validates
+password presence on create, so on the reset (update) path a blank `password=` is a silent no-op that
+`update` reports as success. Treat "no new password provided" as a failure and re-render the form.
+
+### D4 — Single-use and a nil-safe expiry window
+- **Single-use:** after a successful reset, clear the column token (`password_reset_token` /
+  `password_reset_sent_at`) so the same link cannot be replayed. The generated-token scheme gave this
+  for free; the column scheme must clear it.
+- **Expiry:** keep the existing 2-hour `password_reset_sent_at` window (version-agnostic), but treat a
+  nil timestamp as expired instead of raising `NoMethodError` on `nil < 2.hours.ago`.
+
+### D5 — Refuse a blank token
+Only treat a **present** `params[:h]` as a reset-link submission, so an empty token is refused rather
+than turned into a `where(password_reset_token: '')` probe.
+
+## Risks / Trade-offs
+
+- **Reset links outstanding at upgrade time stop working** → on 7.1+ they were already non-functional
+  (the lookup never matched); the CHANGELOG tells users to re-request. No silent regression.
+- **Expiry stays the 2-hour column window** rather than the generated token's 15 minutes → keeps the
+  documented behavior and avoids a version-specific mechanism; the window is unchanged, only its
+  nil-crash is fixed.
+- **The legacy columns remain in use** (not vestigial as first proposed) → the column scheme is the
+  cross-version mechanism, so the columns stay load-bearing; dropping them is out of scope.
+- **Coordination with the concurrent 2.9.3 docs** → this change adds its own CHANGELOG bullet; if
+  `docs/upgrading-to-2.9.3.md` already exists at apply time, append a short note rather than recreating
+  it.
+
+## Migration Plan
+
+- **Deploy:** no schema change; users with a pending (non-working) reset link re-request one.
+- **Rollback:** revert; the legacy columns are untouched, so there is no schema residue.

--- a/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/proposal.md
+++ b/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Administrator password reset is silently broken on current installs. On Rails 7.1+,
+`has_secure_password` generates a `password_reset_token` **method** that shadows Camaleon's same-named
+database column: the mailer emails the method's signed token, while `SessionsController#forgot` looks
+the account up by the column (`where(password_reset_token: params[:h])`). The two never match, so every
+emailed reset link dead-ends on "URL incorrect" while the user is told the email was sent. The engine
+runs Rails 8.1, so this affects every current install. Separately, the reset token is never consumed,
+so a link that *did* work would remain replayable for its whole window.
+
+## What Changes
+
+- **The mailer emits the token the lookup actually uses** — the DB column, read explicitly via
+  `read_attribute` so it dodges the Rails 7.1+ shadowing method — so a legitimate reset link resolves
+  to its account. (The engine supports Rails 6.1 → 8.1; the framework generated-token finder is 7.1+
+  only, so the cross-version fix is column-based on both sides. See design.md D1.)
+- **The lookup stays scoped to the current site** (`current_site.users`), so a token cannot be redeemed
+  against an unrelated site.
+- **Reset links become single-use and time-bounded**: the column token is cleared after a successful
+  reset (so a used link cannot be replayed), and the 2-hour `password_reset_sent_at` window is kept but
+  no longer crashes on a nil timestamp.
+- **A blank password submitted through the reset form no longer reports success without changing
+  anything.**
+- The `password_reset_token` / `password_reset_sent_at` columns remain load-bearing (they are the
+  cross-version mechanism); no schema change.
+- **Docs:** a CHANGELOG entry noting that recovery is restored and that any reset links already
+  outstanding at upgrade time are invalidated and must be re-requested.
+
+## Capabilities
+
+### New Capabilities
+- `password-reset-token-validation`: emailed password-reset links resolve to the correct account,
+  expire, and are single-use, so administrator account recovery is reliable and safe.
+
+### Modified Capabilities
+<!-- None. No existing capability specifies the password-reset flow; it is introduced fresh here. -->
+
+## Impact
+
+- **Controllers:** `admin/sessions_controller.rb#forgot` — refuse a blank token, keep the
+  current-site-scoped column lookup, make the `password_reset_sent_at` window nil-safe, clear the token
+  after a successful reset (single-use), and reject a blank-password reset.
+- **Helpers/mailers:** `helpers/camaleon_cms/email_helper.rb` — emit `read_attribute(:password_reset_token)`
+  (the column) so the link carries the value the lookup matches on Rails 7.1+.
+- **Model:** `CamaleonCms::User` — no change; the column scheme is the cross-version mechanism.
+- **Compatibility:** Rails 6.1 → 8.1. Reset links issued before the upgrade stop working and must be
+  re-requested; the columns remain load-bearing.
+- **Docs:** CHANGELOG entry (and, if the 2.9.3 migration guide exists at apply time, a short note there).
+- **Tests:** a spec reproducing the broken lookup (an emailed link's token does not resolve today),
+  plus expiry, single-use, and foreign-site coverage.

--- a/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/specs/password-reset-token-validation/spec.md
+++ b/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/specs/password-reset-token-validation/spec.md
@@ -1,0 +1,57 @@
+## Purpose
+
+Ensures the administrator password-reset link a user receives by email actually identifies their
+account, expires after a bounded window, and cannot be replayed once used — so account recovery is
+reliable and safe.
+
+## ADDED Requirements
+
+### Requirement: An emailed reset link resolves to its account
+
+A password-reset link SHALL be validated against the same token value that was emailed to the user,
+so that following a legitimate link presents that user's password-reset form. A reset request that
+carries no token, or a token that does not correspond to any account, SHALL be refused without
+resetting any password.
+
+#### Scenario: A legitimate reset link is accepted
+- **WHEN** a user follows the reset link delivered to their email within its validity window
+- **THEN** the password-reset form is presented for that user's account
+
+#### Scenario: An unrecognized token is refused
+- **WHEN** a reset request supplies a token that matches no account
+- **THEN** the request is refused and no password is changed
+
+### Requirement: Reset links expire
+
+A reset link SHALL stop being accepted after a bounded expiry window from when it was issued.
+
+#### Scenario: An expired link is refused
+- **WHEN** a user follows a reset link after its expiry window has passed
+- **THEN** the request is refused and no password is changed
+
+### Requirement: Reset links are single-use
+
+Once a reset link has been used to successfully change a password, the same link SHALL NOT be usable
+to change the password again.
+
+#### Scenario: A used link cannot be replayed
+- **WHEN** a reset link is used to change a password successfully, and the same link is then submitted again
+- **THEN** the second attempt does not change the password
+
+### Requirement: A blank password is not accepted as a successful reset
+
+Submitting the reset form without a new password SHALL NOT report success or leave the existing
+password in place under the guise of a completed reset.
+
+#### Scenario: Blank password is rejected
+- **WHEN** a user submits the reset form with an empty password
+- **THEN** the reset is not reported as successful and the existing password is unchanged
+
+### Requirement: Reset links are honored only for the account's own site
+
+In a multi-site install, a reset link SHALL be honored only in the context of the site the account
+belongs to, so a token cannot be redeemed against an unrelated site.
+
+#### Scenario: A token is not honored on a foreign site
+- **WHEN** a reset link for an account on one site is submitted in the context of a different site that does not own the account
+- **THEN** the request is refused and no password is changed

--- a/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/tasks.md
+++ b/openspec/changes/archive/2026-08-11-fix-password-reset-token-shadowing/tasks.md
@@ -1,0 +1,39 @@
+## 1. Branch and reproducing spec
+
+- [x] 1.1 Create a `fix/password-reset-token-shadowing` branch off `master`.
+- [x] 1.2 Add a request spec (`spec/requests/security/password_reset_token_spec.rb`) reproducing the
+      break: it captures the token the mailer actually emits, follows the link, and asserts it
+      currently fails to resolve the account (red) and resolves after the fix.
+
+## 2. Fix the reset lookup (Rails 6.1–8.1 — column-based, not the 7.1+ finder)
+
+- [x] 2.1 In `email_helper.rb#send_password_reset_email`, emit `read_attribute(:password_reset_token)`
+      (the DB column) so the emitted link carries the value the controller's column lookup matches —
+      dodging the Rails 7.1+ shadowing method on every supported version. (The originally-planned
+      generated-token finder is 7.1+ only; see design.md D1.)
+- [x] 2.2 Keep the current-site-scoped column lookup in `sessions_controller.rb#forgot`
+      (`current_site.users.where(password_reset_token: params[:h])`), which is the intrinsic site
+      boundary; refuse a blank token.
+- [x] 2.3 Make the `password_reset_sent_at` expiry window nil-safe (a nil timestamp is expired, not a
+      `NoMethodError`); keep the 2-hour window (version-agnostic, no generated-token expiry).
+
+## 3. Single-use and blank-password guards
+
+- [x] 3.1 Clear the column token after a successful reset so the link cannot be replayed.
+- [x] 3.2 Reject a blank-password submission so it does not report success with the password unchanged.
+
+## 4. Docs
+
+- [x] 4.1 CHANGELOG "Unreleased" entry: recovery restored; outstanding reset links invalidated.
+- [x] 4.2 `docs/upgrading-to-2.9.3.md` already existed (installer change) — appended a short
+      password-reset section and a rollout bullet rather than recreating it.
+
+## 5. Verification
+
+- [x] 5.1 Reproducing spec passes; coverage added for expiry, single-use replay, blank password, and
+      the foreign-site scenario (the last under `users_share_sites: false`, the boundary's precondition).
+- [x] 5.2 `bin/rubocop` clean on touched files.
+- [x] 5.3 `bin/rspec` green (spec + the broader sessions suite).
+- [x] 5.4 `bin/brakeman --no-pager` clean.
+- [x] 5.5 `(cd spec/dummy && bin/rails zeitwerk:check)` passes.
+- [x] 5.6 Archive this change on the branch before merge, as part of the PR.

--- a/openspec/specs/password-reset-token-validation/spec.md
+++ b/openspec/specs/password-reset-token-validation/spec.md
@@ -1,0 +1,57 @@
+# password-reset-token-validation Specification
+
+## Purpose
+Ensures the administrator password-reset link a user receives by email actually identifies their
+account, expires after a bounded window, and cannot be replayed once used — so account recovery is
+reliable and safe.
+## Requirements
+### Requirement: An emailed reset link resolves to its account
+
+A password-reset link SHALL be validated against the same token value that was emailed to the user,
+so that following a legitimate link presents that user's password-reset form. A reset request that
+carries no token, or a token that does not correspond to any account, SHALL be refused without
+resetting any password.
+
+#### Scenario: A legitimate reset link is accepted
+- **WHEN** a user follows the reset link delivered to their email within its validity window
+- **THEN** the password-reset form is presented for that user's account
+
+#### Scenario: An unrecognized token is refused
+- **WHEN** a reset request supplies a token that matches no account
+- **THEN** the request is refused and no password is changed
+
+### Requirement: Reset links expire
+
+A reset link SHALL stop being accepted after a bounded expiry window from when it was issued.
+
+#### Scenario: An expired link is refused
+- **WHEN** a user follows a reset link after its expiry window has passed
+- **THEN** the request is refused and no password is changed
+
+### Requirement: Reset links are single-use
+
+Once a reset link has been used to successfully change a password, the same link SHALL NOT be usable
+to change the password again.
+
+#### Scenario: A used link cannot be replayed
+- **WHEN** a reset link is used to change a password successfully, and the same link is then submitted again
+- **THEN** the second attempt does not change the password
+
+### Requirement: A blank password is not accepted as a successful reset
+
+Submitting the reset form without a new password SHALL NOT report success or leave the existing
+password in place under the guise of a completed reset.
+
+#### Scenario: Blank password is rejected
+- **WHEN** a user submits the reset form with an empty password
+- **THEN** the reset is not reported as successful and the existing password is unchanged
+
+### Requirement: Reset links are honored only for the account's own site
+
+In a multi-site install, a reset link SHALL be honored only in the context of the site the account
+belongs to, so a token cannot be redeemed against an unrelated site.
+
+#### Scenario: A token is not honored on a foreign site
+- **WHEN** a reset link for an account on one site is submitted in the context of a different site that does not own the account
+- **THEN** the request is refused and no password is changed
+

--- a/openspec/specs/password-reset-token-validation/spec.md
+++ b/openspec/specs/password-reset-token-validation/spec.md
@@ -40,11 +40,17 @@ to change the password again.
 ### Requirement: A blank password is not accepted as a successful reset
 
 Submitting the reset form without a new password SHALL NOT report success or leave the existing
-password in place under the guise of a completed reset.
+password in place under the guise of a completed reset. A password value that is not a single text
+value (for example an array-shaped parameter) SHALL be treated the same way, and the reset link
+SHALL NOT be consumed by the rejected attempt.
 
 #### Scenario: Blank password is rejected
 - **WHEN** a user submits the reset form with an empty password
 - **THEN** the reset is not reported as successful and the existing password is unchanged
+
+#### Scenario: A non-scalar password value is rejected without consuming the link
+- **WHEN** the reset form is submitted with a password value that is not a single text value
+- **THEN** the reset is not reported as successful, the existing password is unchanged, and the link remains usable
 
 ### Requirement: Reset links are honored only for the account's own site
 

--- a/spec/requests/admin/sessions/malformed_user_param_spec.rb
+++ b/spec/requests/admin/sessions/malformed_user_param_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# A scalar `user` param (`?user=foo`) is not a form submission; every session action must treat it
+# as an empty submission and re-render instead of raising (String has no `permit`/`[]=` — previously
+# a 500 on login, on the forgot send-email branch, and on register).
+RSpec.describe 'Malformed user param on session actions', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+
+  it 'login re-renders with an error instead of failing' do
+    post cama_admin_login_path, params: { user: 'foo' }
+
+    expect(response).to have_http_status(:ok)
+    expect(flash[:error]).to be_present
+  end
+
+  it 'forgot (send-email branch) re-renders with an error instead of failing' do
+    post cama_admin_forgot_path, params: { user: 'foo' }
+
+    expect(response).to have_http_status(:ok)
+    expect(flash[:error]).to be_present
+  end
+
+  it 'register treats it as no submission instead of failing' do
+    current_site.set_option('permit_create_account', true)
+
+    post cama_admin_register_path, params: { user: 'foo' }
+
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/security/password_reset_token_spec.rb
+++ b/spec/requests/security/password_reset_token_spec.rb
@@ -88,6 +88,20 @@ RSpec.describe 'Password reset token validation', type: :request do
     end
   end
 
+  describe 'a malformed password is not accepted as a successful reset' do
+    it 'rejects an array-shaped password without consuming the reset link' do
+      token = emitted_reset_token
+
+      post cama_admin_forgot_path(h: token),
+           params: { user: { password: ['sneakyarray12'], password_confirmation: ['sneakyarray12'] } }
+
+      expect(response).not_to redirect_to(cama_admin_login_path)
+      expect(user.reload.authenticate('oldpassword12')).to be_truthy
+      # The link must survive the rejected attempt (a false success used to consume it).
+      expect(user.read_attribute(:password_reset_token)).to eq(token)
+    end
+  end
+
   describe 'reset links are honored only for the account\'s own site' do
     # The site boundary only applies when users are not shared across sites (with users_share_sites
     # a user belongs to every site, so any site legitimately honors the token).

--- a/spec/requests/security/password_reset_token_spec.rb
+++ b/spec/requests/security/password_reset_token_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Regression: on Rails 7.1+ has_secure_password generates a `password_reset_token` instance method that
+# shadows Camaleon's same-named DB column. The mailer emitted the method's signed token while
+# SessionsController#forgot looked the account up by the column, so every emitted reset link
+# dead-ended on "URL incorrect". The fix reads the column explicitly on both sides (works on Rails
+# 6.1–8.1), scopes to the current site, expires, is single-use, and rejects a blank password.
+RSpec.describe 'Password reset token validation', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:user) { create(:user, site: current_site, password: 'oldpassword12', password_confirmation: 'oldpassword12') }
+
+  # Requests a reset for `user` and returns the `h` token the mailer actually embedded in the link.
+  def emitted_reset_token
+    captured = nil
+    allow_any_instance_of(CamaleonCms::Admin::SessionsController).to receive(:send_email) do |_ctrl, *args|
+      extra_data = args.last
+      captured = Rack::Utils.parse_query(URI.parse(extra_data[:url]).query)['h']
+    end
+    post cama_admin_forgot_path, params: { user: { email: user.email } }
+    captured
+  end
+
+  describe 'an emailed reset link resolves to its account' do
+    it 'presents the reset form for the account the link was emailed to' do
+      token = emitted_reset_token
+      expect(token).to be_present
+
+      get cama_admin_forgot_path(h: token)
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('user[password]')
+    end
+
+    it 'refuses a token that matches no account' do
+      get cama_admin_forgot_path(h: 'not-a-real-token')
+
+      expect(response).to redirect_to(cama_admin_forgot_path)
+    end
+
+    it 'does not present a reset form for a blank token' do
+      get cama_admin_forgot_path(h: '')
+
+      expect(response.body).not_to include('user[password_confirmation]')
+    end
+  end
+
+  describe 'reset links expire' do
+    it 'refuses a link older than the expiry window' do
+      token = emitted_reset_token
+      user.update_columns(password_reset_sent_at: 3.hours.ago) # rubocop:disable Rails/SkipsModelValidations
+
+      get cama_admin_forgot_path(h: token)
+
+      expect(response).to redirect_to(cama_admin_login_path)
+    end
+  end
+
+  describe 'reset links are single-use' do
+    it 'cannot be replayed after a successful reset' do
+      token = emitted_reset_token
+
+      post cama_admin_forgot_path(h: token),
+           params: { user: { password: 'brandnewpass1', password_confirmation: 'brandnewpass1' } }
+      expect(response).to redirect_to(cama_admin_login_path)
+      expect(user.reload.authenticate('brandnewpass1')).to be_truthy
+
+      # Replay the same link with a different password — must not take effect.
+      post cama_admin_forgot_path(h: token),
+           params: { user: { password: 'replayed12345', password_confirmation: 'replayed12345' } }
+
+      expect(user.reload.authenticate('replayed12345')).to be_falsey
+      expect(user.authenticate('brandnewpass1')).to be_truthy
+    end
+  end
+
+  describe 'a blank password is not accepted as a successful reset' do
+    it 'does not report success and leaves the password unchanged' do
+      token = emitted_reset_token
+
+      post cama_admin_forgot_path(h: token), params: { user: { password: '', password_confirmation: '' } }
+
+      expect(response).not_to redirect_to(cama_admin_login_path)
+      expect(user.reload.authenticate('oldpassword12')).to be_truthy
+    end
+  end
+
+  describe 'reset links are honored only for the account\'s own site' do
+    # The site boundary only applies when users are not shared across sites (with users_share_sites
+    # a user belongs to every site, so any site legitimately honors the token).
+    it 'does not honor a token for an account on a different site (non-shared users)' do
+      allow(PluginRoutes).to receive(:system_info)
+        .and_return(PluginRoutes.system_info.merge('users_share_sites' => false))
+      other_site = CamaleonCms::Site.create!(name: 'Other', slug: 'other-site', taxonomy: 'site')
+      other_user = create(:user, site: other_site, password: 'oldpassword12', password_confirmation: 'oldpassword12')
+      other_user.send_password_reset
+      foreign_token = other_user.read_attribute(:password_reset_token)
+
+      # Pin the request to the first site (Camaleon resolves the site by slug-as-host) so it runs in
+      # that site's context; the token belongs to the other site and must not resolve here.
+      host! current_site.slug
+      get cama_admin_forgot_path(h: foreign_token)
+
+      expect(response).to redirect_to(cama_admin_forgot_path)
+    end
+  end
+end

--- a/spec/requests/security/password_reset_token_spec.rb
+++ b/spec/requests/security/password_reset_token_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe 'Password reset token validation', type: :request do
       # The link must survive the rejected attempt (a false success used to consume it).
       expect(user.read_attribute(:password_reset_token)).to eq(token)
     end
+
+    it 'treats a scalar user param as an empty submission instead of failing' do
+      token = emitted_reset_token
+
+      post cama_admin_forgot_path(h: token), params: { user: 'foo' }
+
+      expect(response).to have_http_status(:ok) # the reset form re-renders with an error
+      expect(user.reload.authenticate('oldpassword12')).to be_truthy
+    end
   end
 
   describe 'reset links are honored only for the account\'s own site' do


### PR DESCRIPTION
## What and Why

Administrator password reset is silently broken on current installs, and this restores it.

On **Rails 7.1+**, `has_secure_password` generates a `password_reset_token` **method** (from `activemodel/secure_password.rb`) that shadows Camaleon's same-named database column. The mailer emailed the method's signed token, while `SessionsController#forgot` looked the account up by the **column** — two different values — so every emitted reset link dead-ended on "URL incorrect" even though the user was told the email was sent. Verified on Rails 8.1: the method returns a signed token while `read_attribute` returns the column.

The engine supports **Rails 6.1 → 8.1**, and the framework generated-token finder (`find_by_password_reset_token`) is 7.1+ only — so it can't be the fix. Instead both sides align on the DB column, read explicitly so it dodges the shadow on 7.1+ and behaves identically on 6.1–7.0:

- **Mailer** emits `read_attribute(:password_reset_token)` — the stored column the lookup matches.
- **`forgot`** keeps the current-site-scoped column lookup, refuses a blank token, makes the `password_reset_sent_at` window nil-safe (it raised `NoMethodError` on a nil timestamp), **clears the token after a successful reset** (single-use), and **rejects a blank-password submission** (which `has_secure_password` otherwise treats as a silent, "successful" no-op).

Review hardening on the same flow (each change proven with a spec that fails before it):

- **The blank-password guard checks the *permitted* value.** An array-shaped `user[password][]` passed the raw-param check, was then dropped by `permit`, and the resulting empty `update` reported a "successful" reset while consuming the single-use token without changing the password. Malformed password shapes now land on the error branch and the link survives the rejected attempt.
- **A scalar `user` parameter (`?user=foo`) no longer raises a 500.** The reset path treats it as an empty submission and re-renders with an error, and the same pre-existing crash class is closed on login, register, and the forgot send-email branch (`user_permit_data` returns an empty submission for a shapeless value).

No schema change; the columns remain load-bearing (they are the cross-version mechanism).

The reproducing request spec captures the token the mailer actually emits and confirms it fails to resolve before the fix and resolves after; coverage adds expiry, single-use replay, blank/malformed password shapes, the foreign-site boundary (under `users_share_sites: false`, that boundary's precondition), and the malformed `user` parameter on each session endpoint.

The design/proposal artifacts were realigned from the originally-planned 7.1+ finder to this column-based approach for the 6.1–8.1 support range (see the change's design.md D1).

## User-Visible Impact

Administrator password-reset emails work again. Any reset links already outstanding at upgrade time are invalidated and must be re-requested (they were non-functional in practice); see `docs/upgrading-to-2.9.3.md`. Malformed session-form submissions (a non-form `user` parameter) now re-render with an error instead of raising a 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
