### PR TITLE
Gate content shortcodes behind a default-off content_shortcodes permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- **Security fix:** Shortcodes in authored content are now gated behind a default-off `content_shortcodes` role permission. A save carrying a registered shortcode is refused (never sanitized) for a non-admin lacking it, across post content, custom-field values, taxonomy content and widget descriptions. Detection is precise and fails closed; admins, stored content and rendering are unaffected. [#1277](https://github.com/owen2345/camaleon-cms/pull/1277).
+  - **Breaking change:** a non-administrator role without `content_shortcodes` can no longer publish shortcode-bearing content on any of those surfaces. Grant the permission (Settings → User Roles → *Allow shortcodes in content*) to roles that author shortcodes.
+  - **Notes for upgraders:** a shortcode is gated only if its name is declared to the boot registry. Core declares its own; a theme/plugin registering shortcodes must declare their names through the DSL from its own boot (request-independently), e.g. `CamaleonCms::ShortcodeRegistry.register('redirect', 'my_slider')`. Rendering is untouched — the render-time `shortcode_add` handler stays as-is.
+
 - **Bug fix:** Publishing a post without an explicit date saved it `published` with a nil `published_at` — undated, and raising in themes that format the publish date. `CamaleonCms::Post` now stamps `published_at` (UTC) when a post becomes `published` without one; supplied/scheduled dates and already-published posts are untouched, and existing undated posts are not backfilled. [#1276](https://github.com/owen2345/camaleon-cms/pull/1276).
 
 - **Performance fix:** Frontend post listings no longer issue N+1 queries for post `metas`, `categories`, `post_tags` and post-type `metas` — a `Post.with_eager` `preload` scope loads them up front on the listing paths (single-post lookups stay lean), and stale association caches are reset after category/tag mutations. [#1275](https://github.com/owen2345/camaleon-cms/pull/1275).

--- a/app/models/camaleon_cms/custom_fields_relationship.rb
+++ b/app/models/camaleon_cms/custom_fields_relationship.rb
@@ -1,5 +1,7 @@
 module CamaleonCms
   class CustomFieldsRelationship < CamaleonRecord
+    include CamaleonCms::ContentShortcodeGate
+
     self.table_name = "#{PluginRoutes.static_system_info['db_prefix']}custom_fields_relationships"
 
     # attr_accessible :objectid, :custom_field_id, :term_order, :value, :object_class,
@@ -24,6 +26,11 @@ module CamaleonCms
     GATED_FIELD_KEYS = (MARKUP_FIELD_KEYS + JSON_MARKUP_FIELD_KEYS + URI_FIELD_KEYS).freeze
 
     validate :reject_untrusted_dangerous_value
+    # Any custom-field value is expanded by do_shortcode at render (CustomFieldsConcern#the_field
+    # and friends), regardless of field type, so gate a shortcode in ANY value behind
+    # content_shortcodes -- broader than the HTML gate above, which only covers markup/URI field
+    # types.
+    gate_content_shortcodes :value
 
     after_save :set_parent_slug
     after_save :update_model_owner # TODO: convert this model into polymorphic

--- a/app/models/camaleon_cms/post.rb
+++ b/app/models/camaleon_cms/post.rb
@@ -1,6 +1,7 @@
 module CamaleonCms
   class Post < CamaleonCms::PostDefault
     include CamaleonCms::CategoriesTagsForPosts
+    include CamaleonCms::ContentShortcodeGate
 
     # Structural, non-executable markup that long-form post content legitimately uses but the
     # sanitizer default drops. Superset of the default so upstream security additions are inherited.
@@ -39,6 +40,9 @@ module CamaleonCms
     default_scope -> { where(post_class: 'Post').order(post_order: :asc, created_at: :desc) }
 
     validate :reject_untrusted_dangerous_content, on: %i[create update]
+    # Shortcodes in post content are expanded by do_shortcode at render (PostDecorator#the_content),
+    # an end-run around post_content_unfiltered_html; gate authorship behind content_shortcodes.
+    gate_content_shortcodes :content
 
     # DEPRECATED
     has_many :post_relationships, class_name: 'CamaleonCms::PostRelationship', foreign_key: :objectid,

--- a/app/models/camaleon_cms/term_taxonomy.rb
+++ b/app/models/camaleon_cms/term_taxonomy.rb
@@ -2,6 +2,7 @@ module CamaleonCms
   class TermTaxonomy < CamaleonRecord
     include CamaleonCms::Metas
     include CamaleonCms::CustomFieldsRead
+    include CamaleonCms::ContentShortcodeGate
 
     extend CamaleonCms::NormalizeAttrs
 
@@ -72,6 +73,11 @@ module CamaleonCms
     # validates
     validates :name, :taxonomy, presence: true
     validates_with CamaleonCms::UniqValidator
+    # A taxonomy/widget description is expanded by do_shortcode at render
+    # (TermTaxonomyDecorator#the_content, shortcode_templates/widget.html.erb); STI-covers every
+    # subclass (post types, categories, tags, widgets, sidebars). Gate authorship behind
+    # content_shortcodes -- benign descriptions pass without ever building an Ability.
+    gate_content_shortcodes :description
 
     # relations
     has_many :term_relationships, class_name: 'CamaleonCms::TermRelationship',

--- a/app/models/camaleon_cms/user_role.rb
+++ b/app/models/camaleon_cms/user_role.rb
@@ -199,6 +199,21 @@ module CamaleonCms
                      'active content there. Site-wide, unlike the per-post-type "Allow unfiltered HTML in post ' \
                      'content" permission.'
           ).to_s
+        },
+        {
+          key: 'content_shortcodes',
+          label: I18n.t('camaleon_cms.admin.users.roles_values.content_shortcodes',
+                        default: 'Allow shortcodes in content').to_s,
+          color: 'danger',
+          description: I18n.t(
+            'camaleon_cms.admin.users.tool_tip.content_shortcodes',
+            default: 'Permit users with this role to publish shortcodes in content that the CMS expands at ' \
+                     'render: post content, custom-field values, taxonomy content and widget descriptions. A ' \
+                     'shortcode makes theme/plugin code emit arbitrary HTML/JS on the page, which the ' \
+                     'content scan cannot judge. Without it, a save carrying a registered shortcode is refused ' \
+                     'rather than cleaned up. Site-wide, and an end-run around the per-post-type "Allow ' \
+                     'unfiltered HTML in post content" permission.'
+          ).to_s
         }
       ]
     }.freeze

--- a/app/models/concerns/camaleon_cms/content_shortcode_gate.rb
+++ b/app/models/concerns/camaleon_cms/content_shortcode_gate.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  # Save-time authorization gate for authored content that `do_shortcode` later expands (post
+  # content, custom-field values, taxonomy/widget descriptions). A registered shortcode makes
+  # theme/plugin code emit arbitrary HTML/JS at render, which the content scan cannot judge, so
+  # authorship is GATED behind the default-off `content_shortcodes` manager permission rather than
+  # filtered. The content is never escaped, stripped or rewritten -- a save carrying a shortcode is
+  # refused for an untrusted author, and stored verbatim for a trusted one.
+  #
+  # Conforms to `security-capability-gating` (fail-closed) and the content-shortcode-gating
+  # capability. A model gates an attribute with `gate_content_shortcodes :attr`; a newly added
+  # surface that `do_shortcode` expands MUST adopt this gate (asserted by the coverage spec).
+  module ContentShortcodeGate
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # Gate the named attribute(s) on create/update. Each attribute is scanned in its RAW stored
+      # form -- which contains every locale of a translatable value at once, so a shortcode in any
+      # locale is caught -- and, if a registered shortcode is present and the actor is a
+      # non-administrator lacking `content_shortcodes`, the save is refused with a base error.
+      def gate_content_shortcodes(*attributes, on: %i[create update])
+        gated = attributes.map(&:to_sym)
+        validate(on: on) { cama_reject_unauthorized_shortcodes(gated) }
+      end
+    end
+
+    private
+
+    def cama_reject_unauthorized_shortcodes(attributes)
+      return unless attributes.any? { |attr| cama_shortcode_attr_gated?(attr) }
+      return if cama_trusted_for_shortcodes?
+
+      errors.add(:base, cama_shortcode_rejection_message)
+    end
+
+    # An attribute needs the gate only when it (a) changed on this save (or the record is new) -- so
+    # a title-only edit never re-gates pre-existing shortcode content, mirroring
+    # Post#reject_untrusted_dangerous_content -- and (b) actually contains a registered shortcode.
+    def cama_shortcode_attr_gated?(attr)
+      return false unless new_record? || cama_gate_attribute_changed?(attr)
+
+      value = self[attr]
+      value.present? && CamaleonCms::ShortcodeRegistry.content_has_shortcode?(value.to_s)
+    end
+
+    def cama_gate_attribute_changed?(attr)
+      respond_to?("#{attr}_changed?") ? public_send("#{attr}_changed?") : attribute_changed?(attr.to_s)
+    end
+
+    # Fail closed (the gate applies) without a request context or on any evaluation error, per
+    # security-capability-gating: a background job, rake task or console is untrusted. Administrators
+    # always pass; a non-administrator passes only while holding the `content_shortcodes` manager
+    # permission.
+    def cama_trusted_for_shortcodes?
+      user = CurrentRequest.user
+      site = CurrentRequest.site
+      return false if user.blank? || site.blank?
+      return true if user.admin?
+
+      CamaleonCms::Ability.new(user, site).can?(:manage, :content_shortcodes)
+    rescue StandardError
+      false
+    end
+
+    # Only en.yml carries this key while the process locale follows the current admin/site language
+    # -- fall back to English rather than emit "translation missing".
+    def cama_shortcode_rejection_message
+      key = 'camaleon_cms.admin.shortcodes.message.rejected'
+      I18n.t(key, default: I18n.t(key, locale: :en))
+    end
+  end
+end

--- a/config/locales/camaleon_cms/admin/en.yml
+++ b/config/locales/camaleon_cms/admin/en.yml
@@ -287,6 +287,9 @@ en:
         new_site: 'New Site'
         edit_site: 'Edit Site'
         update: 'Update'
+      shortcodes:
+        message:
+          rejected: "This content contains a shortcode that your role is not allowed to publish. Remove the shortcode, or ask an administrator for the shortcode-content permission."
       post:
         add_tag: 'Add a Tag'
         clone: 'Clone'

--- a/lib/camaleon_cms.rb
+++ b/lib/camaleon_cms.rb
@@ -11,6 +11,18 @@ require 'camaleon_cms/uploader_image_processing'
 require 'camaleon_cms/uploader_support'
 require 'camaleon_cms/captcha_image_generation'
 require 'camaleon_cms/task_reporter'
+require 'camaleon_cms/shortcode_registry'
 
 module CamaleonCms
+end
+
+# Declare core's bundled shortcode names through the boot DSL, then mark the registry available. This
+# runs at require time (before any request), so the save-time shortcode gate can detect shortcodes
+# with no frontend request. If this ever raises the registry stays unavailable and the gate fails
+# closed (non-administrators are refused) rather than fail open on an empty set.
+begin
+  CamaleonCms::ShortcodeRegistry.register(*CamaleonCms::ShortcodeRegistry::CORE_SHORTCODES)
+  CamaleonCms::ShortcodeRegistry.mark_available!
+rescue StandardError => e
+  warn("CamaleonCms::ShortcodeRegistry boot registration failed (gate fails closed): #{e.message}")
 end

--- a/lib/camaleon_cms/shortcode_registry.rb
+++ b/lib/camaleon_cms/shortcode_registry.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+module CamaleonCms
+  # Process-wide, boot-time registry of shortcode NAMES. It exists so that save-time code can detect
+  # shortcodes without a frontend request: the per-request `CurrentRequest.shortcodes` list is
+  # populated by the active frontend theme's `front_before_load` hook and is therefore empty in the
+  # admin save path, so the save-time gate consults this canonical set instead.
+  #
+  # Providers declare their shortcode names through the `register` DSL at boot. Declarations run with
+  # NO request/site context, so a declaration MUST NOT touch `current_site`/`request` -- only the
+  # names move here; the render-time handler stays in `shortcode_add`. Core declares its own bundled
+  # names (see CORE_SHORTCODES); a theme/plugin gem declares its names from its own boot (an
+  # initializer or engine), e.g. `CamaleonCms::ShortcodeRegistry.register('redirect')`.
+  #
+  # Detection mirrors the engine's `ShortCodeHelper#cama_reg_shortcode` regex shape, sourced from
+  # this registry rather than `CurrentRequest`, so a name is a match only when followed by a space +
+  # attributes or an immediate "]" -- bracketed prose that is not a registered name is never treated
+  # as a shortcode.
+  #
+  # Fail-closed (design D4): an "unavailable" registry -- boot never completed registration -- treats
+  # any non-blank content as gated, so a non-administrator is refused rather than let through on an
+  # empty set. A legitimately empty registry (available, but no provider declared any name) is a
+  # distinct, non-error state that gates nothing.
+  class ShortcodeRegistry
+    # Core-bundled shortcode names, declared through the DSL at boot. Mirrors the shortcodes that
+    # `ShortCodeHelper#shortcodes_init` adds per request; the two are kept in sync by hand (unifying
+    # the boot DSL with the render-time `shortcode_add` registration is a deliberate non-goal -- see
+    # the gate-content-shortcodes design).
+    CORE_SHORTCODES = %w[widget load_libraries asset data].freeze
+
+    class << self
+      # Boot-time DSL: declare one or more shortcode names. Request-independent, idempotent, and
+      # order-independent. Blank names are ignored.
+      def register(*names)
+        names.flatten.each do |name|
+          name = name.to_s.strip
+          registered_names << name unless name.empty?
+        end
+        @regexp = nil
+        self
+      end
+
+      # Mark the registry as successfully built at boot. Called once registration has completed; if
+      # boot raises before this point the registry stays unavailable and detection fails closed.
+      def mark_available!
+        @available = true
+        self
+      end
+
+      def available?
+        @available == true
+      end
+
+      # Frozen snapshot of the registered names.
+      def names
+        registered_names.dup.freeze
+      end
+
+      # Whether `content` contains a registered shortcode. Fails closed when the registry is
+      # unavailable (any non-blank content is treated as gated); a legitimately empty registry
+      # matches nothing.
+      def content_has_shortcode?(content)
+        content = content.to_s
+        return false if content.empty?
+        return true unless available?
+
+        matcher = regexp
+        return false if matcher.nil?
+
+        matcher.match?(content)
+      end
+
+      # Test-only: reset to the unavailable/empty baseline.
+      def reset!
+        @registered_names = nil
+        @regexp = nil
+        @available = false
+        self
+      end
+
+      private
+
+      def registered_names
+        @registered_names ||= Set.new
+      end
+
+      # Mirrors ShortCodeHelper#cama_reg_shortcode: "(\\[(a|b)((\s)((?!\\]).)*|)\\])". In that source
+      # the "\s" is a literal space (a double-quoted-string escape, not the regex whitespace class),
+      # so a code matches only when followed by a literal space + attributes, or an immediate "]".
+      # Names are regex-escaped and ordered longest-first so a name that is a prefix of another
+      # (e.g. media / media_gallery) still matches its own token.
+      def regexp
+        return nil if registered_names.empty?
+
+        @regexp ||= begin
+          codes = registered_names.sort_by { |name| -name.length }.map { |name| Regexp.escape(name) }.join('|')
+          Regexp.new("(\\[(#{codes})((\s)((?!\\]).)*|)\\])")
+        end
+      end
+    end
+  end
+end

--- a/openspec/changes/archive/2026-08-23-gate-content-shortcodes/.openspec.yaml
+++ b/openspec/changes/archive/2026-08-23-gate-content-shortcodes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-23

--- a/openspec/changes/archive/2026-08-23-gate-content-shortcodes/design.md
+++ b/openspec/changes/archive/2026-08-23-gate-content-shortcodes/design.md
@@ -1,0 +1,46 @@
+## Context
+
+See proposal.md — Why. The blocker for a save-time gate is detection: the shortcode-name registry (`CurrentRequest.shortcodes`, read by `cama_reg_shortcode`) is populated per request by the active frontend theme's `front_before_load` hook, so it is empty in the admin save path, and shortcode names are added imperatively via `shortcode_add` — nowhere enumerable at boot. Model-level `can?` is already available: `check_select_eval_authorization` (`custom_field.rb`) calls `can?(:manage, :select_eval)` in a model callback. `do_shortcode` is called from several authored surfaces — `post_decorator` (post content), `custom_fields_concern` (field values), `term_taxonomy_decorator` (taxonomy content), and the widget template (widget descriptions).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Precise save-time detection (only real, registered shortcodes — no false positives on bracketed text).
+- Reject a non-administrator's save of shortcode-bearing content on **every** surface `do_shortcode` expands, unless the actor holds `content_shortcodes`.
+- Leave stored content and all rendering untouched.
+
+**Non-Goals:**
+- No change to how shortcodes expand at render; no content sanitization anywhere.
+- Not unifying the render-time `shortcode_add` template registration with the new boot DSL (the DSL declares names; converging the two is a possible later refactor).
+
+## Decisions
+
+### D1 — A boot-time shortcode registration DSL feeding a canonical registry
+Core exposes a registration DSL that runs at boot (not per request, not `config.json`): shortcode providers declare their shortcode names through it, and the CMS aggregates them into a process-wide canonical set (e.g. `CamaleonCms::ShortcodeRegistry`). Core declares its own bundled shortcodes through the same DSL. Save-time detection builds its match regex from this registry (the `cama_reg_shortcode` shape, sourced from the registry rather than `CurrentRequest`).
+
+*Alternatives considered:* (a) `config.json` `"shortcodes"` array — pure data, but the maintainer chose a code DSL for flexibility; (b) generic `[name …]` detector — rejected: false positives; (c) accumulate names from runtime `shortcode_add` — rejected: cold-start fail-open. **Constraint the DSL imposes:** declarations run at boot with no request/site context, so a provider's declaration must not depend on `current_site`/`request`. Where a provider today computes shortcode names dynamically in a front hook, only the *names* need to move to the boot DSL; the render-time handler can stay in `shortcode_add`.
+
+### D2 — Gate at every authored-content save that feeds do_shortcode
+Apply the same check at each surface's save path — post content (`Post`), custom-field values (the field-value save path), taxonomy content (`TermTaxonomy`/post-type/category/tag), and widget descriptions (the appearances/widgets save path). Factor the logic into a shared detector + authorization check (a concern/mixin or a shared service) rather than duplicating it, so the surfaces stay consistent and adding a surface is one call. Each check mirrors `check_select_eval_authorization`: if the registry-backed detector finds a shortcode in the content of any stored locale and the actor is a non-administrator lacking `content_shortcodes`, add a base error and abort. **A missed surface is a fail-open bypass**, so the task list enumerates the `do_shortcode` call sites and gates each; a test asserts the current known set is covered.
+
+### D3 — `content_shortcodes` permission per security-capability-gating
+Define the permission alongside the existing gated permissions in the `Ability` model and the admin roles UI toggle: default-off, seeded on no role, admin-bypass via `can :manage, :all`, absent key reads not-granted (no migration), fail-closed.
+
+### D4 — Fail-closed on unavailable registry / unevaluable permission
+If the registry cannot be built (boot error) it MUST NOT silently become empty (fail-open). An error-unavailable registry, an absent authorization context, or an evaluation failure resolves to gated/not-granted for non-administrators (block). A legitimately empty registry (no provider declared shortcodes) is a distinct, non-error state.
+
+### D5 — Remove any pre-existing shortcode escaping/sanitizing (audit — core + ecosystem)
+Because the remedy is the gate, no escape/sanitize should be applied to shortcodes on save or render. **Audit at proposal time (2026-08-23): none found in core or the cloned ecosystem.** Core: the shortcode engine (`short_code_helper.rb`), `_shortcode_parse_attr`, the `shortcode_templates/` views (`widget.html.erb` uses `raw`), and every `do_shortcode` call site are verbatim; the post-content save path is reject-based (`reject_untrusted_dangerous_content`), not shortcode sanitizing; bundled plugins/themes register no shortcodes. Ecosystem: the four active shortcode providers — `cama_contact_form` (`forms`, view-rendered), `cama_image_lightbox` (`lightbox`), `cama-stripe-donation` (`stripe_donation`, view-rendered), `camaleon-download` (`download`) — apply no escaping/sanitizing; the two with shortcode-XSS (`camaleon-download` DL-1, `cama_image_lightbox` LB-1) interpolate attrs **raw**, so there is nothing to remove and the gate is what closes them. The only escaping ever added anywhere was the theme-level `escape_javascript` in texpert/camaleon_website#758, already reverted. Apply must **re-audit** core and ecosystem (the trees may change before implementation) and remove any shortcode-specific escaping/sanitizing found — but only where this gate covers the threat it guarded; anything the gate does not cover is recorded, not silently dropped (removing a security escape without equivalent coverage would re-open the vuln).
+
+## Risks / Trade-offs
+
+- **A `do_shortcode` surface is missed → fail-open on that surface.** → Enumerate all call sites (post content, field values, taxonomy content, widget descriptions today) and gate each behind the shared check; add a coverage test; document that new expanded surfaces must adopt the check.
+- **Third-party shortcodes not declared through the DSL aren't detected → fail-open for them.** → Core declares its bundled shortcodes; document the DSL for providers. Concrete ecosystem providers that must adopt the DSL to be gated: `cama_contact_form` (`forms`), `cama_image_lightbox` (`lightbox`), `cama-stripe-donation` (`stripe_donation`), `camaleon-download` (`download`); plus camaleon_website's `camaleon_cms` theme (`redirect`, `bootstrap_slider`). Declaring `download` and `lightbox` is what actually closes DL-1/LB-1 through the gate. These are per-repo follow-ups (separate repos — never pushed without direction; see `docs/ai/ecosystem.md`), enabled by the core mechanism, not part of this change's implementation.
+- **DSL declarations that reach for request/site context at boot will fail.** → Document the request-independence constraint; only names move to the DSL.
+- **Regex over content on every gated save / multi-locale.** → Negligible; one anchored scan from a bounded name set, over each stored locale, on create/update only.
+
+## Migration Plan
+
+- `content_shortcodes` is default-off and seeded on no role → existing installs read it as not-granted with no data migration; grant it to roles that author shortcodes.
+- Declare core's bundled shortcode names through the boot DSL.
+- Rollback: removing the permission + the shared check disables the gate; no stored data changed.

--- a/openspec/changes/archive/2026-08-23-gate-content-shortcodes/proposal.md
+++ b/openspec/changes/archive/2026-08-23-gate-content-shortcodes/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Shortcodes in authored content trigger theme/plugin code that emits arbitrary HTML/JS at render. The save-time content scan (`CamaleonCms::UnsafeMarkup`, which enforces `post_content_unfiltered_html`) cannot reach a verdict on a shortcode: the shortcode-name registry is populated per request by the active *frontend* theme, so it isn't available at an admin save; shortcode output is dynamic; and after expansion, trusted theme-emitted markup is indistinguishable from author input. So an author who lacks `post_content_unfiltered_html` can still emit a `<script>` through a shortcode — e.g. `[redirect url="';alert(document.cookie);//"]` expands to `<script>window.location.href='…'</script>` for every viewer (audit finding WEB-2). Shortcodes are an end-run around the `post_content_unfiltered_html` gate. Because no scan can judge them, the sanctioned remedy under `security-capability-gating` is a default-off permission — not a scan, and not render-time escaping.
+
+Shortcodes are expanded on more than post bodies: `do_shortcode` also runs over custom-field values, taxonomy content, and widget descriptions. The gate must cover every authored surface that is later expanded, or the bypass simply moves to an ungated surface.
+
+## What Changes
+
+- Add a dedicated, default-off role permission `content_shortcodes`.
+- Introduce a **boot-time shortcode registration DSL** so the set of registered shortcode names is known outside a frontend request (the per-request frontend registry is unavailable at save). This is what makes *precise* save-time detection possible.
+- On save of any authored content that will be expanded by `do_shortcode` — post content, custom-field values, taxonomy content, and widget descriptions — if the content contains a registered shortcode and the acting user is a non-administrator lacking `content_shortcodes`, the save is **rejected** with an error naming the reason (mirroring `check_select_eval_authorization`).
+- **BREAKING**: a non-administrator role without `content_shortcodes` can no longer publish shortcode-bearing content on any gated surface. Grant the permission to roles that need it. Administrators are unaffected (`can :manage, :all`).
+- Rendering is **unchanged**: stored content stays verbatim and no escape or sanitize is applied on render for anyone. Trusted authors' shortcodes render raw exactly as today.
+- Supersedes the theme-level `escape_javascript` fix (texpert/camaleon_website#758, closed): under reject-don't-sanitize we gate the capability rather than escape trusted content.
+
+## Capabilities
+
+### New Capabilities
+
+- `content-shortcode-gating`: authoring shortcodes in any surface that `do_shortcode` expands (post content, custom-field values, taxonomy content, widget descriptions) is permitted for a non-administrator role only through the default-off `content_shortcodes` permission, enforced by a save-time rejection, with administrators bypassing. Includes a boot-time shortcode-name registry (a registration DSL) that makes precise save-time detection possible. Conforms to and cites `security-capability-gating`.
+
+### Modified Capabilities
+
+- None. `security-capability-gating` is cited and conformed to, not changed — this adds a new conformant instance.
+
+## Impact
+
+- New default-off role permission `content_shortcodes` in the `Ability`/role model and the admin roles UI toggle, mirroring the existing gated permissions.
+- New boot-time shortcode registration DSL + a process-wide canonical shortcode-name registry (replaces reliance on the per-request frontend registry for detection).
+- A save-time authorization check applied at every authored-content save path that feeds `do_shortcode`: post content, custom-field values, taxonomy content, and widget descriptions — factored into a shared detector + check rather than duplicated per model.
+- No change to stored content, to the content scan, or to rendering.

--- a/openspec/changes/archive/2026-08-23-gate-content-shortcodes/specs/content-shortcode-gating/spec.md
+++ b/openspec/changes/archive/2026-08-23-gate-content-shortcodes/specs/content-shortcode-gating/spec.md
@@ -1,0 +1,82 @@
+## Purpose
+
+Authoring shortcodes in content that the CMS later expands is a privileged capability: a shortcode makes theme/plugin code emit arbitrary HTML/JS at render, which the save-time content scan cannot judge. This capability gates it behind a default-off `content_shortcodes` permission across every authored surface that `do_shortcode` expands (post content, custom-field values, taxonomy content, widget descriptions), closing the shortcode end-run around `post_content_unfiltered_html`.
+
+## ADDED Requirements
+
+### Requirement: Publishing content with shortcodes requires the content_shortcodes permission
+
+Saving authored content that will be expanded by `do_shortcode` — post content, custom-field values, taxonomy content, or widget descriptions — and that contains one or more registered shortcodes SHALL be permitted for a non-administrator role only when that role holds the `content_shortcodes` permission. When the acting user is neither an administrator nor a holder of the permission, the save SHALL be rejected with a validation error that names the reason, and the content SHALL NOT be persisted. Content that contains no registered shortcode SHALL be unaffected by this gate.
+
+#### Scenario: A non-administrator without the permission is refused
+
+- **WHEN** a non-administrator role that does not hold `content_shortcodes` saves post content containing a registered shortcode
+- **THEN** the save SHALL be rejected with an error naming the reason
+- **AND** the content SHALL NOT be persisted
+
+#### Scenario: The gate covers every expanded surface
+
+- **WHEN** a non-administrator without `content_shortcodes` saves a registered shortcode into a custom-field value, taxonomy content, or a widget description
+- **THEN** that save SHALL be rejected the same way as post content
+
+#### Scenario: A non-administrator with the permission is allowed
+
+- **WHEN** a non-administrator role that holds `content_shortcodes` saves content containing a registered shortcode
+- **THEN** the save SHALL succeed
+
+#### Scenario: An administrator is allowed
+
+- **WHEN** an administrator saves content containing a registered shortcode
+- **THEN** the save SHALL succeed without the permission being present in any role meta
+
+#### Scenario: Content without a registered shortcode is unaffected
+
+- **WHEN** any user saves content that contains no registered shortcode (including bracketed prose such as `[note]` or `[text]`)
+- **THEN** the save SHALL NOT be gated by `content_shortcodes`
+
+### Requirement: Registered shortcode names are known at save time
+
+The set of registered shortcode names SHALL be available in the save path without a frontend request. Shortcode providers SHALL declare their shortcode names through a boot-time registration mechanism, and the CMS SHALL aggregate them into a canonical registry that save-time detection consults. Detection SHALL match only names present in this registry, so bracketed text that is not a registered shortcode is never treated as one.
+
+#### Scenario: Detection matches a registered name but not arbitrary brackets
+
+- **WHEN** the registry contains the name `redirect` and content contains `[redirect url="…"]` as well as unrelated bracketed text `[see figure]`
+- **THEN** detection SHALL flag the content as containing a shortcode on account of `redirect`
+- **AND** unrelated bracketed text alone SHALL NOT be treated as a shortcode
+
+### Requirement: The content_shortcodes permission conforms to security-capability-gating
+
+The `content_shortcodes` permission SHALL be default-off and SHALL follow `security-capability-gating`: seeded onto no role; an administrator satisfies the check through `can :manage, :all` without the key present; an installation whose stored role meta predates the permission reads the absent key as not-granted without a migration; and the gate fails closed — an absent authorization context, a failure while evaluating the permission, or an unavailable shortcode registry SHALL resolve to not-granted / gated, and the save SHALL be refused for a non-administrator.
+
+#### Scenario: An upgraded installation reads the absent key as not-granted
+
+- **WHEN** a role whose stored permission meta predates `content_shortcodes` is evaluated
+- **THEN** the permission SHALL read as not-granted with no migration required
+
+#### Scenario: The gate fails closed
+
+- **WHEN** the permission cannot be evaluated, or the shortcode registry is unavailable due to error
+- **THEN** the gate SHALL resolve to not-granted / gated, and a non-administrator's save of shortcode-bearing content SHALL be refused
+
+### Requirement: Stored content and rendering are unchanged by the gate
+
+The gate SHALL act only as a save-time authorization decision. It SHALL NOT alter, escape, strip, or sanitize stored content, and it SHALL NOT change how shortcodes are expanded or rendered. Content that was permitted — authored by an administrator or a permission-holder — SHALL be stored and rendered verbatim, exactly as before this capability.
+
+#### Scenario: Permitted shortcode content renders verbatim
+
+- **WHEN** a permitted author's content containing a shortcode is rendered
+- **THEN** the shortcode SHALL expand exactly as it did before this capability, with no added escaping or sanitization of the stored content
+
+### Requirement: Shortcodes are neither escaped nor sanitized
+
+Because authorship is gated rather than filtered, the CMS SHALL NOT escape, sanitize, strip, or otherwise transform shortcode syntax, shortcode attributes, or shortcode output — neither when content is saved/updated nor when it is expanded at render. Any pre-existing escaping or sanitizing applied specifically to shortcodes SHALL be removed, provided the authorization gate covers the threat it addressed; any instance the gate does not cover SHALL be recorded rather than silently removed. The `content_shortcodes` authorization check SHALL be the only save-time control specific to shortcodes.
+
+#### Scenario: Shortcode output is emitted verbatim
+
+- **WHEN** a permitted author's shortcode is expanded at render
+- **THEN** the shortcode's syntax, attributes, and output SHALL appear exactly as the theme/plugin emits them, with no escaping or sanitizing applied by the CMS
+
+#### Scenario: No shortcode-specific escaping remains on save or render
+
+- **WHEN** the save/update and render paths are audited for escaping or sanitizing applied specifically to shortcodes
+- **THEN** none SHALL remain, except any instance explicitly recorded as guarding a threat the authorization gate does not cover

--- a/openspec/changes/archive/2026-08-23-gate-content-shortcodes/tasks.md
+++ b/openspec/changes/archive/2026-08-23-gate-content-shortcodes/tasks.md
@@ -1,0 +1,41 @@
+## 1. Permission (security-capability-gating conformance)
+
+- [x] 1.1 Add `content_shortcodes` to the `CamaleonCms::Ability` permission set alongside `post_content_unfiltered_html` / `select_eval` / `media_unfiltered_upload` / `contact_form_unfiltered_html` — default-off, seeded on no role, administrators satisfied via `can :manage, :all`.
+- [x] 1.2 Expose the permission as a toggle in the admin roles UI, mirroring the existing gated permissions.
+- [x] 1.3 Confirm an absent key reads as not-granted (no migration) and the check fails closed (no ability/context or evaluation error => not-granted).
+
+## 2. Boot-time shortcode registration DSL + canonical registry
+
+- [x] 2.1 Add a boot-time registration DSL (e.g. `CamaleonCms::ShortcodeRegistry`) that shortcode providers call to declare their shortcode names, running with no request/site context; aggregate declarations into a process-wide canonical set.
+- [x] 2.2 Declare core's bundled shortcode names through the DSL; document the DSL and the request-independence constraint for theme/plugin authors.
+- [x] 2.3 Provide a registry-backed detector (regex built from the canonical set, matching the `cama_reg_shortcode` shape but sourced from the registry) that reports whether a content string contains a registered shortcode.
+- [x] 2.4 Fail closed: distinguish a legitimately empty registry from an error-unavailable one; on the error case, treat content as gated for non-administrators.
+
+## 3. Save-time gate across every expanded surface
+
+- [x] 3.1 Factor the check into a shared detector + authorization helper (concern/mixin or service) that runs the registry-backed detector over every stored locale/translation of the content and refuses when the actor is a non-administrator lacking `content_shortcodes`.
+- [x] 3.2 Apply it at each authored-content save path that feeds `do_shortcode`: post content (`Post`), custom-field values, taxonomy content (`TermTaxonomy` / post-type / category / tag), and widget descriptions (appearances/widgets).
+- [x] 3.3 Enumerate the current `do_shortcode` call sites and add a coverage test asserting each authored surface is gated, so a newly added surface is caught.
+- [x] 3.4 Re-audit the save/update and render paths for escaping/sanitizing applied specifically to shortcodes (none in core at proposal time; the theme-level `escape_javascript` in #758 is reverted). Remove any found where this gate covers the threat it guarded; record — do not silently remove — any instance the gate does not cover.
+
+## 4. Tests (reproducing specs, red-first)
+
+- [x] 4.1 A non-administrator without `content_shortcodes` saving shortcode-bearing post content is rejected and nothing is persisted.
+- [x] 4.2 The same rejection holds for a custom-field value, taxonomy content, and a widget description.
+- [x] 4.3 A non-administrator granted `content_shortcodes` succeeds on those surfaces; an administrator succeeds without the key in role meta.
+- [x] 4.4 Content with no registered shortcode (including bracketed prose / `[text]`) is not gated (precise detection, no false positives).
+- [x] 4.5 Upgraded install (role meta predating the key) reads not-granted with no migration; fail-closed paths (unevaluable permission, error-unavailable registry) resolve to gated.
+- [x] 4.6 A permitted author's stored shortcode content still renders/expands verbatim (no added escaping or sanitization).
+- [x] 4.7 A permitted author's shortcode output renders byte-for-byte verbatim — no CMS escaping/sanitizing of the shortcode syntax, attributes, or output on save or render.
+
+## 5. Docs, changelog, OpenSpec
+
+- [x] 5.1 Changelog entry (short, PR-linked) with a Breaking-changes note: non-admin roles without `content_shortcodes` can no longer publish shortcode content on any expanded surface; grant the permission; shortcode providers must declare names through the boot DSL to be gated. Draft upgrader notes under **Notes for upgraders**.
+- [x] 5.2 Optionally add `content_shortcodes` to the conformant-examples list in `openspec/specs/security-capability-gating/spec.md`.
+- [x] 5.3 Archive this OpenSpec change on the branch before merge (`/opsx:archive`), committed as part of the PR.
+
+## 6. CI parity (before push)
+
+- [x] 6.1 `bin/rspec` green (new specs + full suite).
+- [x] 6.2 `bin/rubocop` clean on touched files; `bin/brakeman` no new warnings.
+- [x] 6.3 `(cd spec/dummy && bin/rails zeitwerk:check)` passes.

--- a/openspec/specs/content-shortcode-gating/spec.md
+++ b/openspec/specs/content-shortcode-gating/spec.md
@@ -1,0 +1,82 @@
+# content-shortcode-gating Specification
+
+## Purpose
+Authoring shortcodes in content that the CMS later expands is a privileged capability: a shortcode makes theme/plugin code emit arbitrary HTML/JS at render, which the save-time content scan cannot judge. This capability gates it behind a default-off `content_shortcodes` permission across every authored surface that `do_shortcode` expands (post content, custom-field values, taxonomy content, widget descriptions), closing the shortcode end-run around `post_content_unfiltered_html`.
+## Requirements
+### Requirement: Publishing content with shortcodes requires the content_shortcodes permission
+
+Saving authored content that will be expanded by `do_shortcode` — post content, custom-field values, taxonomy content, or widget descriptions — and that contains one or more registered shortcodes SHALL be permitted for a non-administrator role only when that role holds the `content_shortcodes` permission. When the acting user is neither an administrator nor a holder of the permission, the save SHALL be rejected with a validation error that names the reason, and the content SHALL NOT be persisted. Content that contains no registered shortcode SHALL be unaffected by this gate.
+
+#### Scenario: A non-administrator without the permission is refused
+
+- **WHEN** a non-administrator role that does not hold `content_shortcodes` saves post content containing a registered shortcode
+- **THEN** the save SHALL be rejected with an error naming the reason
+- **AND** the content SHALL NOT be persisted
+
+#### Scenario: The gate covers every expanded surface
+
+- **WHEN** a non-administrator without `content_shortcodes` saves a registered shortcode into a custom-field value, taxonomy content, or a widget description
+- **THEN** that save SHALL be rejected the same way as post content
+
+#### Scenario: A non-administrator with the permission is allowed
+
+- **WHEN** a non-administrator role that holds `content_shortcodes` saves content containing a registered shortcode
+- **THEN** the save SHALL succeed
+
+#### Scenario: An administrator is allowed
+
+- **WHEN** an administrator saves content containing a registered shortcode
+- **THEN** the save SHALL succeed without the permission being present in any role meta
+
+#### Scenario: Content without a registered shortcode is unaffected
+
+- **WHEN** any user saves content that contains no registered shortcode (including bracketed prose such as `[note]` or `[text]`)
+- **THEN** the save SHALL NOT be gated by `content_shortcodes`
+
+### Requirement: Registered shortcode names are known at save time
+
+The set of registered shortcode names SHALL be available in the save path without a frontend request. Shortcode providers SHALL declare their shortcode names through a boot-time registration mechanism, and the CMS SHALL aggregate them into a canonical registry that save-time detection consults. Detection SHALL match only names present in this registry, so bracketed text that is not a registered shortcode is never treated as one.
+
+#### Scenario: Detection matches a registered name but not arbitrary brackets
+
+- **WHEN** the registry contains the name `redirect` and content contains `[redirect url="…"]` as well as unrelated bracketed text `[see figure]`
+- **THEN** detection SHALL flag the content as containing a shortcode on account of `redirect`
+- **AND** unrelated bracketed text alone SHALL NOT be treated as a shortcode
+
+### Requirement: The content_shortcodes permission conforms to security-capability-gating
+
+The `content_shortcodes` permission SHALL be default-off and SHALL follow `security-capability-gating`: seeded onto no role; an administrator satisfies the check through `can :manage, :all` without the key present; an installation whose stored role meta predates the permission reads the absent key as not-granted without a migration; and the gate fails closed — an absent authorization context, a failure while evaluating the permission, or an unavailable shortcode registry SHALL resolve to not-granted / gated, and the save SHALL be refused for a non-administrator.
+
+#### Scenario: An upgraded installation reads the absent key as not-granted
+
+- **WHEN** a role whose stored permission meta predates `content_shortcodes` is evaluated
+- **THEN** the permission SHALL read as not-granted with no migration required
+
+#### Scenario: The gate fails closed
+
+- **WHEN** the permission cannot be evaluated, or the shortcode registry is unavailable due to error
+- **THEN** the gate SHALL resolve to not-granted / gated, and a non-administrator's save of shortcode-bearing content SHALL be refused
+
+### Requirement: Stored content and rendering are unchanged by the gate
+
+The gate SHALL act only as a save-time authorization decision. It SHALL NOT alter, escape, strip, or sanitize stored content, and it SHALL NOT change how shortcodes are expanded or rendered. Content that was permitted — authored by an administrator or a permission-holder — SHALL be stored and rendered verbatim, exactly as before this capability.
+
+#### Scenario: Permitted shortcode content renders verbatim
+
+- **WHEN** a permitted author's content containing a shortcode is rendered
+- **THEN** the shortcode SHALL expand exactly as it did before this capability, with no added escaping or sanitization of the stored content
+
+### Requirement: Shortcodes are neither escaped nor sanitized
+
+Because authorship is gated rather than filtered, the CMS SHALL NOT escape, sanitize, strip, or otherwise transform shortcode syntax, shortcode attributes, or shortcode output — neither when content is saved/updated nor when it is expanded at render. Any pre-existing escaping or sanitizing applied specifically to shortcodes SHALL be removed, provided the authorization gate covers the threat it addressed; any instance the gate does not cover SHALL be recorded rather than silently removed. The `content_shortcodes` authorization check SHALL be the only save-time control specific to shortcodes.
+
+#### Scenario: Shortcode output is emitted verbatim
+
+- **WHEN** a permitted author's shortcode is expanded at render
+- **THEN** the shortcode's syntax, attributes, and output SHALL appear exactly as the theme/plugin emits them, with no escaping or sanitizing applied by the CMS
+
+#### Scenario: No shortcode-specific escaping remains on save or render
+
+- **WHEN** the save/update and render paths are audited for escaping or sanitizing applied specifically to shortcodes
+- **THEN** none SHALL remain, except any instance explicitly recorded as guarding a threat the authorization gate does not cover
+

--- a/openspec/specs/security-capability-gating/spec.md
+++ b/openspec/specs/security-capability-gating/spec.md
@@ -7,10 +7,10 @@ through a dedicated permission that is off by default, seeded onto no role, and 
 by upgraded installations without a migration. The gate is an authorization decision on the acting
 user — never a filesystem path, output filename, client flag or other proxy signal — and it fails
 closed: no request context, or a failure while evaluating the permission, resolves to untrusted.
-States as a checkable rule the convention the four existing permissions
+States as a checkable rule the convention the five existing permissions
 (`post_content_unfiltered_html`, `contact_form_unfiltered_html`, `media_unfiltered_upload`,
-`select_eval`) already follow, so a new dangerous capability must conform to it and cite it rather
-than ship ungated, gate by a proxy, or fail open.
+`select_eval`, `content_shortcodes`) already follow, so a new dangerous capability must conform to it
+and cite it rather than ship ungated, gate by a proxy, or fail open.
 ## Requirements
 ### Requirement: Security-sensitive actions are gated by a default-off role permission
 Any action or method that presents a security threat SHALL be permitted for a non-administrator role
@@ -20,7 +20,7 @@ not-granted without a migration. Administrators SHALL satisfy the check through 
 without the permission being present in role meta.
 
 Conformant examples: `post_content_unfiltered_html`, `contact_form_unfiltered_html`,
-`media_unfiltered_upload`, `select_eval`.
+`media_unfiltered_upload`, `select_eval`, `content_shortcodes`.
 
 #### Scenario: An administrator performs the action
 - **WHEN** a user with the `admin` role performs a gated security-sensitive action

--- a/spec/lib/camaleon_cms/shortcode_registry_spec.rb
+++ b/spec/lib/camaleon_cms/shortcode_registry_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The boot-time canonical registry of shortcode NAMES that makes precise save-time detection
+# possible: the per-request CurrentRequest.shortcodes list is empty at an admin save, so the gate
+# consults this process-wide set instead. Detection mirrors the engine's cama_reg_shortcode regex
+# shape (a name is a match only when followed by a space + attributes or an immediate "]"), so
+# bracketed prose that is not a registered name is never treated as a shortcode.
+RSpec.describe CamaleonCms::ShortcodeRegistry do
+  around do |example|
+    saved_names = described_class.names
+    saved_available = described_class.available?
+    example.run
+  ensure
+    described_class.reset!
+    described_class.register(*saved_names)
+    described_class.mark_available! if saved_available
+  end
+
+  describe '.register / .names (the boot DSL)' do
+    it 'aggregates declared names into the canonical set' do
+      described_class.reset!
+      described_class.register('redirect')
+      described_class.register('bootstrap_slider', 'lightbox')
+
+      expect(described_class.names).to include('redirect', 'bootstrap_slider', 'lightbox')
+    end
+
+    it 'ignores blank declarations and de-duplicates' do
+      described_class.reset!
+      described_class.register('redirect', '', '  ', 'redirect')
+
+      expect(described_class.names.to_a).to eq(['redirect'])
+    end
+
+    it 'has declared the core-bundled shortcode names at boot' do
+      expect(described_class.names).to include('widget', 'load_libraries', 'asset', 'data')
+      expect(described_class).to be_available
+    end
+  end
+
+  describe '.content_has_shortcode? (precise detection)' do
+    before do
+      described_class.reset!
+      described_class.register('redirect', 'data')
+      described_class.mark_available!
+    end
+
+    it 'flags content containing a registered shortcode' do
+      expect(described_class.content_has_shortcode?('hello [redirect url="/x"] world')).to be true
+      expect(described_class.content_has_shortcode?('[data key="contact" attr="url"]')).to be true
+      expect(described_class.content_has_shortcode?('[redirect]')).to be true
+    end
+
+    it 'does not flag unrelated bracketed prose' do
+      expect(described_class.content_has_shortcode?('see [figure 2] and [note]')).to be false
+      expect(described_class.content_has_shortcode?('[see figure]')).to be false
+    end
+
+    it 'does not flag a name that is only a prefix of the bracketed token' do
+      expect(described_class.content_has_shortcode?('[redirection now]')).to be false
+      expect(described_class.content_has_shortcode?('[database x]')).to be false
+    end
+
+    it 'detects a registered name inside any translated locale of the raw stored string' do
+      raw = '<!--:en-->plain<!--:--><!--:es-->[redirect url="/y"]<!--:-->'
+      expect(described_class.content_has_shortcode?(raw)).to be true
+    end
+
+    it 'is false for blank content' do
+      expect(described_class.content_has_shortcode?('')).to be false
+      expect(described_class.content_has_shortcode?(nil)).to be false
+    end
+  end
+
+  describe 'fail-closed vs legitimately-empty (D4)' do
+    it 'treats any non-blank content as gated when the registry is unavailable (error state)' do
+      described_class.reset! # unavailable: boot never completed registration
+
+      expect(described_class).not_to be_available
+      expect(described_class.content_has_shortcode?('just plain text, no brackets')).to be true
+    end
+
+    it 'gates nothing when the registry is legitimately empty but available' do
+      described_class.reset!
+      described_class.mark_available! # available, no names declared
+
+      expect(described_class).to be_available
+      expect(described_class.content_has_shortcode?('[redirect] anything')).to be false
+    end
+  end
+end

--- a/spec/models/content_shortcode_gating_spec.rb
+++ b/spec/models/content_shortcode_gating_spec.rb
@@ -1,0 +1,291 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Security (gate-content-shortcodes): a shortcode in authored content triggers theme/plugin code
+# that emits arbitrary HTML/JS at render, which the save-time content scan cannot judge (the
+# shortcode registry is populated per frontend request, output is dynamic, and after expansion the
+# theme-emitted markup is indistinguishable from author input). So an author lacking
+# post_content_unfiltered_html can still emit a <script> through a shortcode -- an end-run around
+# that gate. Because no scan can judge a shortcode, the sanctioned remedy under
+# security-capability-gating is a default-off permission (content_shortcodes), enforced by a
+# save-time rejection across every surface do_shortcode expands: post content, custom-field values,
+# taxonomy content and widget descriptions. Rendering is unchanged -- stored content stays verbatim.
+#
+# `[widget ...]` is a core-registered shortcode, used here as a concrete registered name; the
+# real-world threat is a frontend/plugin shortcode such as `[redirect url="';alert(...);//"]`
+# (audit WEB-2) that a theme expands to a <script> for every viewer.
+RSpec.describe 'Content shortcode gating', type: :model do
+  let(:site) { create(:site) }
+  let(:post_type) { create(:post_type, site: site) }
+  let(:admin) { create(:user, role: 'admin', site: site) }
+  let(:contributor) { create(:user, role: 'contributor', site: site) }
+  let(:shortcode_content) { 'Intro [widget my_widget] outro' }
+
+  def as_user(user)
+    CurrentRequest.user = user
+    CurrentRequest.site = site
+  end
+
+  def grant_content_shortcodes(role_slug)
+    role = site.user_roles.find_by(slug: role_slug)
+    meta = role.get_meta("_manager_#{site.id}", {}) || {}
+    role.set_meta("_manager_#{site.id}", meta.merge('content_shortcodes' => 1))
+  end
+
+  after do
+    CurrentRequest.user = nil
+    CurrentRequest.site = nil
+    CurrentRequest.shortcodes = nil
+    CurrentRequest.shortcodes_template = nil
+  end
+
+  describe 'post content (Post#content)' do
+    def build_post(content, owner: nil)
+      build(:post, post_type: post_type, owner: owner, content: content)
+    end
+
+    it 'refuses a non-administrator without content_shortcodes and stores nothing' do
+      as_user(contributor)
+      post = build_post(shortcode_content, owner: contributor)
+
+      expect(post).not_to be_valid
+      expect(post.errors[:base].join).to match(/shortcode/i)
+      expect(post.save).to be false
+    end
+
+    it 'still allows the same author to save shortcode-free content' do
+      as_user(contributor)
+      post = build_post('<p>Just prose, and even [bracketed] text</p>', owner: contributor)
+
+      expect(post.save).to be true
+    end
+
+    it 'allows a non-administrator granted content_shortcodes' do
+      editor = create(:user, role: 'editor', site: site)
+      grant_content_shortcodes('editor')
+      as_user(editor)
+      post = build_post(shortcode_content, owner: editor)
+
+      expect(post.save).to be true
+      expect(post.reload.content).to eq(shortcode_content)
+    end
+
+    it 'allows an administrator without the key present in role meta' do
+      as_user(admin)
+      post = build_post(shortcode_content, owner: admin)
+
+      expect(post.save).to be true
+      expect(post.reload.content).to eq(shortcode_content)
+    end
+
+    it 'refuses a dangerous edit of previously safe content and keeps the stored value' do
+      as_user(contributor)
+      post = build_post('<p>safe</p>', owner: contributor)
+      post.save!
+
+      expect(post.update(content: shortcode_content)).to be false
+      expect(post.reload.content).to eq('<p>safe</p>')
+    end
+
+    it 'leaves pre-gate stored shortcode content editable when the content itself is untouched' do
+      as_user(contributor)
+      post = build_post('<p>ok</p>', owner: contributor)
+      post.save!
+      post.update_column(:content, shortcode_content) # rubocop:disable Rails/SkipsModelValidations
+
+      expect(post.update(title: 'New title')).to be true
+    end
+  end
+
+  describe 'custom-field values (CustomFieldsRelationship#value)' do
+    let(:post) { create(:post, post_type: post_type, owner: admin) }
+
+    before do
+      group = CamaleonCms::CustomFieldGroup.create!(name: 'Fields', slug: 'fields',
+                                                    object_class: 'PostType_Post', objectid: post_type.id,
+                                                    site: site)
+      group.add_manual_field({ name: 'Note', slug: 'note' }, { field_key: 'text_box' })
+    end
+
+    it 'refuses a shortcode in a plain text_box value for a non-administrator' do
+      as_user(contributor)
+
+      expect { post.set_field_value('note', shortcode_content) }
+        .to raise_error(ActiveRecord::RecordInvalid, /shortcode/i)
+      expect(post.get_field_value('note')).to be_blank
+    end
+
+    it 'stores the same value verbatim for an administrator' do
+      as_user(admin)
+
+      post.set_field_value('note', shortcode_content)
+
+      expect(post.get_field_value('note')).to eq(shortcode_content)
+    end
+
+    it 'allows a non-administrator granted content_shortcodes' do
+      editor = create(:user, role: 'editor', site: site)
+      grant_content_shortcodes('editor')
+      as_user(editor)
+
+      post.set_field_value('note', shortcode_content)
+
+      expect(post.get_field_value('note')).to eq(shortcode_content)
+    end
+  end
+
+  describe 'taxonomy content (TermTaxonomy#description)' do
+    it 'refuses a shortcode in a post-type description for a non-administrator' do
+      as_user(contributor)
+      taxonomy = build(:post_type, site: site, description: shortcode_content)
+
+      expect(taxonomy).not_to be_valid
+      expect(taxonomy.errors[:base].join).to match(/shortcode/i)
+    end
+
+    it 'allows an administrator' do
+      as_user(admin)
+      taxonomy = build(:post_type, site: site, description: shortcode_content)
+
+      expect(taxonomy.save).to be true
+    end
+  end
+
+  describe 'widget descriptions (Widget::Main#description, a TermTaxonomy STI subclass)' do
+    it 'refuses a shortcode in a widget description for a non-administrator' do
+      as_user(contributor)
+      widget = site.widgets.new(name: 'W', slug: 'w', description: shortcode_content)
+
+      expect(widget).not_to be_valid
+      expect(widget.errors[:base].join).to match(/shortcode/i)
+    end
+
+    it 'allows an administrator' do
+      as_user(admin)
+      widget = site.widgets.new(name: 'W', slug: 'w', description: shortcode_content)
+
+      expect(widget.save).to be true
+    end
+  end
+
+  # 3.3 coverage: every do_shortcode-expanded surface maps to a model including the shared gate, so a
+  # newly added expanded surface that forgets the gate is caught here. Post#content, custom-field
+  # values and TermTaxonomy#description (which STI-covers taxonomy content AND widget descriptions)
+  # are the known set today.
+  describe 'gate coverage across expanded surfaces (3.3)' do
+    it 'includes the shared gate in every model whose content do_shortcode expands' do
+      [CamaleonCms::Post, CamaleonCms::TermTaxonomy, CamaleonCms::CustomFieldsRelationship].each do |model|
+        expect(model.ancestors).to include(CamaleonCms::ContentShortcodeGate),
+                                   "#{model} must include ContentShortcodeGate to gate its shortcode-expanded content"
+      end
+    end
+
+    it 'STI-covers taxonomy and widget subclasses through TermTaxonomy' do
+      [CamaleonCms::PostType, CamaleonCms::Category, CamaleonCms::PostTag,
+       CamaleonCms::Widget::Main, CamaleonCms::Widget::Sidebar].each do |model|
+        expect(model.ancestors).to include(CamaleonCms::ContentShortcodeGate)
+      end
+    end
+  end
+
+  describe 'security-capability-gating conformance' do
+    it 'reads an absent key as not-granted for an upgraded install (no migration)' do
+      # A role whose stored manager meta predates the permission: the key is simply absent.
+      legacy = create(:user, role: 'editor', site: site)
+      site.user_roles.find_by(slug: 'editor').set_meta("_manager_#{site.id}", { 'media' => 1 })
+
+      expect(CamaleonCms::Ability.new(legacy, site).can?(:manage, :content_shortcodes)).to be false
+    end
+
+    it 'grants the capability once the key is present and truthy' do
+      editor = create(:user, role: 'editor', site: site)
+      grant_content_shortcodes('editor')
+
+      expect(CamaleonCms::Ability.new(editor, site).can?(:manage, :content_shortcodes)).to be true
+    end
+
+    it 'exposes content_shortcodes as a danger-flagged manager permission in the roles UI list' do
+      keys = CamaleonCms::UserRole::ROLES[:manager].map { |perm| perm[:key] }
+      perm = CamaleonCms::UserRole::ROLES[:manager].find { |p| p[:key] == 'content_shortcodes' }
+
+      expect(keys).to include('content_shortcodes')
+      expect(perm[:color]).to eq('danger')
+    end
+
+    context 'when the gate cannot fully evaluate (fail-closed)' do
+      def build_post(content, owner: nil)
+        build(:post, post_type: post_type, owner: owner, content: content)
+      end
+
+      it 'refuses shortcode content with no user context (job/rake/console)' do
+        CurrentRequest.user = nil
+        CurrentRequest.site = site
+
+        expect(build_post(shortcode_content)).not_to be_valid
+      end
+
+      it 'refuses shortcode content when the site context is missing, without raising' do
+        CurrentRequest.user = contributor
+        CurrentRequest.site = nil
+        post = build_post(shortcode_content, owner: contributor)
+
+        expect { post.valid? }.not_to raise_error
+        expect(post).not_to be_valid
+      end
+
+      it 'resolves to gated for a non-administrator when the registry is unavailable' do
+        post_type # force factory creation while the registry is still available
+        as_user(contributor)
+        allow(CamaleonCms::ShortcodeRegistry).to receive(:available?).and_return(false)
+        # An unavailable registry treats any non-blank content as gated: even plain prose is refused
+        # for a non-administrator (fail closed), while an administrator still passes.
+        expect(build_post('plain prose', owner: contributor)).not_to be_valid
+      end
+
+      it 'still lets an administrator save while the registry is unavailable' do
+        post_type
+        as_user(admin)
+        allow(CamaleonCms::ShortcodeRegistry).to receive(:available?).and_return(false)
+
+        expect(build_post(shortcode_content, owner: admin).save).to be true
+      end
+
+      it 'resolves to gated when evaluating the permission raises' do
+        # Exercised through TermTaxonomy, which carries only the shortcode gate (no competing HTML
+        # gate), so a raising Ability isolates this gate's own fail-closed rescue.
+        as_user(contributor) # forces site creation before the stub
+        allow(CamaleonCms::Ability).to receive(:new).and_raise(StandardError)
+        taxonomy = build(:post_type, site: site, description: shortcode_content)
+
+        expect { taxonomy.valid? }.not_to raise_error
+        expect(taxonomy).not_to be_valid
+      end
+    end
+  end
+
+  # 4.6 / 4.7: the gate is a save-time authorization decision only. A permitted author's stored
+  # shortcode content is neither escaped nor sanitized on save, and expands byte-for-byte at render.
+  describe 'rendering is unchanged (no escaping/sanitizing)' do
+    it 'stores a permitted author shortcode value byte-for-byte' do
+      as_user(admin)
+      raw = %([data key="contact" attr="url"] & <em>x</em> [widget k])
+      post = build(:post, post_type: post_type, owner: admin, content: raw)
+
+      expect(post.save).to be true
+      expect(post.reload.content).to eq(raw)
+    end
+
+    it 'expands the stored shortcode verbatim at render, with no CMS escaping of its output' do
+      # do_shortcode runs the registered handler and splices its output back in unchanged: the CMS
+      # applies no escaping/sanitizing to the shortcode syntax, attributes or output at render.
+      harness = Object.new.extend(CamaleonCms::ShortCodeHelper)
+      CurrentRequest.shortcodes = ['demo']
+      CurrentRequest.shortcodes_template = { 'demo' => ->(_attrs, _args) { '<b>RAW</b> & "quotes"' } }
+
+      rendered = harness.do_shortcode('before [demo] after')
+
+      expect(rendered).to eq('before <b>RAW</b> & "quotes" after')
+    end
+  end
+end


### PR DESCRIPTION
## What and Why

Shortcodes in authored content are expanded by `do_shortcode` at render, which runs theme/plugin code that can emit arbitrary HTML/JS on the page. That output is dynamic and, after expansion, indistinguishable from author input, so the save-time content scan (`UnsafeMarkup`, which enforces `post_content_unfiltered_html`) cannot judge it. An author who lacks `post_content_unfiltered_html` could therefore still emit a `<script>` through a shortcode — e.g. a frontend theme's `[redirect url="';alert(document.cookie);//"]` expands to a `<script>` for every viewer (audit WEB-2). Shortcodes are an end-run around the unfiltered-HTML gate.

Because no scan can judge a shortcode, the sanctioned remedy under `security-capability-gating` is a **default-off permission** — not a scan, and not render-time escaping. This PR adds `content_shortcodes` and **rejects** (never sanitizes) a save that carries a registered shortcode when the actor is a non-administrator without the permission, across **every** surface `do_shortcode` expands.

## How

- **Boot-time `CamaleonCms::ShortcodeRegistry`** — a registration DSL that declares shortcode *names* at boot (request-independently) into a process-wide canonical set. This is what makes precise save-time detection possible: the per-request `CurrentRequest.shortcodes` list is populated by the active *frontend* theme's `front_before_load` hook, so it is empty/incomplete at an admin save. Core declares its bundled names (`widget`, `load_libraries`, `asset`, `data`); themes/plugins declare theirs from their own boot. Detection reuses the engine's `cama_reg_shortcode` regex shape sourced from the registry, so only registered names match — bracketed prose like `[note]` never does.
- **Shared save-time gate** (`ContentShortcodeGate` concern) applied to the three models behind the four `do_shortcode` surfaces: `Post#content`, `CustomFieldsRelationship#value` (any field type — all values are expanded), and `TermTaxonomy#description` (STI-covers taxonomy content **and** widget descriptions, since `Widget::Main`/`Widget::Sidebar` are `TermTaxonomy` subclasses). The check mirrors `check_select_eval_authorization` / `reject_untrusted_dangerous_content`: reject on `create`/`update` when a registered shortcode is present and the actor is a non-admin lacking the permission; a title-only edit of pre-existing content is left editable.
- **Conforms to `security-capability-gating`**: `content_shortcodes` is a default-off `ROLES[:manager]` permission, seeded onto no non-admin role (upgraded installs read it as not-granted, no migration), admin-bypass via `can :manage, :all`, and **fail-closed** — no request context, a permission-evaluation error, or an unavailable registry all resolve to gated for non-administrators. A *legitimately empty* registry (available, no names) is distinct and gates nothing.
- **Rendering is unchanged.** Stored content stays verbatim; nothing is escaped or sanitized on save or render. A re-audit of core (and the cloned ecosystem) found no shortcode-specific escaping to remove — the only escaping ever added was the theme-level `escape_javascript` in texpert/camaleon_website#758 (already reverted); this supersedes it by gating the capability instead.

Third-party shortcode providers must declare their names through the DSL to be detected — a per-repo follow-up enabled by this core mechanism, not part of this PR.

## User-Visible Impact

**Breaking:** a non-administrator role without `content_shortcodes` can no longer publish shortcode-bearing content on post content, custom-field values, taxonomy content, or widget descriptions. Grant the permission (Settings → User Roles → *Allow shortcodes in content*) to roles that author shortcodes. Administrators are unaffected; stored content and rendering are unchanged.

OpenSpec: `content-shortcode-gating` (archived on the branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
