### PR TITLE
Release 2.9.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,31 @@
 # Change Log
 
-## Unreleased
+## [2.9.4](https://github.com/owen2345/camaleon-cms/tree/2.9.4) (2026-08-25)
+
+> **Upgrading to 2.9.4?** The one action for every install is `bundle update camaleon_cms`; required grants, behaviour changes, and notes for theme/plugin developers are collected in **[docs/upgrading-to-2.9.4.md](docs/upgrading-to-2.9.4.md)**. Breaking changes are flagged inline below.
 
 - **Security fix:** The bundled `front_cache` plugin ran `Rails.cache.clear` on every POST/PATCH, wiping every cache-based counter in the shared store — an attacker could reset the per-IP login brute-force counter with one interleaved frontend POST. Pages are now cached per site under versioned keys (one entry per URL, one-week TTL, any store); invalidation bumps the version and never touches entries the plugin does not own. [#1279](https://github.com/owen2345/camaleon-cms/pull/1279).
   - **Breaking change:** the *Invalidate the cache instead of deleting it* checkbox is removed from the front_cache settings — versioned invalidation is now the only behavior, and a stored `invalidate_only` value is ignored. PUT and DELETE requests now invalidate the page cache like POST/PATCH; draft autosaves (`posts/drafts`) no longer invalidate it (a draft is not published content); and the admin *Clean cache* action also physically purges the site's stored pages.
-  - **Notes for theme/plugin developers:** third-party `Rails.cache` entries are no longer implicitly wiped on every POST — a fragment cached without its own invalidation now lives until its own TTL. Operators on FileStore can reclaim pre-upgrade `pages/…` files with a one-time cache clear (`rails runner 'Rails.cache.clear'`).
+  - [Upgrade notes](docs/upgrading-to-2.9.4.md#front_cache-page-caching).
+
+- **Security fix (dependency):** Raises the bundled `cama_contact_form` floor to `~> 0.1.13`, which validates the contact-form auto-reply recipient (CF-1): the optional confirmation email previously went to a visitor-controlled address, turning a site into an email relay from its own From address. 0.1.13 also routes the plugin's markup gate through `CamaleonCms::UnsafeMarkup` and gates its `forms` shortcode. [cama_contact_form#76](https://github.com/owen2345/cama_contact_form/pull/76).
+  - [Upgrade notes](docs/upgrading-to-2.9.4.md#pick-up-the-dependency-and-security-fixes).
 
 - **Bug fix:** The engine no longer force-requires `factory_bot_rails` nor appends its `spec/factories` to the application's factory paths — a host app loading the gem from a path/git checkout while defining its own same-named factory (e.g. `:site`) crashed at boot with `FactoryBot::DuplicateDefinitionError`. Released-gem installs never received the factories (`spec/` is not packaged). [#1280](https://github.com/owen2345/camaleon-cms/pull/1280).
-  - **Notes for plugin developers:** a camaleon-backed test harness that used the engine's factories from a checkout must now set `FactoryBot.definition_file_paths` itself (see `docs/ai/testing.md`).
+  - [Upgrade notes](docs/upgrading-to-2.9.4.md#test-harnesses-using-the-engines-factories).
 
 - **Testing:** Specs are now bootstrapped through `rails_helper` — `.rspec` uses `--require rails_helper`, so individual specs no longer `require 'rails_helper'` — and `rails_helper` forces `RAILS_ENV=test` before the app boots, so an exported `RAILS_ENV` can never point the suite (whose `before(:suite)` purges every table) at a development or production database. Development-only. [#1278](https://github.com/owen2345/camaleon-cms/pull/1278).
 
-- **Testing:** The contact-form security specs (content rejection, output escaping, gate soundness, and the admin feature spec) moved to the `cama_contact_form` plugin, which now has its own camaleon_cms-backed harness and owns the code they exercise. The `contact_form_unfiltered_html` permission-model spec stays here, where the permission is defined. Development-only; no shipped code changed. [#1278](https://github.com/owen2345/camaleon-cms/pull/1278) · pairs with [cama_contact_form#73](https://github.com/owen2345/cama_contact_form/pull/73), which adds the moved specs.
+- **Testing:** The contact-form security specs moved to the `cama_contact_form` plugin, which now has its own camaleon_cms-backed harness and owns the code they exercise; the `contact_form_unfiltered_html` permission-model spec stays here, where the permission is defined. Development-only; no shipped code changed. [#1278](https://github.com/owen2345/camaleon-cms/pull/1278) · pairs with [cama_contact_form#73](https://github.com/owen2345/cama_contact_form/pull/73).
 
 - **Security fix:** Shortcodes in authored content are now gated behind a default-off `content_shortcodes` role permission. A save carrying a registered shortcode is refused (never sanitized) for a non-admin lacking it, across post content, custom-field values, taxonomy content and widget descriptions. Detection is precise and fails closed; admins, stored content and rendering are unaffected. [#1277](https://github.com/owen2345/camaleon-cms/pull/1277).
   - **Breaking change:** a non-administrator role without `content_shortcodes` can no longer publish shortcode-bearing content on any of those surfaces. Grant the permission (Settings → User Roles → *Allow shortcodes in content*) to roles that author shortcodes.
-  - **Notes for upgraders:** a shortcode is gated only if its name is declared to the boot registry. Core declares its own; a theme/plugin registering shortcodes must declare their names through the DSL from its own boot (request-independently), e.g. `CamaleonCms::ShortcodeRegistry.register('redirect', 'my_slider')`. Rendering is untouched — the render-time `shortcode_add` handler stays as-is.
+  - [Upgrade notes](docs/upgrading-to-2.9.4.md#shortcodes-in-authored-content-are-gated).
 
 - **Bug fix:** Publishing a post without an explicit date saved it `published` with a nil `published_at` — undated, and raising in themes that format the publish date. `CamaleonCms::Post` now stamps `published_at` (UTC) when a post becomes `published` without one; supplied/scheduled dates and already-published posts are untouched, and existing undated posts are not backfilled. [#1276](https://github.com/owen2345/camaleon-cms/pull/1276).
 
 - **Performance fix:** Frontend post listings no longer issue N+1 queries for post `metas`, `categories`, `post_tags` and post-type `metas` — a `Post.with_eager` `preload` scope loads them up front on the listing paths (single-post lookups stay lean), and stale association caches are reset after category/tag mutations. [#1275](https://github.com/owen2345/camaleon-cms/pull/1275).
-  - **Notes for theme/plugin developers:** frontend listings (`the_posts`/`the_contents`) now `preload` these associations instead of joining `metas`. A view that filters or sorts `@posts` on a `metas` column must chain `.joins(:metas)` / `.eager_load(:metas)` itself, and a column-narrowed `select` on `the_posts` must keep `taxonomy_id` (or use `pluck`).
+  - [Upgrade notes](docs/upgrading-to-2.9.4.md#frontend-listings-preload-their-associations).
 
 ## [2.9.3](https://github.com/owen2345/camaleon-cms/tree/2.9.3) (2026-08-16)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    camaleon_cms (2.9.3)
+    camaleon_cms (2.9.4)
       addressable
       aws-sdk-s3 (~> 1)
       bcrypt
       breadcrumbs_on_rails
-      cama_contact_form (~> 0.1.12)
+      cama_contact_form (~> 0.1.13)
       cama_meta_tag
       cancancan (>= 2.0, < 4)
       dartsass-sprockets
@@ -142,7 +142,7 @@ GEM
       thor (~> 1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    cama_contact_form (0.1.12)
+    cama_contact_form (0.1.13)
       rails
       recaptcha (>= 5.0)
     cama_meta_tag (1.7.2)
@@ -183,7 +183,7 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.3)
-    erb (6.0.6)
+    erb (6.0.7)
     erubi (1.13.1)
     factory_bot (6.6.0)
       activesupport (>= 6.1.0)
@@ -208,7 +208,7 @@ GEM
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     interception (0.5)
-    io-console (0.8.2)
+    io-console (0.9.2)
     ipaddress (0.8.3)
     irb (1.18.0)
       pp (>= 0.6.0)
@@ -293,7 +293,7 @@ GEM
     puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (3.2.6)
+    rack (3.2.7)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -336,7 +336,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.4.2)
-    rbs (4.1.1)
+    rbs (4.2.0)
       logger
       prism (>= 1.6.0)
       tsort
@@ -347,7 +347,7 @@ GEM
       tsort
     recaptcha (5.21.2)
     regexp_parser (2.12.0)
-    reline (0.6.3)
+    reline (0.7.0)
       io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
@@ -471,7 +471,7 @@ GEM
       will_paginate (>= 3.0.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.8.2)
+    zeitwerk (2.8.3)
 
 PLATFORMS
   arm64-darwin-24

--- a/camaleon_cms.gemspec
+++ b/camaleon_cms.gemspec
@@ -26,9 +26,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable'
   s.add_dependency 'bcrypt'
   s.add_dependency 'breadcrumbs_on_rails'
-  # 0.1.12 or newer: every earlier release carries the contact-form output-escaping vulnerability,
-  # and `~> 0.1.0` would have kept resolving 0.1.0 for anyone whose lock already named it.
-  s.add_dependency 'cama_contact_form', '~> 0.1.12'
+  # 0.1.13 or newer: earlier releases carry the contact-form output-escaping vulnerability, and
+  # pre-0.1.13 also lacks the auto-reply recipient-validation fix (CF-1). `~> 0.1.0` would have kept
+  # resolving 0.1.0 for anyone whose lock already named it.
+  s.add_dependency 'cama_contact_form', '~> 0.1.13'
   s.add_dependency 'cama_meta_tag'
   s.add_dependency 'cancancan', '>= 2.0', '< 4'
   s.add_dependency 'dartsass-sprockets'

--- a/docs/upgrading-to-2.9.4.md
+++ b/docs/upgrading-to-2.9.4.md
@@ -1,0 +1,123 @@
+# Upgrading to 2.9.4
+
+Version `2.9.4` is a small security and maintenance release. It picks up a contact-form security
+fix from the bundled `cama_contact_form` plugin, scopes the bundled `front_cache` plugin's cache
+invalidation, adds a save-time shortcode-permission gate in core, and ships a handful of bug and
+performance fixes.
+
+As always under this project's *reject on save, never rewrite* model, **nothing you already stored
+is modified by upgrading**. Each change is described in full in [CHANGELOG.md](../CHANGELOG.md),
+where **breaking changes** are flagged per entry; this guide is the upgrader runbook — what to do,
+what you may observe, and what theme/plugin developers should know.
+
+## At a glance — what applies to you
+
+| If your install… | Do this |
+| --- | --- |
+| **Any install** | `bundle update camaleon_cms` — see [below](#pick-up-the-dependency-and-security-fixes) |
+| Uses the **contact form** | Same bundle update; it closes the auto-reply recipient issue (CF-1) |
+| Has non-admin roles that author **shortcodes** | Grant them the new **content_shortcodes** permission |
+| Runs the bundled **front_cache** plugin on **FileStore** | Optional: clear the cache once to reclaim pre-upgrade `pages/…` files |
+
+If you maintain a theme or plugin, also review
+[Notes for theme & plugin developers](#notes-for-theme--plugin-developers).
+
+---
+
+## Pick up the dependency and security fixes
+
+The one action for every install:
+
+```bash
+bundle update camaleon_cms
+```
+
+This raises the `cama_contact_form` floor to `~> 0.1.13` and picks up several transitive patch
+updates. Nothing to add to your `Gemfile`. `cama_contact_form` `0.1.13` fixes:
+
+- **Contact-form auto-reply recipient validation (CF-1).** The optional confirmation e-mail was
+  sent to whatever address the visitor typed into the field named by the `to_answer` setting — an
+  unauthenticated, fully attacker-controlled recipient — turning a site into an email relay from
+  its own From address. The recipient must now be a single well-formed address, so one submission
+  can neither header-inject a `Bcc` nor fan out to a list; a refused auto-reply is logged. The owner
+  notification is unaffected.
+  [cama_contact_form#76](https://github.com/owen2345/cama_contact_form/pull/76).
+- **Markup gate routed through `CamaleonCms::UnsafeMarkup`**, closing an entity-encoded-markup
+  bypass through a kept attribute (e.g. a `data-html` tooltip sink).
+  [cama_contact_form#75](https://github.com/owen2345/cama_contact_form/pull/75).
+- **The plugin's `forms` shortcode is declared to the shortcode registry**, so it is covered by the
+  new `content_shortcodes` gate below.
+  [cama_contact_form#69](https://github.com/owen2345/cama_contact_form/pull/69).
+
+---
+
+## front_cache page caching
+
+The bundled `front_cache` plugin previously ran `Rails.cache.clear` on every POST/PATCH, wiping
+every cache-based counter in the shared store (including the per-IP login brute-force counter).
+Pages are now cached per site under versioned keys — one entry per URL, a one-week TTL, on any
+store — and invalidation bumps a version the plugin owns rather than clearing the whole store.
+
+- **Breaking change:** the *Invalidate the cache instead of deleting it* checkbox is removed; a
+  stored `invalidate_only` value is ignored. **PUT and DELETE now invalidate** the page cache like
+  POST/PATCH; **draft autosaves (`posts/drafts`) no longer invalidate it** (a draft is not published
+  content); and the admin **Clean cache** action now also physically purges the site's stored pages.
+- **Operator note (FileStore only).** Pre-upgrade `pages/…` entries are keyed under the old scheme
+  and are simply superseded — no action is required. To reclaim the old files immediately, clear the
+  cache once during your upgrade window:
+
+  ```bash
+  RAILS_ENV=production bundle exec rails runner 'Rails.cache.clear'
+  ```
+
+- **Theme/plugin developers:** third-party `Rails.cache` entries are no longer implicitly wiped on
+  every POST — a fragment cached without its own invalidation now lives until its own TTL.
+
+---
+
+## Shortcodes in authored content are gated
+
+Shortcodes in authored content are now gated behind a default-off `content_shortcodes` role
+permission. A save carrying a **registered** shortcode is refused (never sanitized) for a non-admin
+lacking the permission, across post content, custom-field values, taxonomy content and widget
+descriptions. Admins, stored content and rendering are unaffected.
+
+- **Breaking change:** a non-administrator role without `content_shortcodes` can no longer publish
+  shortcode-bearing content on those surfaces. Grant the permission at **Settings → User Roles →
+  *Allow shortcodes in content*** to roles that author shortcodes.
+- **Theme/plugin developers:** a shortcode is gated only if its name is declared to the boot
+  registry. Core declares its own; a theme or plugin registering shortcodes must declare their names
+  through the DSL from its own boot (request-independently), e.g.
+  `CamaleonCms::ShortcodeRegistry.register('redirect', 'my_slider')`. Rendering is untouched — the
+  render-time `shortcode_add` handler is unchanged.
+
+---
+
+## Notes for theme & plugin developers
+
+Beyond the front_cache and shortcode notes above:
+
+### Frontend listings preload their associations
+
+Frontend post listings (`the_posts`/`the_contents`) now `preload` post `metas`, `categories`,
+`post_tags` and post-type `metas` instead of joining `metas`. A view that filters or sorts `@posts`
+on a `metas` column must chain `.joins(:metas)` / `.eager_load(:metas)` itself, and a column-narrowed
+`select` on `the_posts` must keep `taxonomy_id` (or use `pluck`). Single-post lookups stay lean.
+
+### Test harnesses using the engine's factories
+
+The engine no longer force-requires `factory_bot_rails` nor appends its `spec/factories` to the
+application's factory paths. A camaleon-backed test harness that used the engine's factories from a
+path/git checkout must now set `FactoryBot.definition_file_paths` itself (see
+[docs/ai/testing.md](ai/testing.md)). Released-gem installs never received the factories (`spec/` is
+not packaged), so they are unaffected.
+
+---
+
+## Recommended rollout
+
+1. `bundle update camaleon_cms`.
+2. Grant `content_shortcodes` to any non-admin role that authors shortcodes.
+3. On FileStore, optionally clear the cache once to reclaim pre-upgrade `front_cache` files.
+4. If you maintain a theme or plugin, review
+   [Notes for theme & plugin developers](#notes-for-theme--plugin-developers).

--- a/lib/camaleon_cms/version.rb
+++ b/lib/camaleon_cms/version.rb
@@ -1,3 +1,3 @@
 module CamaleonCms
-  VERSION = '2.9.3'.freeze
+  VERSION = '2.9.4'.freeze
 end


### PR DESCRIPTION
**User-visible impact:** Upgraders picking up 2.9.4 get the contact-form auto-reply recipient fix (CF-1) via `cama_contact_form 0.1.13`, plus the front_cache and shortcode-gating changes already merged this cycle.

**What & why:** Bumps the version to 2.9.4, raises the bundled `cama_contact_form` floor to `~> 0.1.13` to pull in the auto-reply recipient-validation fix, and closes the CHANGELOG's Unreleased section for release. Upgrader notes accumulated across #1275–#1280 are consolidated into `docs/upgrading-to-2.9.4.md`.
