### PR TITLE
Stop injecting the engine's factories into the loading application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Bug fix:** The engine no longer force-requires `factory_bot_rails` nor appends its `spec/factories` to the application's factory paths — a host app loading the gem from a path/git checkout while defining its own same-named factory (e.g. `:site`) crashed at boot with `FactoryBot::DuplicateDefinitionError`. Released-gem installs never received the factories (`spec/` is not packaged). [#1280](https://github.com/owen2345/camaleon-cms/pull/1280).
+  - **Notes for plugin developers:** a camaleon-backed test harness that used the engine's factories from a checkout must now set `FactoryBot.definition_file_paths` itself (see `docs/ai/testing.md`).
+
 - **Testing:** Specs are now bootstrapped through `rails_helper` — `.rspec` uses `--require rails_helper`, so individual specs no longer `require 'rails_helper'` — and `rails_helper` forces `RAILS_ENV=test` before the app boots, so an exported `RAILS_ENV` can never point the suite (whose `before(:suite)` purges every table) at a development or production database. Development-only. [#1278](https://github.com/owen2345/camaleon-cms/pull/1278).
 
 - **Testing:** The contact-form security specs (content rejection, output escaping, gate soundness, and the admin feature spec) moved to the `cama_contact_form` plugin, which now has its own camaleon_cms-backed harness and owns the code they exercise. The `contact_form_unfiltered_html` permission-model spec stays here, where the permission is defined. Development-only; no shipped code changed. [#1278](https://github.com/owen2345/camaleon-cms/pull/1278) · pairs with [cama_contact_form#73](https://github.com/owen2345/cama_contact_form/pull/73), which adds the moved specs.

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -92,6 +92,13 @@ end
 
 ## Factory Bot Conventions
 
+Factories live in `spec/factories/` and are loaded by `spec/rails_helper.rb`, which sets
+`FactoryBot.definition_file_paths` to that directory explicitly and calls `FactoryBot.reload`
+(Rails.root is `spec/dummy`, so factory_bot_rails' root-relative defaults find nothing). The engine
+does NOT inject its factories into applications that load the gem — a host app or plugin harness
+that wants them must point `FactoryBot.definition_file_paths` at them itself (the cama_contact_form
+harness does exactly this with its own factories).
+
 ```ruby
 FactoryBot.define do
   factory :site, class: 'CamaleonCms::Site' do

--- a/lib/camaleon_cms/engine.rb
+++ b/lib/camaleon_cms/engine.rb
@@ -14,15 +14,6 @@ require 'dartsass-sprockets'
 require 'cama_contact_form'
 require 'cama_meta_tag'
 
-# `factory_bot_rails` gem can be added to test, development and/or other environments in the main app, containing the
-# `camaleon_cms` gem.
-# So, being unknown, whether it is defined or not, we're trying requiring the gem, using `rescue` in case of failures.
-begin
-  require 'factory_bot_rails'
-rescue LoadError
-  # do nothing
-end
-
 $camaleon_engine_dir = File.expand_path('../..', __dir__)
 require File.join($camaleon_engine_dir, 'lib', 'plugin_routes').to_s
 require File.join($camaleon_engine_dir, 'lib', 'camaleon_cms', 'setup_token').to_s
@@ -127,11 +118,6 @@ module CamaleonCms
     # set without perturbing initializer ordering.
     config.after_initialize do
       PluginRoutes.draw_routes_eagerly
-    end
-
-    if defined?(FactoryBotRails)
-      config.factory_bot.definition_file_paths +=
-        [File.expand_path('../../spec/factories', __dir__)]
     end
   end
 end

--- a/spec/factories_configuration_spec.rb
+++ b/spec/factories_configuration_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# The engine must not feed its spec/factories into the loading application: that auto-append
+# (engine.rb, removed) aborted the boot of any path-gem host that defines a same-named factory
+# (FactoryBot::DuplicateDefinitionError on :site), while released-gem hosts got a dangling path —
+# spec/ is not shipped in the packaged gem. This suite (whose Rails.root is spec/dummy) configures
+# the factory path itself in rails_helper instead.
+RSpec.describe 'Factory definition paths' do # rubocop:disable RSpec/DescribeClass
+  it 'contain only the path this suite configures, and the factories are loaded from it' do
+    expect(FactoryBot.definition_file_paths).to eq([File.expand_path('factories', __dir__)])
+    expect(FactoryBot.factories.registered?(:site)).to be true
+    expect(FactoryBot.factories.registered?(:user)).to be true
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,14 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+# This suite's factories live in the engine repo, but Rails.root is spec/dummy, so factory_bot_rails'
+# root-relative defaults find nothing. Point factory_bot here explicitly and reload — the engine no
+# longer injects its spec/factories into the host app (that auto-append aborted the boot of any host
+# defining a same-named factory, and the packaged gem does not ship spec/ anyway). Same pattern as
+# the cama_contact_form harness.
+FactoryBot.definition_file_paths = [File.expand_path('factories', __dir__)]
+FactoryBot.reload
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
## What and Why

`lib/camaleon_cms/engine.rb` force-required `factory_bot_rails` (rescuing LoadError) and appended the gem's `spec/factories` to the shared factory_bot definition paths. That append has no legitimate consumer: released gems do not ship `spec/`, so for packaged installs the path never existed — and for path/git checkouts it loaded the engine's factories into the **host** application, so any host defining a factory with the same name (a real host app defines its own `:site` and `:user` with its theme installer) aborted at boot with `FactoryBot::DuplicateDefinitionError` in every environment that bundles factory_bot_rails, development included: `rails server` refused to start.

Both are removed. The engine's own suite — the only real consumer, since its Rails.root is `spec/dummy` — now points `FactoryBot.definition_file_paths` at `spec/factories` explicitly in `rails_helper` and reloads, the same pattern the cama_contact_form harness already uses (it overrides the paths itself and never depended on the append). A new spec pins the contract (definition paths contain only the suite-configured directory, and the factories load from it), and `docs/ai/testing.md` documents the loading rule. Verified against the reporting host app: it boots and serves again with no changes on its side.

**Note for plugin/theme developers with camaleon-backed test harnesses:** the engine no longer registers its factories anywhere. If your harness used them from a path checkout, set `FactoryBot.definition_file_paths` (plus `FactoryBot.reload`) in your own `rails_helper`, as cama_contact_form does.

## User-Visible Impact

Host applications that define their own `:site`/`:user` (or other same-named) factories boot again with the gem loaded from a path or git checkout; released-gem installs see no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)