### PR TITLE
Harden media folders against collapsing names and paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Bug fix:** A media folder whose name collapses in the stored path (production data held a scanner-created folder named `.`) resolved its children query back to itself, so deleting it recursed until `SystemStackError`. `Media#items` now excludes the folder's own row; such folders delete cleanly and real children are still destroyed with their folder. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
+
 - **Security:** Floors the bundled `cama_contact_form` dependency at `~> 0.1.14`, the release that completes its contact-form security series (output escaping, auto-reply recipient validation, a submission throttle, an attachment-count cap, upload-scan coverage, an e-mail tracking-pixel block, and response-file-cleanup confinement). An install still resolving 0.1.13 moves up on `bundle update`; drop-in, no config or API change. [#1284](https://github.com/owen2345/camaleon-cms/pull/1284).
 
 - **Tooling:** Ruby 3.4.10 for development and for the Release job, both of which read `.tool-versions`; RubyGems/Bundler 4.0.19 there, in the two CI matrix workflows and in `BUNDLED WITH`, plus the transitive development bumps that came with it. The CI Ruby/Rails matrices are unchanged, and `openspec/config.yaml` no longer restates the Ruby and Rails versions. Development-only; the gem's supported ranges are unchanged. [#1283](https://github.com/owen2345/camaleon-cms/pull/1283).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-- **Bug fix:** A media folder whose name collapses in the stored path (production data held a scanner-created folder named `.`) resolved its children query back to itself, so deleting it recursed until `SystemStackError`. `Media#items` now excludes the folder's own row; such folders delete cleanly and real children are still destroyed with their folder. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
+- **Security fix:** The local uploader's delete-folder action guarded only against `..`, so a folder key that resolves to the media root (e.g. `/.`) let a user with media permission recursively delete the site's entire upload directory from disk. Folder deletion is now contained to the media root. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
+
+- **Bug fix:** Deleting a media folder whose stored name or path collapses (production data held a scanner-created folder named `.`) no longer crashes with `SystemStackError` or silently deletes sibling media; such non-canonical names and paths are now refused at save, and the local uploader normalizes storage keys like the S3 uploader. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
 
 - **Security:** Floors the bundled `cama_contact_form` dependency at `~> 0.1.14`, the release that completes its contact-form security series (output escaping, auto-reply recipient validation, a submission throttle, an attachment-count cap, upload-scan coverage, an e-mail tracking-pixel block, and response-file-cleanup confinement). An install still resolving 0.1.13 moves up on `bundle update`; drop-in, no config or API change. [#1284](https://github.com/owen2345/camaleon-cms/pull/1284).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## Unreleased
 
-- **Security fix:** The local uploader's delete-folder action guarded only against `..`, so a folder key that resolves to the media root (e.g. `/.`) let a user with media permission recursively delete the site's entire upload directory from disk. Folder deletion is now contained to the media root. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
-
-- **Bug fix:** Deleting a media folder whose stored name or path collapses (production data held a scanner-created folder named `.`) no longer crashes with `SystemStackError` or silently deletes sibling media; such non-canonical names and paths are now refused at save, and the local uploader normalizes storage keys like the S3 uploader. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
+- **Security fix:** A media folder-delete whose key resolved to the media root (e.g. `/.`) let a media-permission user delete the site's entire upload directory from disk; deletion is now contained to the media root. The same change stops folders whose stored name or path collapses (e.g. one named `.`) from crashing with `SystemStackError` or deleting sibling media on destroy, and refuses such non-canonical names and paths at save. [#1285](https://github.com/owen2345/camaleon-cms/pull/1285).
 
 - **Security:** Floors the bundled `cama_contact_form` dependency at `~> 0.1.14`, the release that completes its contact-form security series (output escaping, auto-reply recipient validation, a submission throttle, an attachment-count cap, upload-scan coverage, an e-mail tracking-pixel block, and response-file-cleanup confinement). An install still resolving 0.1.13 moves up on `bundle update`; drop-in, no config or API change. [#1284](https://github.com/owen2345/camaleon-cms/pull/1284).
 

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -41,11 +41,17 @@ module CamaleonCms
     # return all items of current folder
     def items
       coll = is_public ? site.public_media : site.private_media
-      coll = coll.where(folder_path: "#{folder_path}/#{name}".cama_fix_media_key)
-      # A name that collapses under cama_fix_media_key (e.g. '.') resolves the
-      # children path back to this row's own folder_path, so a folder can select
-      # itself and destroy would recurse forever: never treat self as a child.
-      persisted? ? coll.where.not(id: id) : coll
+      children_path = "#{folder_path}/#{name}".cama_fix_media_key
+      # A folder's children live strictly below its own path. A name that collapses
+      # under cama_fix_media_key (e.g. '.', '/', '..') resolves children_path back to
+      # this row's own folder_path or an ancestor, which would make the folder select
+      # its own siblings: destroy would then wipe them, or two such rows would select
+      # each other and recurse forever. Descend only into a genuine sub-path, which
+      # also makes cycles impossible (path depth would have to strictly increase).
+      prefix = folder_path == '/' ? '/' : "#{folder_path}/"
+      return coll.none unless children_path != folder_path && children_path.start_with?(prefix)
+
+      coll.where(folder_path: children_path)
     end
 
     private

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -11,6 +11,11 @@ module CamaleonCms
     # so such a row is invisible to both listings and skipped by the site's
     # dependent: :destroy, orphaning it and its children. Force an explicit boolean.
     validates :is_public, inclusion: { in: [true, false] }
+    # Reject rows that cannot hold a canonical position rather than storing a name or
+    # path that aliases another row: a name of '.', '..', '' or one containing '/'
+    # collapses under cama_fix_media_key, and a non-canonical folder_path ('/.', '/a//b',
+    # a trailing slash) points a row at a place the media browser addresses differently.
+    validate :canonical_media_position
     scope :only_folder, -> { where(is_folder: true) }
     scope :only_file, -> { where(is_folder: false) }
     default_scope { order(is_folder: :asc, name: :asc) }
@@ -64,6 +69,28 @@ module CamaleonCms
     end
 
     private
+
+    def canonical_media_position
+      errors.add(:name, 'is not a valid media name') unless valid_media_segment?(name)
+      errors.add(:folder_path, 'must be a canonical media path') unless canonical_media_folder?(folder_path)
+    end
+
+    # A single, non-collapsing path component: present, no separator, not '.'/'..'.
+    def valid_media_segment?(value)
+      value = value.to_s
+      value.present? && !value.include?('/') && value != '.' && value != '..'
+    end
+
+    # An absolute path whose every segment is a valid segment and which carries no
+    # doubled or trailing slash (so it equals how the browser addresses it).
+    def canonical_media_folder?(path)
+      path = path.to_s
+      return false unless path.start_with?('/')
+      return true if path == '/'
+      return false if path.end_with?('/')
+
+      path.split('/').drop(1).all? { |segment| valid_media_segment?(segment) }
+    end
 
     # recover folder or file format
     def create_parent_folders

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -61,6 +61,11 @@ module CamaleonCms
       coll = is_public ? site.public_media : site.private_media
       _p = []
       folder_path.split('/').each do |f_name|
+        # A blank segment (doubled or trailing slash in folder_path) is not a real
+        # folder; creating a row for it would mint a nameless folder whose own
+        # children path collapses back onto its parent.
+        next if f_name.blank?
+
         _path = "/#{_p.join('/')}".cama_fix_media_key
         if "#{_path}/#{f_name}".cama_fix_media_key != '/'
           coll.only_folder.where(name: f_name,

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -40,6 +40,11 @@ module CamaleonCms
 
     # return all items of current folder
     def items
+      # site is optional and unconstrained by a foreign key, so an orphan row (nil or
+      # dangling site) must not raise here — otherwise before_destroy could never run
+      # and the orphan would be undeletable through the model.
+      return self.class.none unless site
+
       coll = is_public ? site.public_media : site.private_media
       children_path = "#{folder_path}/#{name}".cama_fix_media_key
       # A folder's children live strictly below its own path. A name that collapses
@@ -58,6 +63,8 @@ module CamaleonCms
 
     # recover folder or file format
     def create_parent_folders
+      return unless site
+
       coll = is_public ? site.public_media : site.private_media
       _p = []
       folder_path.split('/').each do |f_name|

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -41,7 +41,11 @@ module CamaleonCms
     # return all items of current folder
     def items
       coll = is_public ? site.public_media : site.private_media
-      coll.where(folder_path: "#{folder_path}/#{name}".cama_fix_media_key)
+      coll = coll.where(folder_path: "#{folder_path}/#{name}".cama_fix_media_key)
+      # A name that collapses under cama_fix_media_key (e.g. '.') resolves the
+      # children path back to this row's own folder_path, so a folder can select
+      # itself and destroy would recurse forever: never treat self as a child.
+      persisted? ? coll.where.not(id: id) : coll
     end
 
     private

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -7,6 +7,10 @@ module CamaleonCms
       scope: %i[site_id is_folder folder_path is_public],
       message: 'Duplicates not allowed'
     }
+    # A NULL is_public matches neither the public_media nor the private_media scope,
+    # so such a row is invisible to both listings and skipped by the site's
+    # dependent: :destroy, orphaning it and its children. Force an explicit boolean.
+    validates :is_public, inclusion: { in: [true, false] }
     scope :only_folder, -> { where(is_folder: true) }
     scope :only_file, -> { where(is_folder: false) }
     default_scope { order(is_folder: :asc, name: :asc) }

--- a/app/models/camaleon_cms/media.rb
+++ b/app/models/camaleon_cms/media.rb
@@ -72,7 +72,10 @@ module CamaleonCms
 
     # return all children items
     def delete_folder_items
-      items.destroy_all if is_folder
+      # Rails runs before_destroy on unsaved records too. Such an instance owns no
+      # persisted children, so cascading would destroy real rows that merely share
+      # its computed path; only a persisted folder has children to remove.
+      items.destroy_all if is_folder && persisted?
     end
   end
 end

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -129,11 +129,17 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
 
   # Remove an existent folder
   def delete_folder(key)
-    return { error: 'Invalid folder path' } if key.include?('..')
+    return { error: 'Invalid folder path' } unless valid_folder_path?(key)
 
-    folder = File.join(@root_folder, key)
-    FileUtils.rm_rf(folder) if Dir.exist? folder
-    get_media_collection.by_key(key).take.destroy
+    # Resolve the target and require it to stay strictly below the media root, so a
+    # key such as '/.' (which expands back to the root) or any escape cannot make
+    # rm_rf wipe the whole upload directory.
+    folder = File.expand_path(File.join(@root_folder, key))
+    root = File.expand_path(@root_folder)
+    return { error: 'Invalid folder path' } unless folder.start_with?("#{root}/")
+
+    FileUtils.rm_rf(folder) if Dir.exist?(folder)
+    get_media_collection.by_key(key).take&.destroy
   end
 
   # Remove an existent file

--- a/app/uploaders/camaleon_cms_local_uploader.rb
+++ b/app/uploaders/camaleon_cms_local_uploader.rb
@@ -92,6 +92,11 @@ class CamaleonCmsLocalUploader < CamaleonCmsUploader
   def add_file(uploaded_io_or_file_path, key, args = {})
     args = { same_name: false, is_thumb: false }.merge(args)
     res = nil
+    # Normalize the key the same way the AWS uploader does, so the persisted
+    # folder_path is canonical (leading slash, no './' or '..' segments). Without
+    # this a folder like '/./.' or a slash-less 'temporal' is stored verbatim,
+    # producing invisible or self-aliasing media rows.
+    key = key.cama_fix_media_key
     key = search_new_key(key) unless args[:same_name]
 
     if @instance # private hook to upload files by different way, add file data into result_data

--- a/app/uploaders/camaleon_cms_uploader.rb
+++ b/app/uploaders/camaleon_cms_uploader.rb
@@ -77,6 +77,14 @@ class CamaleonCmsUploader
   end
 
   # return the media collection for current situation
+  #
+  # NOTE: the branches read inverted — a private uploader resolves to public_media
+  # (is_public: true) and vice versa — so stored is_public is the opposite of the
+  # row's real visibility. This is self-consistent today (every reader and writer of
+  # media rows goes through this same method, and access control keys off
+  # is_private_uploader? directly, not off the stored flag), so it must NOT be swapped
+  # on its own: flipping the ternary without a data migration that inverts every
+  # existing row would mislabel all stored media. Fix the flag and the data together.
   def get_media_collection
     is_private_uploader? ? @current_site.public_media : @current_site.private_media
   end

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -94,6 +94,7 @@ Other consequences to plan for:
     - **NO** Test failure/example counts.
     - **NO** Verification logs/commands.
     - **NO** Commit SHAs or history references.
+    - **NO** evolution narrative — describe the PR's net what/why/how as it now stands; when commits are added later, integrate their substance into the description, never append follow-up or review-history sections.
     - **REQUIRED:** One sentence on **User-Visible Impact** (or state "None").
     - **REQUIRED:** A "What and Why" summary.
 
@@ -108,7 +109,7 @@ Other consequences to plan for:
     - **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController, [#1152](https://github.com/owen2345/camaleon-cms/pull/1152)
     ```
 
-    **🔴 Keep the entry short. The PR description is where the reasoning lives.** The changelog is read by someone deciding whether an upgrade affects them — not by someone auditing your analysis. A lead paragraph carrying the PR link is the whole entry for most changes; it **MUST NOT exceed 500 characters**, and the PR link and any reporter credit count toward that limit. Do not restate the root cause, the code path, the attack mechanics, or the design rationale — every one of those is already in the PR body, one click away through the link you just added.
+    **🔴 Keep the entry short. The PR description is where the reasoning lives.** The changelog is read by someone deciding whether an upgrade affects them — not by someone auditing your analysis. A lead paragraph carrying the PR link is the whole entry for most changes; the **entire entry — every paragraph included — MUST NOT exceed 500 characters**, and the PR link and any reporter credit count toward that limit. Do not restate the root cause, the code path, the attack mechanics, or the design rationale — every one of those is already in the PR body, one click away through the link you just added.
 
     Keep a **Breaking changes** list in the changelog entry — a short list, *only* for what the reader must act on or will observe (behavior that changed, output that moved, a dependency floor that was raised, data that is or is not rewritten). Two to four bullets, one or two sentences each. If a bullet explains *why* rather than *what changed for the reader*, delete it.
 

--- a/openspec/specs/upload-path-security/spec.md
+++ b/openspec/specs/upload-path-security/spec.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-Define the security requirements for validating file upload source paths. The system MUST canonicalize string paths before validating them against allowed directory prefixes, preventing path traversal bypasses where `../` segments after an allowed prefix resolve to arbitrary filesystem locations.
+Define the security requirements for validating file upload source paths. The system MUST canonicalize string paths before validating them against allowed directory prefixes, preventing path traversal bypasses where `../` segments after an allowed prefix resolve to arbitrary filesystem locations. The same canonicalize-then-contain rule governs media folder deletion targets, so a delete cannot escape the media root or resolve to the root itself.
 
 ## Requirements
 
@@ -103,3 +103,17 @@ When converting a URL to a local filesystem path, the system SHALL compare host 
 
 - **WHEN** a user provides `http://evil.com?url=http://site.com/path`
 - **THEN** the substring match does NOT trigger URL-to-path conversion (host comparison fails)
+
+### Requirement: Folder deletion is contained to the media root
+
+The system SHALL resolve a media folder-delete target with `File.expand_path` and require it to start with the media root followed by the path separator before removing it. A key that resolves to the media root itself (e.g. `/.`) or escapes it SHALL be refused, so a folder delete cannot recursively remove the whole upload directory.
+
+#### Scenario: A folder key resolving to the media root is refused
+
+- **WHEN** a user with media permission requests deletion of a folder whose key resolves to the media root (e.g. `/.`)
+- **THEN** the expanded target equals the root rather than a path below it, the delete is refused with an error, and the upload directory is left intact
+
+#### Scenario: A genuine subfolder is still deleted
+
+- **WHEN** a user deletes an existing folder below the media root (e.g. `/docs`)
+- **THEN** the expanded target starts with the root followed by the separator, and the folder is removed

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -26,5 +26,48 @@ RSpec.describe CamaleonCms::Media, type: :model do
 
       expect(described_class.exists?(child.id)).to be false
     end
+
+    it 'does not destroy sibling rows when a degenerate root folder is removed' do
+      junk = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
+      sibling_folder = site.public_media.create!(name: 'docs', folder_path: '/', is_folder: true)
+      sibling_file = site.public_media.create!(name: 'a.txt', folder_path: '/', is_folder: false)
+      nested = site.public_media.create!(name: 'b.txt', folder_path: '/docs', is_folder: false)
+
+      junk.destroy!
+
+      expect(described_class.exists?(sibling_folder.id)).to be true
+      expect(described_class.exists?(sibling_file.id)).to be true
+      expect(described_class.exists?(nested.id)).to be true
+    end
+
+    it 'destroys mutually-aliasing degenerate rows without recursing or wiping siblings' do
+      row_a = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
+      row_b = site.public_media.create!(name: './', folder_path: '/', is_folder: true)
+      sibling = site.public_media.create!(name: 'keep.txt', folder_path: '/', is_folder: false)
+
+      expect { row_a.destroy! }.not_to raise_error
+      expect { row_b.destroy! }.not_to raise_error
+      expect(described_class.exists?(sibling.id)).to be true
+    end
+
+    it 'destroys a cross-path aliasing pair without recursing' do
+      row_a = site.public_media.create!(name: '..', folder_path: '/.', is_folder: true)
+      row_b = site.public_media.create!(name: '.', folder_path: '/..', is_folder: true)
+
+      expect { row_a.destroy! }.not_to raise_error
+      expect { row_b.destroy! }.not_to raise_error
+    end
+  end
+
+  describe '#items' do
+    it 'excludes the folder itself even when loaded without its id column' do
+      folder = site.public_media.create!(name: '.', folder_path: '/.', is_folder: true)
+
+      partial = site.public_media.select(:name, :folder_path, :is_public, :is_folder, :site_id)
+                    .find_by(name: '.', folder_path: '/.')
+
+      expect(partial.id).to be_nil
+      expect(partial.items.to_a).not_to include(folder)
+    end
   end
 end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -3,16 +3,25 @@
 RSpec.describe CamaleonCms::Media, type: :model do
   let(:site) { Cama::Site.first }
 
+  # Persist a row the canonical-position validation would now reject, to simulate
+  # the pre-validation (legacy / externally-written) data the destroy and listing
+  # guards must still handle.
+  def persist_legacy(attrs)
+    record = site.public_media.new(attrs)
+    record.save!(validate: false)
+    record
+  end
+
   describe '#destroy' do
     it 'destroys a folder whose items path resolves to its own path without recursing' do
-      folder = site.public_media.create!(name: '.', folder_path: '/.', is_folder: true)
+      folder = persist_legacy(name: '.', folder_path: '/.', is_folder: true)
 
       expect { folder.destroy! }.not_to raise_error
       expect(described_class.exists?(folder.id)).to be false
     end
 
     it 'destroys a root folder whose name collapses to the root path without recursing' do
-      folder = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
+      folder = persist_legacy(name: '/', folder_path: '/', is_folder: true)
 
       expect { folder.destroy! }.not_to raise_error
       expect(described_class.exists?(folder.id)).to be false
@@ -28,7 +37,7 @@ RSpec.describe CamaleonCms::Media, type: :model do
     end
 
     it 'does not destroy sibling rows when a degenerate root folder is removed' do
-      junk = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
+      junk = persist_legacy(name: '/', folder_path: '/', is_folder: true)
       sibling_folder = site.public_media.create!(name: 'docs', folder_path: '/', is_folder: true)
       sibling_file = site.public_media.create!(name: 'a.txt', folder_path: '/', is_folder: false)
       nested = site.public_media.create!(name: 'b.txt', folder_path: '/docs', is_folder: false)
@@ -41,8 +50,8 @@ RSpec.describe CamaleonCms::Media, type: :model do
     end
 
     it 'destroys mutually-aliasing degenerate rows without recursing or wiping siblings' do
-      row_a = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
-      row_b = site.public_media.create!(name: './', folder_path: '/', is_folder: true)
+      row_a = persist_legacy(name: '/', folder_path: '/', is_folder: true)
+      row_b = persist_legacy(name: './', folder_path: '/', is_folder: true)
       sibling = site.public_media.create!(name: 'keep.txt', folder_path: '/', is_folder: false)
 
       expect { row_a.destroy! }.not_to raise_error
@@ -51,8 +60,8 @@ RSpec.describe CamaleonCms::Media, type: :model do
     end
 
     it 'destroys a cross-path aliasing pair without recursing' do
-      row_a = site.public_media.create!(name: '..', folder_path: '/.', is_folder: true)
-      row_b = site.public_media.create!(name: '.', folder_path: '/..', is_folder: true)
+      row_a = persist_legacy(name: '..', folder_path: '/.', is_folder: true)
+      row_b = persist_legacy(name: '.', folder_path: '/..', is_folder: true)
 
       expect { row_a.destroy! }.not_to raise_error
       expect { row_b.destroy! }.not_to raise_error
@@ -61,7 +70,7 @@ RSpec.describe CamaleonCms::Media, type: :model do
 
   describe '#items' do
     it 'excludes the folder itself even when loaded without its id column' do
-      folder = site.public_media.create!(name: '.', folder_path: '/.', is_folder: true)
+      folder = persist_legacy(name: '.', folder_path: '/.', is_folder: true)
 
       partial = site.public_media.select(:name, :folder_path, :is_public, :is_folder, :site_id)
                     .find_by(name: '.', folder_path: '/.')
@@ -111,6 +120,30 @@ RSpec.describe CamaleonCms::Media, type: :model do
     it 'accepts explicit true and false' do
       expect(site.public_media.new(name: 'pub', folder_path: '/', is_folder: true, is_public: true)).to be_valid
       expect(site.public_media.new(name: 'priv', folder_path: '/', is_folder: true, is_public: false)).to be_valid
+    end
+  end
+
+  describe 'canonical position validation' do
+    it 'rejects a name that collapses under the media key' do
+      expect(site.public_media.new(name: '.', folder_path: '/', is_folder: true)).to be_invalid
+      expect(site.public_media.new(name: '..', folder_path: '/', is_folder: true)).to be_invalid
+      expect(site.public_media.new(name: '/', folder_path: '/', is_folder: true)).to be_invalid
+    end
+
+    it 'rejects a name containing a path separator that aliases another folder' do
+      expect(site.public_media.new(name: 'b/', folder_path: '/a', is_folder: true)).to be_invalid
+    end
+
+    it 'rejects a non-canonical folder_path' do
+      expect(site.public_media.new(name: 'x', folder_path: '/a//b', is_folder: false)).to be_invalid
+      expect(site.public_media.new(name: 'x', folder_path: '/.', is_folder: false)).to be_invalid
+      expect(site.public_media.new(name: 'x', folder_path: '/a/', is_folder: false)).to be_invalid
+    end
+
+    it 'accepts normal folders and files' do
+      expect(site.public_media.new(name: 'docs', folder_path: '/', is_folder: true)).to be_valid
+      expect(site.public_media.new(name: 'a.txt', folder_path: '/docs', is_folder: false)).to be_valid
+      expect(site.public_media.new(name: 'file.tar.gz', folder_path: '/a/b', is_folder: false)).to be_valid
     end
   end
 end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -80,4 +80,15 @@ RSpec.describe CamaleonCms::Media, type: :model do
       expect(described_class.exists?(child.id)).to be true
     end
   end
+
+  describe '#create_parent_folders' do
+    it 'does not mint blank-name folder rows from doubled slashes in the path' do
+      record = site.public_media.new(name: 'b', folder_path: '/a//b', is_folder: true)
+
+      record.send(:create_parent_folders)
+
+      expect(site.public_media.where(name: '').exists?).to be false
+      expect(site.public_media.exists?(name: 'a', folder_path: '/')).to be true
+    end
+  end
 end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -91,4 +91,13 @@ RSpec.describe CamaleonCms::Media, type: :model do
       expect(site.public_media.exists?(name: 'a', folder_path: '/')).to be true
     end
   end
+
+  describe 'a folder row without a site' do
+    it 'can be saved and destroyed without raising' do
+      orphan = described_class.new(name: 'orphan', folder_path: '/', is_folder: true, site: nil)
+
+      expect { orphan.save! }.not_to raise_error
+      expect { orphan.destroy! }.not_to raise_error
+    end
+  end
 end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+RSpec.describe CamaleonCms::Media, type: :model do
+  let(:site) { Cama::Site.first }
+
+  describe '#destroy' do
+    it 'destroys a folder whose items path resolves to its own path without recursing' do
+      folder = site.public_media.create!(name: '.', folder_path: '/.', is_folder: true)
+
+      expect { folder.destroy! }.not_to raise_error
+      expect(described_class.exists?(folder.id)).to be false
+    end
+
+    it 'destroys a root folder whose name collapses to the root path without recursing' do
+      folder = site.public_media.create!(name: '/', folder_path: '/', is_folder: true)
+
+      expect { folder.destroy! }.not_to raise_error
+      expect(described_class.exists?(folder.id)).to be false
+    end
+
+    it 'still destroys the real children of a folder' do
+      folder = site.public_media.create!(name: 'docs', folder_path: '/', is_folder: true)
+      child = site.public_media.create!(name: 'file.txt', folder_path: '/docs', is_folder: false)
+
+      folder.destroy!
+
+      expect(described_class.exists?(child.id)).to be false
+    end
+  end
+end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -100,4 +100,17 @@ RSpec.describe CamaleonCms::Media, type: :model do
       expect { orphan.destroy! }.not_to raise_error
     end
   end
+
+  describe 'is_public validation' do
+    it 'rejects a NULL is_public' do
+      expect do
+        site.public_media.create!(name: 'x', folder_path: '/', is_folder: true, is_public: nil)
+      end.to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it 'accepts explicit true and false' do
+      expect(site.public_media.new(name: 'pub', folder_path: '/', is_folder: true, is_public: true)).to be_valid
+      expect(site.public_media.new(name: 'priv', folder_path: '/', is_folder: true, is_public: false)).to be_valid
+    end
+  end
 end

--- a/spec/models/camaleon_cms/media_spec.rb
+++ b/spec/models/camaleon_cms/media_spec.rb
@@ -70,4 +70,14 @@ RSpec.describe CamaleonCms::Media, type: :model do
       expect(partial.items.to_a).not_to include(folder)
     end
   end
+
+  describe '#delete_folder_items' do
+    it 'does not destroy real rows when an unsaved folder instance is destroyed' do
+      child = site.public_media.create!(name: 'real.txt', folder_path: '/docs', is_folder: false)
+
+      site.public_media.new(name: 'docs', folder_path: '/', is_folder: true).destroy
+
+      expect(described_class.exists?(child.id)).to be true
+    end
+  end
 end

--- a/spec/uploaders/local_uploader_spec.rb
+++ b/spec/uploaders/local_uploader_spec.rb
@@ -6,6 +6,32 @@ RSpec.describe CamaleonCmsLocalUploader do
   let(:current_site) { Cama::Site.first.decorate }
   let(:uploader) { described_class.new(current_site: current_site) }
 
+  describe '#add_file (key normalization)' do
+    let(:root_folder) { uploader.instance_variable_get(:@root_folder) }
+
+    def upload(key)
+      io = Tempfile.new(['src', '.txt'])
+      io.write('data')
+      io.rewind
+      uploader.add_file(io, key, same_name: true)
+    ensure
+      io.close
+    end
+
+    after do
+      FileUtils.rm_f(File.join(root_folder, 'x.txt'))
+      FileUtils.rm_rf(File.join(root_folder, 'temporal'))
+    end
+
+    it 'stores a canonical folder_path for a dot-segment key' do
+      expect(upload('/./x.txt')['folder_path']).to eq('/')
+    end
+
+    it 'forces a leading slash for a key without one' do
+      expect(upload('temporal/x.txt')['folder_path']).to eq('/temporal')
+    end
+  end
+
   context 'with an invalid path containing path traversal characters' do
     describe '#add_folder' do
       it 'returns an error' do

--- a/spec/uploaders/local_uploader_spec.rb
+++ b/spec/uploaders/local_uploader_spec.rb
@@ -6,6 +6,34 @@ RSpec.describe CamaleonCmsLocalUploader do
   let(:current_site) { Cama::Site.first.decorate }
   let(:uploader) { described_class.new(current_site: current_site) }
 
+  describe '#delete_folder (path containment)' do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        uploader.instance_variable_set(:@root_folder, dir)
+        example.run
+      end
+    end
+
+    it 'refuses a key that resolves to the media root and keeps the files' do
+      keep = File.join(uploader.instance_variable_get(:@root_folder), 'keep.txt')
+      File.write(keep, 'data')
+
+      result = uploader.delete_folder('/.')
+
+      expect(result).to eq(error: 'Invalid folder path')
+      expect(File.exist?(keep)).to be true
+    end
+
+    it 'still deletes a genuine subfolder' do
+      sub = File.join(uploader.instance_variable_get(:@root_folder), 'docs')
+      FileUtils.mkdir_p(sub)
+
+      uploader.delete_folder('/docs')
+
+      expect(Dir.exist?(sub)).to be false
+    end
+  end
+
   describe '#add_file (key normalization)' do
     let(:root_folder) { uploader.instance_variable_get(:@root_folder) }
 


### PR DESCRIPTION
## What and Why

Hardens the media library against folder rows whose stored name or path collapses under the media-key normalizer. The trigger was production data holding a scanner-created folder named `.` at folder path `/.`: `"#{folder_path}/#{name}".cama_fix_media_key` resolved that folder's children path back to its own path, so `CamaleonCms::Media#items` selected the folder itself and the `before_destroy` cascade recursed until `SystemStackError`.

The fix works at the right altitude — the folder relation, the row factory, and the storage boundary — rather than patching the single crash:

- **Listing (`#items`) descends only into genuine sub-paths.** Children must live strictly below the folder's own path. This returns an empty relation for a degenerate row instead of selecting its siblings (so destroy no longer silently deletes unrelated media), and makes recursion of any cycle length impossible, since path depth would have to strictly increase around a loop. It also drops the earlier id-based self-exclusion, so a row loaded without its id column no longer re-selects itself.
- **Save-time rejection of non-canonical rows.** A name that is `.`, `..`, blank, or contains `/`, or a non-canonical `folder_path` (`/.`, `/a//b`, a trailing slash), is refused at save instead of stored, so aliasing rows cannot be created going forward. Existing (legacy) rows remain safe to destroy and list through the guards above.
- **The local uploader normalizes storage keys** the same way the S3 uploader already does, so an upload with a dot-segment folder (`/./.`) or a slash-less folder (`temporal`) can no longer mint the aliasing rows or store an unreachable path.
- **Smaller hardening in the same subsystem:** `create_parent_folders` skips blank path segments; destroying an unsaved folder instance no longer cascades onto real rows; orphan (site-less) rows are safe to save and destroy; a NULL `is_public` is rejected.

Also included, in the same media subsystem:

- **Security fix:** the local uploader's delete-folder action guarded only against `..`, so a folder key that resolves to the media root (e.g. `/.`) let a user with media permission recursively delete the site's entire upload directory from disk. Folder deletion is now contained to the media root.

A pre-existing, self-consistent inversion in `get_media_collection` (stored `is_public` is the opposite of a row's real visibility) is documented in place but intentionally not changed here — correcting the flag requires a paired data migration and is tracked separately.

## User-Visible Impact

Media folders whose stored name or path collapses (e.g. a folder named `.`) can now be deleted instead of crashing with `SystemStackError` or silently deleting neighboring media; such names and paths are refused when new media is saved. A folder-delete request can no longer wipe the site's upload directory from disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
