### PR TITLE
Set published_at when a post is published without a date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Bug fix:** Publishing a post without an explicit date saved it `published` with a nil `published_at` — undated, and raising in themes that format the publish date. `CamaleonCms::Post` now stamps `published_at` (UTC) when a post becomes `published` without one; supplied/scheduled dates and already-published posts are untouched, and existing undated posts are not backfilled. [#1276](https://github.com/owen2345/camaleon-cms/pull/1276).
+
 - **Performance fix:** Frontend post listings no longer issue N+1 queries for post `metas`, `categories`, `post_tags` and post-type `metas` — a `Post.with_eager` `preload` scope loads them up front on the listing paths (single-post lookups stay lean), and stale association caches are reset after category/tag mutations. [#1275](https://github.com/owen2345/camaleon-cms/pull/1275).
   - **Notes for theme/plugin developers:** frontend listings (`the_posts`/`the_contents`) now `preload` these associations instead of joining `metas`. A view that filters or sorts `@posts` on a `metas` column must chain `.joins(:metas)` / `.eager_load(:metas)` itself, and a column-narrowed `select` on `the_posts` must keep `taxonomy_id` (or use `pluck`).
 

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -85,6 +85,7 @@ module CamaleonCms
     attr_accessor :show_title_with_parent
 
     before_create :fix_post_order, if: ->(p) { p.post_order.blank? || p.post_order == 0 }
+    before_save :set_published_at_on_publish
 
     # return all parents for current page hierarchy ordered bottom to top
     def parents
@@ -343,6 +344,19 @@ module CamaleonCms
     def fix_post_order
       last_post = post_type.posts.where.not(id: nil).last
       self.post_order = last_post.present? ? (last_post.post_order || 0) + 1 : 1
+    end
+
+    # Stamp the publish time at the moment a post becomes published without an explicit date --
+    # the admin Publish action, or any save that transitions the status to 'published'. Keyed to
+    # the status change (or the record being born published), not to every save, so a post created
+    # as a draft keeps a nil published_at until it is actually published, a caller-supplied date
+    # (e.g. a scheduled post) is preserved, and later edits of an already-published post keep the
+    # original date.
+    def set_published_at_on_publish
+      return unless status == 'published' && published_at.blank?
+      return unless new_record? || will_save_change_to_status?
+
+      self.published_at = Time.current.utc
     end
   end
 end

--- a/openspec/specs/post-publish-timestamp/spec.md
+++ b/openspec/specs/post-publish-timestamp/spec.md
@@ -1,0 +1,55 @@
+# post-publish-timestamp Specification
+
+## Purpose
+Pin when a post's `published_at` is set. Neither the admin publish flow nor the `Post` model
+required a publish date, so a post could reach the `published` status with a nil `published_at`.
+That left published content undated and broke frontends that format the publish date — e.g. a theme
+rendering `l(post.published_at)` raised on the nil. `CamaleonCms::Post` now stamps `published_at` at
+the moment a post becomes published without a caller-supplied date, keyed to the status change so
+drafts stay undated, a supplied (scheduled or backdated) date is preserved, and later edits do not
+move the date.
+
+## Requirements
+
+### Requirement: Publishing a post without a date stamps published_at
+
+`CamaleonCms::Post` SHALL set `published_at` to the current UTC time when a save makes the post
+`published` and no `published_at` was supplied — whether the record is created already published or
+an existing draft transitions to `published`. A post whose status is not `published` SHALL NOT be
+stamped.
+
+#### Scenario: A draft is published without a date
+
+- **WHEN** an existing draft is saved with `status` changed to `published` and a blank `published_at`
+- **THEN** `published_at` is set to the current time
+
+#### Scenario: A post is created already published without a date
+
+- **WHEN** a post is created with `status` `published` and a blank `published_at`
+- **THEN** `published_at` is set to the current time
+
+#### Scenario: A post that is not published stays undated
+
+- **WHEN** a post is created or saved with a non-`published` status and a blank `published_at`
+- **THEN** `published_at` remains nil
+
+### Requirement: A caller-supplied published_at is preserved
+
+When a save that publishes a post carries an explicit `published_at`, `CamaleonCms::Post` SHALL keep
+that value rather than overwriting it, so a scheduled or backdated publish date survives.
+
+#### Scenario: Publishing with a scheduled date keeps it
+
+- **WHEN** a post is published with an explicit future `published_at`
+- **THEN** `published_at` keeps the supplied value
+
+### Requirement: Editing an already-published post does not move the date
+
+A save that does not transition `status` into `published` SHALL NOT change an existing
+`published_at`. Editing a live post preserves its original publish date, and a post already stored
+`published` with a nil date is left as-is rather than stamped on an unrelated save.
+
+#### Scenario: Editing a published post preserves published_at
+
+- **WHEN** an already-published post is saved with an unrelated attribute change
+- **THEN** `published_at` is unchanged

--- a/spec/models/post_published_at_spec.rb
+++ b/spec/models/post_published_at_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CamaleonCms::Post do
+  init_site
+
+  let(:post_type) { create(:post_type, slug: 'published-at-pt', site: @site) }
+
+  it 'leaves published_at nil for a post created as a draft' do
+    post = create(:draft_post, post_type: post_type, published_at: nil)
+    expect(post.published_at).to be_nil
+  end
+
+  it 'stamps published_at when a draft is published without a date' do
+    post = create(:draft_post, post_type: post_type, published_at: nil)
+    post.update!(status: 'published')
+    expect(post.published_at).to be_within(5.seconds).of(Time.current)
+  end
+
+  it 'stamps published_at when a post is created already published without a date' do
+    post = create(:post, post_type: post_type, status: 'published', published_at: nil)
+    expect(post.published_at).to be_within(5.seconds).of(Time.current)
+  end
+
+  it 'preserves a caller-supplied published_at when publishing (scheduled post)' do
+    scheduled = 3.days.from_now
+    post = create(:draft_post, post_type: post_type, published_at: nil)
+    post.update!(status: 'published', published_at: scheduled)
+    expect(post.published_at).to be_within(1.second).of(scheduled)
+  end
+
+  it 'does not change published_at when an already-published post is edited' do
+    original = 10.days.ago
+    post = create(:post, post_type: post_type, status: 'published', published_at: original)
+    post.update!(title: 'A new title')
+    expect(post.reload.published_at).to be_within(1.second).of(original)
+  end
+end


### PR DESCRIPTION
## What and Why

Publishing a post from the admin does not require a publish date, and neither the admin flow nor the model set one — so a post could be saved with `status: 'published'` and a nil `published_at`. That leaves published content undated and breaks any frontend that formats the publish date (for example a theme rendering `l(post.published_at)` raises `I18n::ArgumentError` on the nil).

`CamaleonCms::Post` now stamps `published_at` with the current UTC time at the moment a post becomes published without a supplied date — keyed to the status transition: a record created already published, or an existing draft moving to `published`. It deliberately does not overwrite a caller-supplied date (scheduled or backdated posts survive), does not re-stamp on unrelated edits of a live post, and does not backfill posts already stored `published` with a nil date.

The behavior is recorded as the `post-publish-timestamp` OpenSpec capability.

## User-Visible Impact

A post published without choosing a date now records the publish time (UTC) automatically instead of remaining undated; existing undated posts are left unchanged.
