### PR TITLE
Restore post editor content when TinyMCE initializes empty on cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Bug fix:** The post editor could load with an empty body on a cold server when the edit form was
+  opened in a background browser tab, and saving then overwrote the post with the empty body; the
+  editor now restores the server-rendered content when it initializes empty. [#1273](https://github.com/owen2345/camaleon-cms/pull/1273)
+
 - **Performance fix:** On installs with many sites, the first request after a server (re)start could
   404 or render an admin page half-initialized. Route drawing no longer scales with the number of
   sites, it is drawn at boot in development so no request is served mid-draw, and admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   editor now restores the server-rendered content when it initializes empty. [#1273](https://github.com/owen2345/camaleon-cms/pull/1273)
 
 - **Performance fix:** On installs with many sites, the first request after a server (re)start could
-  404 or render an admin page half-initialized. Route drawing no longer scales with the number of
+  404 or be served against a still-building route table. Route drawing no longer scales with the number of
   sites, it is drawn at boot in development so no request is served mid-draw, and admin
   responses now send `Cache-Control: no-store`. [#1272](https://github.com/owen2345/camaleon-cms/pull/1272).
 

--- a/app/assets/javascripts/camaleon_cms/admin/_data.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_data.js
@@ -60,6 +60,22 @@ function cama_get_tinymce_settings(settings){
 
             editor.on('init', function(e) {
                 for(var ff in tinymce_global_settings["init"]) tinymce_global_settings["init"][ff](editor);
+
+                // Content guard for the cold-boot / background-tab init race: when the edit form is
+                // opened in a background tab on a cold server, the browser throttles the tab and
+                // TinyMCE can initialize empty even though the server rendered the post content into
+                // the textarea -- the field's live value is blanked before TinyMCE reads it. The
+                // DOM still holds the server value in `defaultValue`, so restore it when the editor
+                // came up empty but the server value did not. Skip Translatable clones and encoded
+                // multi-language values (leading `<!--:`), whose per-locale decoding Translatable owns.
+                var ta = document.getElementById(editor.id);
+                if (ta && !ta.classList.contains('translate-item') &&
+                    (editor.getContent() || '').length === 0 &&
+                    (ta.defaultValue || '').length > 0 &&
+                    ta.defaultValue.indexOf('<!--:') !== 0) {
+                    editor.setContent(ta.defaultValue);
+                    editor.save();
+                }
             });
         },
         onPostRender: function(editor){}

--- a/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/design.md
+++ b/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/design.md
@@ -1,0 +1,25 @@
+# Design
+
+## Guard the symptom, not the cause
+
+The blank editor was bisected to #1163 (`PluginRoutes.reload` thread-safety), which shifted
+cold-start timing enough to lose the editor's init race in a throttled background tab. The editor
+JavaScript is unchanged since 2.9.2 and #1163's thread-safety fix must stay, so the race is guarded
+where the symptom lands rather than by reverting the cause. The route/asset boot work in #1272 does
+not help here: the edit form loads with routes already drawn, so this is a client-side race, not a
+route-draw stall.
+
+## Restore from `defaultValue`
+
+The server always renders the post content into the textarea, and the DOM preserves that initial
+value in `textarea.defaultValue` regardless of what blanks the live `value`. So the guard, in
+TinyMCE's `init` handler, restores `defaultValue` when the editor came up empty but `defaultValue`
+is not empty. It skips Translatable clones (`.translate-item`) and encoded multi-language values
+(leading `<!--:`), whose per-locale decoding the Translatable plugin owns, so it can only ever
+restore real single-language content and never corrupts an encoded field.
+
+## Testing
+
+The background-tab throttling race is not reproducible in a headless feature spec. The feature spec
+instead drives the exact DOM state the race produces -- an empty live value with the server value
+still in `defaultValue` -- and asserts the guard refills the editor; it fails without the guard.

--- a/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/proposal.md
+++ b/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/proposal.md
@@ -1,0 +1,21 @@
+# Preserve post editor content when TinyMCE initializes empty
+
+## Why
+
+On a cold server, opening the post edit form in a throttled background browser tab can bring up
+TinyMCE with an empty body even though the server rendered the post content into the textarea: the
+content field's live value is blanked before TinyMCE reads it, and a save then overwrites the post
+with the empty body. A plain (foreground) refresh fixes it, so the content is never lost
+server-side. Bisected to #1163 (`PluginRoutes.reload` thread-safety), which shifted cold-start
+timing enough to lose the editor's init race; the editor JavaScript itself is unchanged since 2.9.2.
+
+## What Changes
+
+- The admin TinyMCE editor restores the server-rendered content from the textarea's `defaultValue`
+  when it initializes empty but the server value is not empty. It never overwrites Translatable
+  clones or encoded multi-language values, whose per-locale decoding the Translatable plugin owns.
+
+## Impact
+
+- Affected capability: `post-editor-content-resilience` (new)
+- Affected code: `app/assets/javascripts/camaleon_cms/admin/_data.js`

--- a/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/specs/post-editor-content-resilience/spec.md
+++ b/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/specs/post-editor-content-resilience/spec.md
@@ -1,0 +1,29 @@
+# post-editor-content-resilience
+
+## Purpose
+
+The admin post editor must not lose server-rendered content when TinyMCE initializes. A cold-boot /
+background-tab init race can blank the content field's live value before TinyMCE reads it, so the
+editor comes up empty and a save overwrites the post -- even though the server rendered the content.
+
+## ADDED Requirements
+
+### Requirement: The editor restores server-rendered content when it initializes empty
+
+When the admin TinyMCE editor initializes empty but the server rendered content into the textarea,
+it SHALL restore that content from the textarea's preserved initial value (`defaultValue`), so a
+transient init-time blanking of the live value cannot lose the post body. The restore SHALL NOT
+apply to Translatable clones or to encoded multi-language values, whose per-locale decoding the
+Translatable plugin owns.
+
+#### Scenario: An editor that comes up empty is refilled from the server value
+
+- **WHEN** the editor initializes with empty content but the textarea's `defaultValue` holds the
+  server-rendered content
+- **THEN** the editor is refilled with that content, so a subsequent save preserves the post body
+
+#### Scenario: A translation clone or encoded multi-language value is left to Translatable
+
+- **WHEN** the field is a Translatable clone or its value is an encoded multi-language string
+  (leading `<!--:`)
+- **THEN** the guard does not restore it, leaving per-locale decoding to the Translatable plugin

--- a/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/tasks.md
+++ b/openspec/changes/archive/2026-08-18-preserve-editor-content-on-empty-init/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## 1. Guard
+- [x] Restore server `defaultValue` in the TinyMCE `init` handler when the editor initializes empty
+- [x] Skip Translatable clones and encoded multi-language values
+
+## 2. Tests
+- [x] Feature spec driving the empty-value / non-empty-`defaultValue` state (fails without the guard)
+
+## 3. Archive
+- [x] Archive this change on the branch before merge

--- a/openspec/specs/post-editor-content-resilience/spec.md
+++ b/openspec/specs/post-editor-content-resilience/spec.md
@@ -1,0 +1,27 @@
+# post-editor-content-resilience Specification
+
+## Purpose
+The admin post editor must not lose server-rendered content when TinyMCE initializes. A cold-boot /
+background-tab init race can blank the content field's live value before TinyMCE reads it, so the
+editor comes up empty and a save overwrites the post -- even though the server rendered the content.
+## Requirements
+### Requirement: The editor restores server-rendered content when it initializes empty
+
+When the admin TinyMCE editor initializes empty but the server rendered content into the textarea,
+it SHALL restore that content from the textarea's preserved initial value (`defaultValue`), so a
+transient init-time blanking of the live value cannot lose the post body. The restore SHALL NOT
+apply to Translatable clones or to encoded multi-language values, whose per-locale decoding the
+Translatable plugin owns.
+
+#### Scenario: An editor that comes up empty is refilled from the server value
+
+- **WHEN** the editor initializes with empty content but the textarea's `defaultValue` holds the
+  server-rendered content
+- **THEN** the editor is refilled with that content, so a subsequent save preserves the post body
+
+#### Scenario: A translation clone or encoded multi-language value is left to Translatable
+
+- **WHEN** the field is a Translatable clone or its value is an encoded multi-language string
+  (leading `<!--:`)
+- **THEN** the guard does not restore it, leaving per-locale decoding to the Translatable plugin
+

--- a/spec/features/admin/posts_spec.rb
+++ b/spec/features/admin/posts_spec.rb
@@ -49,6 +49,32 @@ describe 'Posts workflows for Admin', :js do
     expect(page).to have_text('Test Title changed')
   end
 
+  # Regression: on a cold server, opening the edit form in a throttled background tab could bring up
+  # TinyMCE empty even though the server rendered the post content -- the field's live value was
+  # blanked before TinyMCE read it (surfaced by the PluginRoutes reload changes in #1163). The init
+  # guard in cama_get_tinymce_settings restores the server value (textarea.defaultValue) when the
+  # editor comes up empty. The throttling race is not reproducible headlessly, so this drives the
+  # exact state it produces -- empty live value, server value still in defaultValue -- and asserts
+  # the guard refills the editor. Without the guard the editor stays empty and this fails.
+  it 'restores the server-rendered content when the editor initializes empty' do
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/post_type/#{post_type_id}/posts/#{post.id}/edit"
+    wait(2)
+
+    page.execute_script(<<~JS)
+      tinymce.get('post_content').remove();
+      var ta = document.getElementById('post_content');
+      ta.defaultValue = '<p>Cold-boot guard body</p>';
+      ta.value = '';
+      tinymce.init(cama_get_tinymce_settings({ selector: '#post_content' }));
+    JS
+    wait(2)
+
+    within_frame('post_content_ifr') do
+      expect(page).to have_text('Cold-boot guard body')
+    end
+  end
+
   describe 'when visibility post plugin is enabled' do
     it 'correctly fetches the assets' do
       plugin_install('visibility_post')


### PR DESCRIPTION
## What and Why

On a cold server, opening the post edit form in a background browser tab could bring up the TinyMCE editor with an empty body even though the post has content. The frontend "Edit" link opens the editor in a new (background) tab; browsers throttle background-tab timers, which shifts TinyMCE's initialization timing so the content field's live value is blanked before TinyMCE reads it. The editor then initializes empty, and saving the form overwrites the post with the empty body. A plain refresh (foreground / warm) fixes it — the content was never lost server-side; the server always renders it into the textarea.

This was bisected to #1163 (`PluginRoutes.reload` thread-safety), which shifted cold-start timing enough to lose the init race. The editor JavaScript itself is unchanged since 2.9.2, and #1163's thread-safety fix must stay, so this guards the symptom at the editor: in the TinyMCE `init` handler (`cama_get_tinymce_settings`), when the editor initialized empty but the textarea still holds the server value in `defaultValue`, it restores the content. The guard skips Translatable clones and encoded multi-language values (leading `<!--:`), so it can only restore real single-language content and never corrupts an encoded field.

The throttling race is not reproducible in a headless feature spec, so the added spec drives the exact state it produces — empty live value, server value still in `defaultValue` — and asserts the guard refills the editor (it fails without the guard).

The behaviour is captured as an OpenSpec change (`post-editor-content-resilience`), archived on the branch.

## User-Visible Impact

The post editor no longer loads blank — and a save no longer wipes the post body — when the edit form is opened in a background tab on a freshly (re)started server. Normal editing is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
