### PR TITLE
Fix NameError destroying a term taxonomy row whose taxonomy maps to no subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- **Bug fix:** Destroying a `term_taxonomy` row whose taxonomy value maps to no model — typically one left behind by a removed or renamed plugin — raised `NameError`, which also blocked `Site#destroy` for any site owning such a row. Both now complete normally. [#1287](https://github.com/owen2345/camaleon-cms/pull/1287).
+  - [Upgrade notes](docs/upgrading-to-2.9.5.md#deleting-legacy-taxonomy-rows-no-longer-crashes).
+
 - **Bug fix:** Media rows stored `is_public` inverted — `site.public_media` returned the site's private files and vice versa; uploads now store the flag matching real visibility, plus stale-cache hardening. [#1286](https://github.com/owen2345/camaleon-cms/pull/1286).
   - **Notes for upgraders:** run `bundle exec rake camaleon_cms:repair_media_visibility` right after deploying — [upgrade notes](docs/upgrading-to-2.9.5.md#media-visibility-repair).
 

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -378,7 +378,7 @@ module CamaleonCms
       # CommonRelationships — only their subclasses receive it via the inherited hook — so a
       # row whose stored type maps to no subclass instantiates without custom_field_groups;
       # such records own no groups, so there is nothing to destroy.
-      elsif respond_to?(:custom_field_groups) && get_field_groups.present?
+      elsif respond_to?(:custom_field_groups)
         get_field_groups.destroy_all
       end
     end

--- a/app/models/concerns/camaleon_cms/custom_fields_read.rb
+++ b/app/models/concerns/camaleon_cms/custom_fields_read.rb
@@ -374,7 +374,11 @@ module CamaleonCms
         get_field_groups('Category').destroy_all
         get_field_groups('PostTag').destroy_all
       elsif ['NavMenuItem'].include?(class_name) # menu items doesn't include field groups
-      elsif get_field_groups.present?
+      # STI base classes (TermTaxonomy, PostDefault) include this concern without
+      # CommonRelationships — only their subclasses receive it via the inherited hook — so a
+      # row whose stored type maps to no subclass instantiates without custom_field_groups;
+      # such records own no groups, so there is nothing to destroy.
+      elsif respond_to?(:custom_field_groups) && get_field_groups.present?
         get_field_groups.destroy_all
       end
     end

--- a/docs/upgrading-to-2.9.5.md
+++ b/docs/upgrading-to-2.9.5.md
@@ -2,8 +2,9 @@
 
 Version `2.9.5` is a bug-fix and security release. It corrects the long-standing inversion of the
 media `is_public` flag (with a repair task for existing installs and hardening around stale media
-caches), contains media folder deletion to the media root, and raises the bundled
-`cama_contact_form` floor to the release that completes its security series.
+caches), contains media folder deletion to the media root, lets sites carrying taxonomy rows from
+a removed plugin be deleted again, and raises the bundled `cama_contact_form` floor to the release
+that completes its security series.
 
 **Your stored files are never touched by upgrading.** One change in this release does rewrite
 database rows: the media *cache* table (which mirrors your storage) is purged and rebuilt by the
@@ -18,6 +19,7 @@ what theme/plugin developers should know.
 | --- | --- |
 | **Any install** | `bundle update camaleon_cms`, deploy, then **immediately** run the [media visibility repair](#media-visibility-repair) |
 | Reads `site.public_media` / `site.private_media` or `media.is_public` **directly** (reports, plugins, exports) | Those now return what their names say — drop any compensating inversion ([details](#notes-for-theme--plugin-developers)) |
+| Hit `NameError: undefined local variable or method 'custom_field_groups'` deleting a site or taxonomy row | Nothing — retry the delete after upgrading ([details](#deleting-legacy-taxonomy-rows-no-longer-crashes)) |
 | Uses the **contact form** | The same bundle update raises `cama_contact_form` to `~> 0.1.14` |
 
 ---
@@ -72,6 +74,17 @@ the media root; folders whose stored name or path collapses (e.g. one named `.`)
 with `SystemStackError` or delete sibling media on destroy, and such non-canonical names and
 paths are refused at save. No operator action; you may observe the save-time refusal if something
 was creating such folders programmatically.
+
+---
+
+## Deleting legacy taxonomy rows no longer crashes
+
+A `term_taxonomy` row whose `taxonomy` value matches no model — typically left behind by a plugin
+that was removed or that renamed its taxonomy, such as `ecommerce_coupon` — loads as the base
+`CamaleonCms::TermTaxonomy` by design. Destroying one raised `NameError: undefined local variable
+or method 'custom_field_groups'`, which also aborted **`Site#destroy`** for any site owning such a
+row: the site could not be deleted at all. Both now complete normally. No operator action, and
+nothing to repair — simply retry the delete. Rows that map to a real model are unaffected.
 
 ---
 

--- a/docs/upgrading-to-2.9.5.md
+++ b/docs/upgrading-to-2.9.5.md
@@ -19,7 +19,7 @@ what theme/plugin developers should know.
 | --- | --- |
 | **Any install** | `bundle update camaleon_cms`, deploy, then **immediately** run the [media visibility repair](#media-visibility-repair) |
 | Reads `site.public_media` / `site.private_media` or `media.is_public` **directly** (reports, plugins, exports) | Those now return what their names say — drop any compensating inversion ([details](#notes-for-theme--plugin-developers)) |
-| Hit `NameError: undefined local variable or method 'custom_field_groups'` deleting a site or taxonomy row | Nothing — retry the delete after upgrading ([details](#deleting-legacy-taxonomy-rows-no-longer-crashes)) |
+| Hit `NameError: undefined local variable or method custom_field_groups` deleting a site or taxonomy row | Nothing — retry the delete after upgrading ([details](#deleting-legacy-taxonomy-rows-no-longer-crashes)) |
 | Uses the **contact form** | The same bundle update raises `cama_contact_form` to `~> 0.1.14` |
 
 ---
@@ -82,8 +82,9 @@ was creating such folders programmatically.
 A `term_taxonomy` row whose `taxonomy` value matches no model — typically left behind by a plugin
 that was removed or that renamed its taxonomy, such as `ecommerce_coupon` — loads as the base
 `CamaleonCms::TermTaxonomy` by design. Destroying one raised `NameError: undefined local variable
-or method 'custom_field_groups'`, which also aborted **`Site#destroy`** for any site owning such a
-row: the site could not be deleted at all. Both now complete normally. No operator action, and
+or method custom_field_groups` (the identifier's quoting in the message varies by Ruby version),
+which also aborted **`Site#destroy`** for any site owning such a row: the site could not be
+deleted at all. Both now complete normally. No operator action, and
 nothing to repair — simply retry the delete. Rows that map to a real model are unaffected.
 
 ---

--- a/openspec/specs/sti-discriminator-compatibility/spec.md
+++ b/openspec/specs/sti-discriminator-compatibility/spec.md
@@ -75,6 +75,12 @@ Code handling unmapped rows SHALL work with column attributes only.
 - **WHEN** a `CamaleonCms::Site` with a child `term_taxonomy` row of that kind is destroyed
 - **THEN** the site and the child row are deleted through the `dependent: :destroy` cascade
 
+#### Scenario: Destroying a posts row whose post_class maps to no subclass
+
+- **WHEN** a `posts` row whose `post_class` matches no loaded class is loaded through the base
+  `CamaleonCms::PostDefault` and destroyed
+- **THEN** the row is deleted and no `NameError` is raised
+
 ### Requirement: A discriminator resolving to a non-descendant class is treated as unknown
 
 If a discriminator value camelizes to the name of a class that is not a descendant of the STI

--- a/openspec/specs/sti-discriminator-compatibility/spec.md
+++ b/openspec/specs/sti-discriminator-compatibility/spec.md
@@ -43,15 +43,26 @@ The base-class fallback SHALL NOT change resolution for known values: built-in t
 - **WHEN** a row with `taxonomy == 'category'` is loaded through `TermTaxonomy.find`
 - **THEN** the instance is a `CamaleonCms::Category`
 
-### Requirement: STI root instances support the full record lifecycle
+### Requirement: STI root instances support the plain record lifecycle
 
 A record instantiated as the STI root because its discriminator maps to no known class SHALL be
-readable, savable and destroyable. Model code shared between the root and its subclasses SHALL NOT
+readable, savable and destroyable as a plain record — loaded, persisted and removed through its
+column attributes. Lifecycle callbacks shared between the root and its subclasses SHALL NOT
 assume associations that only subclasses receive: `CamaleonCms::TermTaxonomy` and
 `CamaleonCms::PostDefault` include `CustomFieldsRead` themselves but gain `CommonRelationships`
 (and therefore `custom_field_groups`, `custom_field_values`, `metas`, `custom_fields`) only through
 their `inherited` hook, so root instances respond to neither. Such records own no custom field
 groups, so lifecycle callbacks SHALL skip that teardown rather than raise.
+
+The custom-field and meta APIs are subclass surface, not part of this contract: on a root
+instance, readers and writers such as `get_meta`, `set_meta` and `get_field_values` raise
+`NameError`, and a save carrying `data_options`/`data_metas` raises through the metas callbacks.
+Code handling unmapped rows SHALL work with column attributes only.
+
+#### Scenario: Saving a root with a meta payload fails loudly
+
+- **WHEN** a record instantiated as the STI root is saved with `data_options` or `data_metas` set
+- **THEN** the save raises `NameError` rather than silently dropping the payload
 
 #### Scenario: Destroying a row whose taxonomy maps to no subclass
 

--- a/openspec/specs/sti-discriminator-compatibility/spec.md
+++ b/openspec/specs/sti-discriminator-compatibility/spec.md
@@ -43,6 +43,27 @@ The base-class fallback SHALL NOT change resolution for known values: built-in t
 - **WHEN** a row with `taxonomy == 'category'` is loaded through `TermTaxonomy.find`
 - **THEN** the instance is a `CamaleonCms::Category`
 
+### Requirement: STI root instances support the full record lifecycle
+
+A record instantiated as the STI root because its discriminator maps to no known class SHALL be
+readable, savable and destroyable. Model code shared between the root and its subclasses SHALL NOT
+assume associations that only subclasses receive: `CamaleonCms::TermTaxonomy` and
+`CamaleonCms::PostDefault` include `CustomFieldsRead` themselves but gain `CommonRelationships`
+(and therefore `custom_field_groups`, `custom_field_values`, `metas`, `custom_fields`) only through
+their `inherited` hook, so root instances respond to neither. Such records own no custom field
+groups, so lifecycle callbacks SHALL skip that teardown rather than raise.
+
+#### Scenario: Destroying a row whose taxonomy maps to no subclass
+
+- **WHEN** a `term_taxonomy` row whose `taxonomy` is a value no loaded class claims (e.g.
+  `ecommerce_coupon`, left by a plugin whose model now stores a different `sti_name`) is destroyed
+- **THEN** the row is deleted and no `NameError` is raised
+
+#### Scenario: Destroying a site that owns such a row
+
+- **WHEN** a `CamaleonCms::Site` with a child `term_taxonomy` row of that kind is destroyed
+- **THEN** the site and the child row are deleted through the `dependent: :destroy` cascade
+
 ### Requirement: A discriminator resolving to a non-descendant class is treated as unknown
 
 If a discriminator value camelizes to the name of a class that is not a descendant of the STI

--- a/spec/models/sti_discriminator_compatibility_spec.rb
+++ b/spec/models/sti_discriminator_compatibility_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe 'STI discriminator compatibility', type: :model do
       expect(record.reload.taxonomy).to eq('custom_tax')
     end
 
+    # The plain lifecycle contract covers column attributes only; the meta and custom-field
+    # APIs come from CommonRelationships, which the root never gains, so a meta payload must
+    # fail loudly rather than be silently dropped.
+    it 'raises when saving a root with a meta payload' do
+      record = CamaleonCms::TermTaxonomy.new(taxonomy: 'custom_tax', name: 'Custom With Payload')
+      record.data_options = { color: 'red' }
+
+      expect { record.save! }.to raise_error(NameError, /metas/)
+    end
+
     it 'still resolves built-in values to their subclasses' do
       category = CamaleonCms::Category.first
 

--- a/spec/models/sti_discriminator_compatibility_spec.rb
+++ b/spec/models/sti_discriminator_compatibility_spec.rb
@@ -89,5 +89,16 @@ RSpec.describe 'STI discriminator compatibility', type: :model do
       expect(record).to be_instance_of(CamaleonCms::PostDefault)
       expect(record.post_class).to eq('External::Unknown')
     end
+
+    # Raw insert + find is deliberate: PostDefault.new resolves to CamaleonCms::Post through the
+    # post_class column default, so only a found row exercises the true root's destroy chain.
+    it 'destroys a row with an unknown post_class cleanly' do
+      id = insert_row(table, post_class: 'External::Unknown', title: 'Doomed Foreign Post', status: 'published')
+      record = CamaleonCms::PostDefault.find(id)
+      expect(record).to be_instance_of(CamaleonCms::PostDefault)
+
+      expect { record.destroy! }.not_to raise_error
+      expect(CamaleonCms::PostDefault.exists?(id)).to be(false)
+    end
   end
 end

--- a/spec/models/term_taxonomy_base_class_destroy_spec.rb
+++ b/spec/models/term_taxonomy_base_class_destroy_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Rows whose taxonomy value maps to no STI subclass instantiate as the base
+# CamaleonCms::TermTaxonomy — find_sti_class falls back to base_class by design.
+# The base class does not include CommonRelationships (only subclasses receive it
+# through the inherited hook), so it has no custom_field_groups association, and
+# CustomFieldsRead#_destroy_custom_field_groups must not assume one. Legacy rows
+# like taxonomy='ecommerce_coupon' (an old plugin whose model now stores 'coupon')
+# hit this on Site#destroy through `has_many :term_taxonomies, dependent: :destroy`.
+RSpec.describe 'TermTaxonomy base-class destroy', type: :model do
+  let(:conn) { ActiveRecord::Base.connection }
+  let(:table) { CamaleonCms::TermTaxonomy.table_name }
+
+  def insert_row(columns)
+    now = conn.quote(Time.current)
+    cols = "#{columns.keys.join(', ')}, created_at, updated_at"
+    vals = "#{columns.values.map { |v| conn.quote(v) }.join(', ')}, #{now}, #{now}"
+    conn.execute("INSERT INTO #{table} (#{cols}) VALUES (#{vals})")
+    conn.select_value("SELECT MAX(id) FROM #{table}")
+  end
+
+  it 'destroys a row with an unmapped taxonomy value cleanly' do
+    id = insert_row(taxonomy: 'ecommerce_coupon', name: 'Legacy Coupon')
+    record = CamaleonCms::TermTaxonomy.find(id)
+    expect(record).to be_instance_of(CamaleonCms::TermTaxonomy)
+
+    expect { record.destroy! }.not_to raise_error
+    expect(CamaleonCms::TermTaxonomy.exists?(id)).to be(false)
+  end
+
+  it 'destroys a site with such a legacy child row cleanly' do
+    site = create(:site)
+    id = insert_row(taxonomy: 'ecommerce_coupon', name: 'Legacy Coupon', parent_id: site.id)
+
+    expect { site.destroy! }.not_to raise_error
+    expect(CamaleonCms::TermTaxonomy.exists?(id)).to be(false)
+  end
+end

--- a/spec/models/term_taxonomy_base_class_destroy_spec.rb
+++ b/spec/models/term_taxonomy_base_class_destroy_spec.rb
@@ -1,26 +1,20 @@
 # frozen_string_literal: true
 
 # Rows whose taxonomy value maps to no STI subclass instantiate as the base
-# CamaleonCms::TermTaxonomy — find_sti_class falls back to base_class by design.
+# CamaleonCms::TermTaxonomy — find_sti_class falls back to base_class by design,
+# on the write path too, so create! persists the unmapped value as the root.
 # The base class does not include CommonRelationships (only subclasses receive it
 # through the inherited hook), so it has no custom_field_groups association, and
 # CustomFieldsRead#_destroy_custom_field_groups must not assume one. Legacy rows
 # like taxonomy='ecommerce_coupon' (an old plugin whose model now stores 'coupon')
 # hit this on Site#destroy through `has_many :term_taxonomies, dependent: :destroy`.
 RSpec.describe 'TermTaxonomy base-class destroy', type: :model do
-  let(:conn) { ActiveRecord::Base.connection }
-  let(:table) { CamaleonCms::TermTaxonomy.table_name }
-
-  def insert_row(columns)
-    now = conn.quote(Time.current)
-    cols = "#{columns.keys.join(', ')}, created_at, updated_at"
-    vals = "#{columns.values.map { |v| conn.quote(v) }.join(', ')}, #{now}, #{now}"
-    conn.execute("INSERT INTO #{table} (#{cols}) VALUES (#{vals})")
-    conn.select_value("SELECT MAX(id) FROM #{table}")
+  def create_legacy_row(attrs = {})
+    CamaleonCms::TermTaxonomy.create!({ taxonomy: 'ecommerce_coupon', name: 'Legacy Coupon' }.merge(attrs))
   end
 
   it 'destroys a row with an unmapped taxonomy value cleanly' do
-    id = insert_row(taxonomy: 'ecommerce_coupon', name: 'Legacy Coupon')
+    id = create_legacy_row.id
     record = CamaleonCms::TermTaxonomy.find(id)
     expect(record).to be_instance_of(CamaleonCms::TermTaxonomy)
 
@@ -30,7 +24,7 @@ RSpec.describe 'TermTaxonomy base-class destroy', type: :model do
 
   it 'destroys a site with such a legacy child row cleanly' do
     site = create(:site)
-    id = insert_row(taxonomy: 'ecommerce_coupon', name: 'Legacy Coupon', parent_id: site.id)
+    id = create_legacy_row(parent_id: site.id).id
 
     expect { site.destroy! }.not_to raise_error
     expect(CamaleonCms::TermTaxonomy.exists?(id)).to be(false)


### PR DESCRIPTION
**User-Visible Impact:** A site carrying `term_taxonomy` rows left behind by a removed or renamed plugin (e.g. `taxonomy='ecommerce_coupon'`) can be deleted again, and destroying such a row on its own no longer raises `NameError`.

## What and Why

`CamaleonCms::TermTaxonomy.find_sti_class` returns `base_class` for a discriminator value that maps to no known class. That fallback is deliberate — it preserves the pre-STI tolerance of the `taxonomy` column, where any string was legal (`sti-discriminator-compatibility`). Such rows were readable and savable, but not destroyable.

`CustomFieldsRead` is included directly in `TermTaxonomy` and registers `before_destroy :_destroy_custom_field_groups`. For a class name it does not recognize, that callback falls through to `get_field_groups`, which reads `custom_field_groups`. The association arrives only with `CommonRelationships`, and `TermTaxonomy` includes that into **subclasses**, through its `inherited` hook — never into the base class itself. So destroying a base-class instance raised `NameError: undefined local variable or method custom_field_groups`.

`Site#destroy` inherited the crash through `has_many :term_taxonomies, dependent: :destroy`: one unmapped child row aborted the entire site deletion. This is live production data in camaleon_website — the ecommerce plugin's models compute an `sti_name` of `coupon`, so rows stored as `ecommerce_coupon` resolve to the base class even with the plugin eager-loaded.

## How

The callback's fallback branch is guarded with `respond_to?(:custom_field_groups)`; when the record responds, the groups are destroyed in a single pass (`destroy_all` on an empty collection is already a no-op, so no presence pre-check — which double-loaded the relation for classes like `Site` that build a fresh relation per call — stands in front of it). A base-class instance owns no custom field groups — nothing can be attached through an association it does not have — so skipping the teardown is the correct outcome rather than a suppressed error. Every subclass responds to the association, so subclass teardown is unchanged. `PostDefault` shares the same base-class-includes-the-concern, subclasses-get-the-relationships pattern and is covered by the same guard.

The alternative — defining a no-op or a real association on the base class — was rejected: it would give the STI root a `custom_field_groups` scope keyed on the demodulized name `TermTaxonomy`, a placement no row ever uses, and it would change what the base class exposes to plugins for the sake of a callback that has nothing to destroy.

## Contract

The `sti-discriminator-compatibility` capability spec gains a requirement scoped to what the guard delivers: STI-root instances support the **plain record lifecycle** — loaded, persisted and destroyed through their column attributes — and lifecycle callbacks shared between the root and its subclasses must not assume associations only subclasses receive. The meta and custom-field APIs are explicitly outside that contract: on a root instance they raise `NameError`, and a save carrying `data_options`/`data_metas` fails loudly rather than silently dropping the payload. Code handling unmapped rows works with column attributes only.

## Coverage

A regression spec creates a row with `taxonomy='ecommerce_coupon'` through the model — the `base_class` fallback applies on the write path too, so `create!` persists the unmapped value as the root, exercising the savable half of the contract — asserts it loads as the base class, and destroys it; a second example destroys a `Site` owning such a child row. Both reproduce the reported `NameError` without the fix. The STI-discriminator spec pins the other two edges: destroying a `posts` row whose `post_class` maps to no subclass (raw-inserted and loaded via `find`, since `PostDefault.new` resolves to `CamaleonCms::Post` through the column default), and the loud `NameError` on a root save that carries a meta payload.

The 2.9.5 upgrade guide records the observable half: affected deletes simply work after upgrading, with nothing to repair, and the error message is quoted in a form that matches every supported Ruby (the identifier quoting in `NameError` messages changed in Ruby 3.4).
