### PR TITLE
Make the user_before_register hook fire, with a captcha gate and a veto contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- **Change:** The `user_before_register` hook can now veto a registration by setting `r[:stop_process]`
-  (parity with `user_before_login`), and fires only after the register captcha passes. Follow-up to #1258.
+- **Change:** The `user_before_register` hook now fires during registration (it was previously dispatched
+  as a silent no-op) — after the register captcha passes — and a handler can veto a signup by setting
+  `r[:stop_process]`; the form shows a generic error unless the handler supplies its own. Follow-up to #1258.
   [#1259](https://github.com/owen2345/camaleon-cms/pull/1259).
 
 - **Security fix:** Closed an open redirect in the admin session flows. `safe_redirect_url` treated any URL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Change:** The `user_before_register` hook can now veto a registration by setting `r[:stop_process]`
+  (parity with `user_before_login`), and fires only after the register captcha passes. Follow-up to #1258.
+  [#1259](https://github.com/owen2345/camaleon-cms/pull/1259).
+
 - **Security fix:** Closed an open redirect in the admin session flows. `safe_redirect_url` treated any URL
   whose *parsed* host was blank as same-origin and returned it unchanged, but `return_to=///evil.com` (also
   `https:evil.com`, `javascript:...`) parses to a blank host yet sends a browser off-site — so

--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ RAILS_ENV=test bundle exec rake app:db:test:prepare
 
 See [docs/security/permissions.md](docs/security/permissions.md) for details on manager permissions, custom fields, and security considerations.
 
+## Hooks
+
+Plugins and themes extend Camaleon by handling named hooks. See [docs/hooks.md](docs/hooks.md) for the
+mechanism (registration via `config.json`, the mutable `args` payload) and a code-derived inventory of the
+hooks core fires, including the session/auth hooks (`user_before_login`, `user_before_register`,
+`after_login`, …).
+
 ## Contributing
 * Fork it.
 * Create a branch (git checkout -b my_feature_branch)

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -176,7 +176,7 @@ module CamaleonCms
           user_data = user_permit_data
           result = cama_register_user(user_data, nil)
           if result[:result] == false && result[:type] == :captcha_error
-            @user.errors.add(:captcha, t('camaleon_cms.admin.users.message.error_captcha'))
+            @user.errors.add(:captcha, result[:message])
             render 'register'
           elsif result[:result] == false && result[:type] == :stopped
             # A vetoing user_before_register handler may take over the response itself (render/redirect,

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -179,10 +179,17 @@ module CamaleonCms
             @user.errors.add(:captcha, t('camaleon_cms.admin.users.message.error_captcha'))
             render 'register'
           elsif result[:result] == false && result[:type] == :stopped
-            # A vetoing user_before_register handler may have taken over the response itself
-            # (render/redirect, the user_before_login convention); rendering again would raise
-            # DoubleRenderError, so re-render the form only when the handler did not.
-            render 'register' unless performed?
+            # A vetoing user_before_register handler may take over the response itself (render/redirect,
+            # the user_before_login convention) or add its own errors to r[:user]; rendering again would
+            # raise DoubleRenderError, so re-render only when it did not — and show a generic reason so the
+            # visitor is not left with a silently re-rendered form.
+            unless performed?
+              if @user.errors.empty?
+                @user.errors.add(:base, t('camaleon_cms.admin.users.message.registration_stopped',
+                                          default: 'Registration could not be completed.'))
+              end
+              render 'register'
+            end
           elsif result[:result]
             @user = result[:user] if result[:user].present?
             flash[:notice] = result[:message]

--- a/app/controllers/camaleon_cms/admin/sessions_controller.rb
+++ b/app/controllers/camaleon_cms/admin/sessions_controller.rb
@@ -178,6 +178,11 @@ module CamaleonCms
           if result[:result] == false && result[:type] == :captcha_error
             @user.errors.add(:captcha, t('camaleon_cms.admin.users.message.error_captcha'))
             render 'register'
+          elsif result[:result] == false && result[:type] == :stopped
+            # A vetoing user_before_register handler may have taken over the response itself
+            # (render/redirect, the user_before_login convention); rendering again would raise
+            # DoubleRenderError, so re-render the form only when the handler did not.
+            render 'register' unless performed?
           elsif result[:result]
             @user = result[:user] if result[:user].present?
             flash[:notice] = result[:message]

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -67,11 +67,14 @@ module CamaleonCms
     # - password_confirmation
     def cama_register_user(user_data, meta)
       user = current_site.users.new(user_data)
-      r = { user: user, params: params }
+      r = { user: user, params: params, stop_process: false }
       # Broadcast (hooks_run), not hook_run: hook_run(target, name, …) takes the app as its first arg, so
       # hook_run('user_before_register', r) treated the name as a plugin and silently no-op'd — the hook
       # never fired. Match the sibling user_before_login/user_after_register broadcasts.
       hooks_run('user_before_register', r)
+      # A handler may veto the registration by setting r[:stop_process] (parity with user_before_login):
+      # stop here without saving. The handler is expected to surface the reason itself (e.g. a flash).
+      return { result: false, type: :stopped, user: user } if r[:stop_process]
 
       if current_site.security_user_register_captcha_enabled? && !cama_captcha_verified?
         { result: false, type: :captcha_error, message: t('camaleon_cms.admin.users.message.error_captcha'),

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -69,7 +69,9 @@ module CamaleonCms
       user = current_site.users.new(user_data)
 
       # Gate on the register captcha before running any hook, so user_before_register does not fire for
-      # attempts that fail the captcha.
+      # attempts that fail the captcha. This diverges from user_before_login, which runs its hook even on a
+      # failed captcha and passes the result as r[:captcha_validate]; user_before_register does neither, so
+      # the "parity with user_before_login" below is limited to the stop_process veto.
       if current_site.security_user_register_captcha_enabled? && !cama_captcha_verified?
         return { result: false, type: :captcha_error,
                  message: t('camaleon_cms.admin.users.message.error_captcha'), user: user }

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -67,6 +67,14 @@ module CamaleonCms
     # - password_confirmation
     def cama_register_user(user_data, meta)
       user = current_site.users.new(user_data)
+
+      # Gate on the register captcha before running any hook, so user_before_register does not fire for
+      # attempts that fail the captcha.
+      if current_site.security_user_register_captcha_enabled? && !cama_captcha_verified?
+        return { result: false, type: :captcha_error,
+                 message: t('camaleon_cms.admin.users.message.error_captcha'), user: user }
+      end
+
       r = { user: user, params: params, stop_process: false }
       # Broadcast (hooks_run), not hook_run: hook_run(target, name, …) takes the app as its first arg, so
       # hook_run('user_before_register', r) treated the name as a plugin and silently no-op'd — the hook
@@ -76,10 +84,7 @@ module CamaleonCms
       # stop here without saving. The handler is expected to surface the reason itself (e.g. a flash).
       return { result: false, type: :stopped, user: user } if r[:stop_process]
 
-      if current_site.security_user_register_captcha_enabled? && !cama_captcha_verified?
-        { result: false, type: :captcha_error, message: t('camaleon_cms.admin.users.message.error_captcha'),
-          user: user }
-      elsif user.save
+      if user.save
         user.set_metas(meta)
         message = if current_site.need_validate_email?
                     t('camaleon_cms.admin.users.message.created_pending_validate_email')

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -71,7 +71,9 @@ module CamaleonCms
       # Gate on the register captcha before running any hook, so user_before_register does not fire for
       # attempts that fail the captcha. This diverges from user_before_login, which runs its hook even on a
       # failed captcha and passes the result as r[:captcha_validate]; user_before_register does neither, so
-      # the "parity with user_before_login" below is limited to the stop_process veto.
+      # the "parity with user_before_login" below is limited to the stop_process veto. Verifying here also
+      # consumes the single-use captcha before the hook, so a later veto burns a solved challenge —
+      # harmless, since the re-rendered form issues a fresh one.
       if current_site.security_user_register_captcha_enabled? && !cama_captcha_verified?
         return { result: false, type: :captcha_error,
                  message: t('camaleon_cms.admin.users.message.error_captcha'), user: user }

--- a/app/helpers/camaleon_cms/session_helper.rb
+++ b/app/helpers/camaleon_cms/session_helper.rb
@@ -81,7 +81,8 @@ module CamaleonCms
       # never fired. Match the sibling user_before_login/user_after_register broadcasts.
       hooks_run('user_before_register', r)
       # A handler may veto the registration by setting r[:stop_process] (parity with user_before_login):
-      # stop here without saving. The handler is expected to surface the reason itself (e.g. a flash).
+      # stop here without saving. The handler may surface its own reason (add to r[:user].errors, or
+      # render/redirect); otherwise the controller shows a generic error.
       return { result: false, type: :stopped, user: user } if r[:stop_process]
 
       if user.save

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -71,6 +71,12 @@ Argument shapes are read from the call sites in
 redirect allowlist/opt-in; the policy they feed is specified in
 `openspec/specs/session-return-redirects/spec.md`.
 
+`user_before_login` and `user_before_register` both take a `stop_process` veto, but they are **not**
+symmetric on the captcha: `user_before_login` runs even when the captcha fails (it receives the result as
+`:captcha_validate`), whereas `user_before_register` runs only once the register captcha passes and is
+given no `:captcha_validate`. A `user_before_register` veto stops the save; the handler may add its own
+message to `r[:user].errors` (or render/redirect itself), otherwise the controller shows a generic error.
+
 ## Full inventory (core-fired hooks)
 
 Grouped by subsystem; names only — read the call site (grep the name under `app/`, `lib/`) for the exact

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -62,7 +62,7 @@ Argument shapes are read from the call sites in
 | `session_before_load` / `session_after_load` | around every admin session action | none (notification only) |
 | `user_before_login` | before authenticating a login | `:user`, `:params`, `:password`, `:captcha_validate`, `:stop_process` (set true to halt) |
 | `after_login` | after a successful login, before redirect | `:user`, `:redirect_to` (destination), `:allow_external_redirect` (vouch for an off-site destination) |
-| `user_before_register` | before saving a registering user | `:user` (unsaved), `:params` |
+| `user_before_register` | before saving a registering user | `:user` (unsaved), `:params`, `:stop_process` (set true to veto the registration) |
 | `user_after_register` | after the new user is saved | `:user`, `:message`, `:redirect_url` |
 | `user_registered` | after registration, before redirect | `:user`, `:redirect_url`, `:allow_external_redirect` (vouch for an off-site destination) |
 | `safe_redirect_hosts` | when vetting an off-site redirect target | `:hosts` (append trusted hostnames) |

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -62,7 +62,7 @@ Argument shapes are read from the call sites in
 | `session_before_load` / `session_after_load` | around every admin session action | none (notification only) |
 | `user_before_login` | before authenticating a login | `:user`, `:params`, `:password`, `:captcha_validate`, `:stop_process` (set true to halt) |
 | `after_login` | after a successful login, before redirect | `:user`, `:redirect_to` (destination), `:allow_external_redirect` (vouch for an off-site destination) |
-| `user_before_register` | before saving a registering user | `:user` (unsaved), `:params`, `:stop_process` (set true to veto the registration) |
+| `user_before_register` | past the register captcha, before saving | `:user` (unsaved), `:params`, `:stop_process` (set true to veto the registration) |
 | `user_after_register` | after the new user is saved | `:user`, `:message`, `:redirect_url` |
 | `user_registered` | after registration, before redirect | `:user`, `:redirect_url`, `:allow_external_redirect` (vouch for an off-site destination) |
 | `safe_redirect_hosts` | when vetting an off-site redirect target | `:hosts` (append trusted hostnames) |

--- a/openspec/changes/archive/2026-08-13-user-registration-hooks/design.md
+++ b/openspec/changes/archive/2026-08-13-user-registration-hooks/design.md
@@ -1,0 +1,27 @@
+# Design
+
+## D1. Dispatch: broadcast, not target
+
+`hook_run(target, name, params)` runs one app's handler; `hooks_run(name, params)` broadcasts to every
+enabled app plus anonymous hooks. Registration must broadcast, so it uses `hooks_run` — matching
+`user_before_login`/`user_after_register`. The old `hook_run('user_before_register', r)` passed the hook
+name where the target app belongs, so `_do_hook` returned early (a String has no `['hooks']`) and nothing
+ran.
+
+## D2. Captcha gate precedes the hook
+
+The register-captcha check is a leading guard, so `user_before_register` does not fire for captcha-failing
+attempts. This diverges from `user_before_login`, which runs the hook even on a failed captcha and hands it
+the result as `captcha_validate`. The divergence is intentional (a signup blocked at the captcha should not
+run per-attempt hook work), and documented so a handler ported between the two hooks is not surprised.
+Verifying the captcha at the gate also consumes the single-use challenge before the hook; a subsequent veto
+therefore "burns" a solved captcha, which is harmless because the re-rendered form issues a fresh one.
+
+## D3. Veto contract
+
+`r[:stop_process]` mirrors `user_before_login`'s veto flag, but the two flows own the response differently:
+login `return`s and expects the hook to have redirected; registration re-renders the form. So the register
+veto contract is: the handler stops the save by setting the flag, and communicates by adding to
+`r[:user].errors` or performing its own response. The controller renders the form only `unless performed?`
+(so a handler that redirected is not double-rendered) and adds a generic error only when the handler left
+none — so a veto is never a silent no-feedback re-render.

--- a/openspec/changes/archive/2026-08-13-user-registration-hooks/proposal.md
+++ b/openspec/changes/archive/2026-08-13-user-registration-hooks/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The admin registration flow's pre-save hook, `user_before_register`, was dispatched with `hook_run`
+(which takes the target app as its first argument) instead of `hooks_run`, so it silently no-op'd and no
+plugin handler ever ran — the sibling `user_before_login` broadcasts correctly. Fixing the dispatch made
+the hook live, which raised a contract question this capability answers: when does it fire, and how may a
+handler stop a registration? No existing capability covers the registration hook contract.
+
+## What Changes
+
+- `cama_register_user` broadcasts `user_before_register` via `hooks_run` before saving the user, with a
+  `{ user:, params:, stop_process: false }` payload — so registered plugin/theme and anonymous handlers run.
+- The hook fires only past the register captcha (the captcha check is a leading guard), unlike
+  `user_before_login`, which runs regardless of the captcha and passes the result in its payload.
+- A handler may veto by setting `r[:stop_process]`: the user is not saved. The handler may add its own
+  error to `r[:user].errors` or perform its own response; otherwise the controller shows a generic error,
+  and it never renders on top of a response the handler already performed (no `DoubleRenderError`).
+
+## Notes
+
+- Behavior with no registered handler is unchanged: registration proceeds exactly as before the hook was
+  made live.
+- Documented for plugin authors in `docs/hooks.md`.

--- a/openspec/changes/archive/2026-08-13-user-registration-hooks/specs/user-registration-hooks/spec.md
+++ b/openspec/changes/archive/2026-08-13-user-registration-hooks/specs/user-registration-hooks/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: The registration pre-hook fires before the user is saved
+
+`cama_register_user` SHALL broadcast the `user_before_register` hook via `hooks_run` — reaching every
+installed plugin/theme handler and any anonymous hook — before the registering user is saved, with a
+payload carrying the unsaved `user`, the request `params`, and `stop_process: false`. (The hook was
+previously dispatched with `hook_run` in a form that silently no-op'd, so it never fired.)
+
+#### Scenario: A registered handler runs with the unsaved user
+
+- **WHEN** account registration is permitted and a `user_before_register` handler is registered
+- **THEN** the handler runs before the save, receiving the unsaved user in the payload
+
+### Requirement: The registration pre-hook fires only past the register captcha
+
+When the register captcha is enabled, `user_before_register` SHALL NOT fire for an attempt that fails the
+captcha; such an attempt SHALL return a captcha error before the hook runs. When the captcha passes (or is
+disabled), the hook SHALL fire. This differs from `user_before_login`, which runs its hook regardless of
+the captcha result and passes that result in the payload; `user_before_register` does neither.
+
+#### Scenario: A captcha-failing attempt does not reach the hook
+
+- **WHEN** the register captcha is enabled and the submitted captcha is missing or wrong
+- **THEN** registration returns a captcha error and the `user_before_register` hook does not run
+
+#### Scenario: A captcha-passing attempt reaches the hook
+
+- **WHEN** the register captcha is enabled and correctly solved
+- **THEN** the `user_before_register` hook runs
+
+### Requirement: A handler may veto the registration
+
+A `user_before_register` handler SHALL be able to veto the registration by setting `r[:stop_process]`; the
+registration SHALL stop without saving the user. The handler MAY surface its own reason by adding to
+`r[:user].errors` or by performing its own response (render/redirect); when it does neither, the flow SHALL
+show a generic error, and SHALL NOT render on top of a response the handler already performed.
+
+#### Scenario: A veto stops the save
+
+- **WHEN** a `user_before_register` handler sets `r[:stop_process]`
+- **THEN** the user is not created and the registration form is re-shown
+
+#### Scenario: A veto without its own feedback shows a generic error
+
+- **WHEN** a vetoing handler adds no error of its own and performs no response
+- **THEN** the re-rendered form shows a generic "registration could not be completed" error
+
+#### Scenario: A veto that took over the response is not double-rendered
+
+- **WHEN** a vetoing handler issues its own redirect (or render) and then vetoes
+- **THEN** the flow does not render again on top of it (no DoubleRenderError)

--- a/openspec/changes/archive/2026-08-13-user-registration-hooks/tasks.md
+++ b/openspec/changes/archive/2026-08-13-user-registration-hooks/tasks.md
@@ -1,0 +1,19 @@
+## 1. Implement
+
+- [x] 1.1 Broadcast `user_before_register` via `hooks_run` with a `{ user:, params:, stop_process: false }` payload
+- [x] 1.2 Gate the hook behind the register captcha (leading guard clause)
+- [x] 1.3 Honor `r[:stop_process]` — stop without saving, return `type: :stopped`
+- [x] 1.4 Controller: render the form only `unless performed?`, and add a generic error when the handler left none
+
+## 2. Tests
+
+- [x] 2.1 A registered handler runs with the unsaved user
+- [x] 2.2 Captcha-failing attempt does not reach the hook (asserts the rendered captcha error); captcha-passing does
+- [x] 2.3 A veto stops the save; a no-feedback veto shows a generic error; a handler error is shown instead
+- [x] 2.4 A veto that redirected does not double-render
+
+## 3. Docs and archive
+
+- [x] 3.1 Document the hook (fires, captcha divergence, veto contract) in `docs/hooks.md`
+- [x] 3.2 CHANGELOG entry ([#1259])
+- [x] 3.3 Archive this change on the branch

--- a/openspec/specs/user-registration-hooks/spec.md
+++ b/openspec/specs/user-registration-hooks/spec.md
@@ -1,0 +1,56 @@
+# user-registration-hooks Specification
+
+## Purpose
+TBD - created by archiving change user-registration-hooks. Update Purpose after archive.
+## Requirements
+### Requirement: The registration pre-hook fires before the user is saved
+
+`cama_register_user` SHALL broadcast the `user_before_register` hook via `hooks_run` — reaching every
+installed plugin/theme handler and any anonymous hook — before the registering user is saved, with a
+payload carrying the unsaved `user`, the request `params`, and `stop_process: false`. (The hook was
+previously dispatched with `hook_run` in a form that silently no-op'd, so it never fired.)
+
+#### Scenario: A registered handler runs with the unsaved user
+
+- **WHEN** account registration is permitted and a `user_before_register` handler is registered
+- **THEN** the handler runs before the save, receiving the unsaved user in the payload
+
+### Requirement: The registration pre-hook fires only past the register captcha
+
+When the register captcha is enabled, `user_before_register` SHALL NOT fire for an attempt that fails the
+captcha; such an attempt SHALL return a captcha error before the hook runs. When the captcha passes (or is
+disabled), the hook SHALL fire. This differs from `user_before_login`, which runs its hook regardless of
+the captcha result and passes that result in the payload; `user_before_register` does neither.
+
+#### Scenario: A captcha-failing attempt does not reach the hook
+
+- **WHEN** the register captcha is enabled and the submitted captcha is missing or wrong
+- **THEN** registration returns a captcha error and the `user_before_register` hook does not run
+
+#### Scenario: A captcha-passing attempt reaches the hook
+
+- **WHEN** the register captcha is enabled and correctly solved
+- **THEN** the `user_before_register` hook runs
+
+### Requirement: A handler may veto the registration
+
+A `user_before_register` handler SHALL be able to veto the registration by setting `r[:stop_process]`; the
+registration SHALL stop without saving the user. The handler MAY surface its own reason by adding to
+`r[:user].errors` or by performing its own response (render/redirect); when it does neither, the flow SHALL
+show a generic error, and SHALL NOT render on top of a response the handler already performed.
+
+#### Scenario: A veto stops the save
+
+- **WHEN** a `user_before_register` handler sets `r[:stop_process]`
+- **THEN** the user is not created and the registration form is re-shown
+
+#### Scenario: A veto without its own feedback shows a generic error
+
+- **WHEN** a vetoing handler adds no error of its own and performs no response
+- **THEN** the re-rendered form shows a generic "registration could not be completed" error
+
+#### Scenario: A veto that took over the response is not double-rendered
+
+- **WHEN** a vetoing handler issues its own redirect (or render) and then vetoes
+- **THEN** the flow does not render again on top of it (no DoubleRenderError)
+

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
     seen = []
     add_ubr_hook('spec_ubr') { |r| seen << r[:user]&.username }
 
-    username = "ubr_#{Time.current.to_i}"
+    username = "ubr_#{SecureRandom.hex(4)}"
     register!(username)
 
     expect(seen).to include(username)
@@ -38,7 +38,7 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
   it 'lets a user_before_register handler veto the registration via stop_process' do
     add_ubr_hook('spec_ubr_stop') { |r| r[:stop_process] = true }
 
-    username = "veto_#{Time.current.to_i}"
+    username = "veto_#{SecureRandom.hex(4)}"
     register!(username)
 
     expect(CamaleonCms::User.find_by(username: username)).to be_nil
@@ -87,7 +87,7 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
       ran = []
       add_ubr_hook('spec_ubr_captcha') { |_r| ran << true }
 
-      username = "capfail_#{Time.current.to_i}"
+      username = "capfail_#{SecureRandom.hex(4)}"
       register!(username) # no captcha submitted → verification fails before the hook
 
       expect(ran).to be_empty
@@ -102,7 +102,7 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
       ran = []
       add_ubr_hook('spec_ubr_pass') { |_r| ran << true }
 
-      username = "cappass_#{Time.current.to_i}"
+      username = "cappass_#{SecureRandom.hex(4)}"
       register!(username)
 
       expect(ran).to eq([true])

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
     expect(response).to have_http_status(:ok)
   end
 
+  it 'does not double-render when a vetoing handler already performed the response' do
+    # A manifest handler runs via `send` on the controller, so a veto may redirect itself (the
+    # user_before_login convention). Rendering the form on top of that would raise DoubleRenderError.
+    allow_any_instance_of(CamaleonCms::Admin::SessionsController)
+      .to receive(:cama_register_user) do |controller, *_args|
+        controller.redirect_to('/admin/login')
+        { result: false, type: :stopped, user: CamaleonCms::Site.first.users.new }
+      end
+
+    register!('vetoredir')
+
+    expect(response).to redirect_to('/admin/login')
+  end
+
   context 'with the registration captcha enabled (hook fires only past the captcha gate)' do
     before { CamaleonCms::Site.first.decorate.set_option('security_captcha_user_register', true) }
 

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -44,4 +44,32 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
     expect(CamaleonCms::User.find_by(username: username)).to be_nil
     expect(response).to have_http_status(:ok)
   end
+
+  context 'with the registration captcha enabled (hook fires only past the captcha gate)' do
+    before { CamaleonCms::Site.first.decorate.set_option('security_captcha_user_register', true) }
+
+    it 'does not fire user_before_register when the captcha fails' do
+      ran = []
+      add_ubr_hook('spec_ubr_captcha') { |_r| ran << true }
+
+      username = "capfail_#{Time.current.to_i}"
+      register!(username) # no captcha submitted → verification fails before the hook
+
+      expect(ran).to be_empty
+      expect(CamaleonCms::User.find_by(username: username)).to be_nil
+    end
+
+    it 'fires user_before_register once the captcha passes' do
+      allow_any_instance_of(CamaleonCms::Admin::SessionsController)
+        .to receive(:cama_captcha_verified?).and_return(true)
+      ran = []
+      add_ubr_hook('spec_ubr_pass') { |_r| ran << true }
+
+      username = "cappass_#{Time.current.to_i}"
+      register!(username)
+
+      expect(ran).to eq([true])
+      expect(CamaleonCms::User.find_by(username: username)).not_to be_nil
+    end
+  end
 end

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -59,6 +59,27 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
     expect(response).to redirect_to('/admin/login')
   end
 
+  it 'shows a generic error when a veto provides no feedback of its own' do
+    add_ubr_hook('spec_ubr_stop_default') { |r| r[:stop_process] = true }
+
+    register!("veto_default_#{SecureRandom.hex(4)}")
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('Registration could not be completed.')
+  end
+
+  it "shows the handler's own error instead of the generic one" do
+    add_ubr_hook('spec_ubr_stop_custom') do |r|
+      r[:user].errors.add(:base, 'Signups are paused')
+      r[:stop_process] = true
+    end
+
+    register!("veto_custom_#{SecureRandom.hex(4)}")
+
+    expect(response.body).to include('Signups are paused')
+    expect(response.body).not_to include('Registration could not be completed.')
+  end
+
   context 'with the registration captcha enabled (hook fires only past the captcha gate)' do
     before { CamaleonCms::Site.first.decorate.set_option('security_captcha_user_register', true) }
 

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -10,18 +10,38 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
   init_site
 
   before { CamaleonCms::Site.first.decorate.set_option('permit_create_account', true) }
-  after  { PluginRoutes.remove_anonymous_hook('user_before_register', 'spec_ubr') }
+  after  { (@ubr_ids || []).each { |id| PluginRoutes.remove_anonymous_hook('user_before_register', id) } }
 
-  it 'runs a registered user_before_register handler with the new (unsaved) user' do
-    seen = []
-    PluginRoutes.add_anonymous_hook('user_before_register', ->(r) { seen << r[:user]&.username }, 'spec_ubr')
+  # Register an anonymous user_before_register handler that is torn down after the example.
+  def add_ubr_hook(id, &block)
+    (@ubr_ids ||= []) << id
+    PluginRoutes.add_anonymous_hook('user_before_register', block, id)
+  end
 
-    username = "ubr_#{Time.current.to_i}"
+  def register!(username)
     post cama_admin_register_path, params: {
       user: { first_name: 'U', last_name: 'B', email: "#{username}@tester.com",
               username: username, password: 'password123', password_confirmation: 'password123' }
     }
+  end
+
+  it 'runs a registered user_before_register handler with the new (unsaved) user' do
+    seen = []
+    add_ubr_hook('spec_ubr') { |r| seen << r[:user]&.username }
+
+    username = "ubr_#{Time.current.to_i}"
+    register!(username)
 
     expect(seen).to include(username)
+  end
+
+  it 'lets a user_before_register handler veto the registration via stop_process' do
+    add_ubr_hook('spec_ubr_stop') { |r| r[:stop_process] = true }
+
+    username = "veto_#{Time.current.to_i}"
+    register!(username)
+
+    expect(CamaleonCms::User.find_by(username: username)).to be_nil
+    expect(response).to have_http_status(:ok)
   end
 end

--- a/spec/requests/admin/sessions/register_hooks_spec.rb
+++ b/spec/requests/admin/sessions/register_hooks_spec.rb
@@ -92,6 +92,8 @@ RSpec.describe 'Registration user_before_register hook', type: :request do
 
       expect(ran).to be_empty
       expect(CamaleonCms::User.find_by(username: username)).to be_nil
+      # Prove the hook was skipped by the captcha gate (not merely absent): the captcha error rendered.
+      expect(response.body).to include('Oh! Its error with CAPTCHA!')
     end
 
     it 'fires user_before_register once the captcha passes' do


### PR DESCRIPTION
## User-Visible Impact

None for end users by default. For plugin/theme authors: the `user_before_register` hook — previously a silent no-op — now fires during registration, and a handler can veto a signup by setting `r[:stop_process]`.

## What and Why

Follow-up to #1258. The registration pre-hook `user_before_register` was dispatched with `hook_run` in a form that silently no-op'd (its first argument is the target app, not the hook name), so no handler ever ran, while the sibling `user_before_login` broadcasts correctly. This PR makes the hook live and defines its contract:

- **Fires before the save** — broadcast (`hooks_run`) to plugin/theme and anonymous handlers, with a `{ user:, params:, stop_process: false }` payload.
- **Gated behind the register captcha** — it does not fire for attempts that fail the captcha. This diverges from `user_before_login`, which runs its hook regardless of the captcha and passes the result in its payload; the divergence is intentional and documented, not "parity."
- **Vetoable** — a handler sets `r[:stop_process]` to stop the signup without saving the user. It may communicate by adding to `r[:user].errors` or performing its own response (render/redirect); otherwise the form shows a generic error, and the controller never renders on top of a response the handler already performed (no `DoubleRenderError`).

Behavior with no registered handler is unchanged — registration proceeds exactly as before the hook was made live. The contract is specified in the `user-registration-hooks` OpenSpec capability and documented for plugin authors in `docs/hooks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
