### PR TITLE
Feed the colorpicker custom field its saved value as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Bug fix:** A colorpicker custom field whose saved value is not a colour (the field accepts free text) crashed the picker while the edit form rendered, breaking that field and every custom field after it; the picker now receives the value as a string and falls back to its default colour. [#1288](https://github.com/owen2345/camaleon-cms/pull/1288).
+
 - **Bug fix:** Destroying a `term_taxonomy` row whose taxonomy value maps to no model — typically one left behind by a removed or renamed plugin — raised `NameError`, which also blocked `Site#destroy` for any site owning such a row. Both now complete normally. [#1287](https://github.com/owen2345/camaleon-cms/pull/1287).
   - [Upgrade notes](docs/upgrading-to-2.9.5.md#deleting-legacy-taxonomy-rows-no-longer-crashes).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- **Bug fix:** A colorpicker custom field whose saved value is not a colour (the field accepts free text) crashed the picker while the edit form rendered, breaking that field and every custom field after it; the picker now receives the value as a string and falls back to its default colour. [#1288](https://github.com/owen2345/camaleon-cms/pull/1288).
+- **Bug fix:** A colorpicker custom field whose saved value was not a colour crashed the edit form's field rendering, and saving then silently blanked the record's other custom-field values. Rendering now survives bad values and broken field callbacks, an opened-but-unused picker no longer overwrites the field, and the per-kind field options (colour format, date type, image versions, file formats, post-type filter) persist on save. [#1288](https://github.com/owen2345/camaleon-cms/pull/1288).
+  - [Upgrade notes](docs/upgrading-to-2.9.5.md#audit-custom-field-values-after-a-colorpicker-crash).
 
 - **Bug fix:** Destroying a `term_taxonomy` row whose taxonomy value maps to no model — typically one left behind by a removed or renamed plugin — raised `NameError`, which also blocked `Site#destroy` for any site owning such a row. Both now complete normally. [#1287](https://github.com/owen2345/camaleon-cms/pull/1287).
   - [Upgrade notes](docs/upgrading-to-2.9.5.md#deleting-legacy-taxonomy-rows-no-longer-crashes).

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -139,6 +139,9 @@ function custom_field_colorpicker_val($field, value) {
         var $cp = $field.find(".my-colorpicker");
         var color = value == null || value === '' ? String($cp.attr('data-color') || '') : String(value);
         $cp.attr('data-color', color).data('color', color).colorpicker();
+        // A re-render with a new value must repaint: the bare colorpicker() call is a no-op on
+        // an element whose widget already exists.
+        $cp.colorpicker('update');
     }
 }
 function custom_field_checkbox_val($field, values) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -117,7 +117,11 @@ function custom_field_colorpicker($field) {
 }
 function custom_field_colorpicker_val($field, value) {
     if ($field) {
-        $field.find(".my-colorpicker").attr('data-color', value || '').colorpicker();
+        // Prime jQuery's data cache with the string form as well: the colorpicker reads
+        // data('color'), and reading it from the attribute alone coerces numeric-looking values
+        // to Numbers, which the widget's colour parser cannot take - the throw would abort the
+        // rendering of every custom field after this one.
+        $field.find(".my-colorpicker").attr('data-color', value || '').data('color', String(value || '')).colorpicker();
     }
 }
 function custom_field_checkbox_val($field, values) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -144,15 +144,15 @@ function custom_field_colorpicker_val($field, value) {
 function custom_field_checkbox_val($field, values) {
     if(values == "t") values = 1; // fix for values saved as true
     if ($field) {
-        $field.find('input[value="' + values + '"]').prop('checked', true);
+        // match by property, not a concatenated selector: option values are admin-entered free
+        // text, and a quote in one made the selector throw
+        $field.find('input').filter(function(){ return this.value == values; }).prop('checked', true);
     }
 }
 function custom_field_checkboxs_val($field, values) {
     if ($field) {
-        var selector = values.map(function (value) {
-            return "input[value='" + value + "']"
-        }).join(',');
-        $field.find(selector).prop('checked', true);
+        var vals = ($.isArray(values) ? values : [values]).map(String);
+        $field.find('input').filter(function(){ return vals.indexOf(this.value) != -1; }).prop('checked', true);
     }
 }
 function custom_field_date($field) {
@@ -200,7 +200,7 @@ function custom_field_field_attrs_val($field, value) {
 function custom_field_radio_val($field, value) {
     if ($field) {
         $field.find('input').prop('checked', false);
-        $field.find("input[value='" + value + "']").prop('checked', true);
+        $field.find('input').filter(function(){ return this.value == value; }).prop('checked', true);
     }
 }
 function custom_field_text_area($field) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -112,7 +112,9 @@ function cama_build_custom_field(panel, field_data, values){
 
 function custom_field_colorpicker($field) {
     if ($field) {
-        $field.find(".my-colorpicker").colorpicker();
+        // Same hardening as the _val variant: prime the data cache from whatever the markup
+        // carries, so a coercible or missing data-color cannot crash the widget's constructor.
+        custom_field_colorpicker_val($field, $field.find(".my-colorpicker").attr('data-color'));
     }
 }
 function custom_field_colorpicker_val($field, value) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -117,11 +117,17 @@ function custom_field_colorpicker($field) {
 }
 function custom_field_colorpicker_val($field, value) {
     if ($field) {
-        // Prime jQuery's data cache with the string form as well: the colorpicker reads
-        // data('color'), and reading it from the attribute alone coerces numeric-looking values
-        // to Numbers, which the widget's colour parser cannot take - the throw would abort the
-        // rendering of every custom field after this one.
-        $field.find(".my-colorpicker").attr('data-color', value || '').data('color', String(value || '')).colorpicker();
+        // The widget reads its colour through jQuery's data(), which coerces numeric-looking
+        // attribute values to Numbers the colour parser cannot take; priming the data cache with
+        // the string form is what prevents that (a throw here aborts every later jQuery-ready
+        // handler, not just this group's fields). The attribute write only keeps the DOM
+        // inspectable - it is never read back once the cache is set. A field with no stored
+        // value keeps the markup's declared default (data-color="#fff"). This must receive the
+        // per-instance clone: priming the shared template would leak the first value's colour
+        // into every later instance.
+        var $cp = $field.find(".my-colorpicker");
+        var color = value == null || value === '' ? String($cp.attr('data-color') || '') : String(value);
+        $cp.attr('data-color', color).data('color', color).colorpicker();
     }
 }
 function custom_field_checkbox_val($field, values) {

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -64,7 +64,7 @@ function cama_build_custom_field(panel, field_data, values){
         if(!$field.find('.group-input-fields-content').hasClass('cama_skip_cf_rename_multiple')) {
             field.find('input, textarea, select').each(function(){ $(this).attr('name', $(this).attr('name').replace('[]', '['+field_counter+']')) });
         }
-        if(field_data.disabled){
+        if(field_data.is_disabled){
             field.find('input, textarea, select').prop('readonly', true).filter('select').click(function(){ return false; }).focus(function(){ $(this).blur(); });
             field.find('.btn').addClass('disabled').unbind().click(function(){ return false; });
         }

--- a/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_custom_fields.js
@@ -75,7 +75,16 @@ function cama_build_custom_field(panel, field_data, values){
             field.find('.input-value').val(value).trigger('change', {field_rendered: true}).data('value', value);
         }
         $sortable.append(field);
-        if(callback) window[callback](field, value);
+        // A render callback failure must degrade its own field, not the page: a throw here
+        // escapes the jQuery-ready handler and aborts every custom field and initialiser
+        // registered after it.
+        if(callback){
+            if (typeof window[callback] === 'function') {
+                try { window[callback](field, value); } catch(e){ console.warn('custom field render callback ' + callback + ' failed', e); }
+            } else {
+                console.warn('custom field render callback ' + callback + ' is not defined');
+            }
+        }
         field_counter ++;
     }
     if(field_data.kind != 'checkbox' && values.length <= 0) {

--- a/app/assets/javascripts/camaleon_cms/admin/_translator.js
+++ b/app/assets/javascripts/camaleon_cms/admin/_translator.js
@@ -27,6 +27,9 @@ jQuery(function($){
         // language(optional): get translation value for this language
         // return a hash of translations
         get_translations = function(text, language){
+            // values reach here through jQuery's data(), which preserves JSON types; this
+            // parser needs a string
+            if(text != null && typeof text != 'string') text = String(text);
             var translations_per_locale = {};
             var res = "";
             if(!text || text.trim().search("<!--") != 0){ // not translated string

--- a/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
+++ b/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
@@ -133,7 +133,7 @@
 	var Colorpicker = function(element, options){
 		this.element = $(element);
 		var format = options.format||this.element.data('color-format')||'hex';
-		this.format = CPGlobal.translateFormats[format];
+		this.format = CPGlobal.translateFormats[format] || CPGlobal.translateFormats.hex; // unknown or coerced formats fall back instead of leaving format undefined (hide() calls it uncaught)
 		this.isInput = this.element.is('input');
 		this.component = this.element.is('.color') ? this.element.find('.input-group-addon') : false;
 		

--- a/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
+++ b/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
@@ -169,6 +169,9 @@
 		
 		this.base = this.picker.find('div:first')[0].style;
 		this.update();
+		// Track whether a colour was actually chosen: hide() must not write the formatted
+		// default back over a value the user never touched.
+		this.colorpicked = false;
 	};
 	
 	Colorpicker.prototype = {
@@ -204,6 +207,7 @@
 		},
 		
 		setValue: function(newColor) {
+			this.colorpicked = true;
 			this.color = new Color(newColor);
 			this.picker.find('i')
 				.eq(0).css({left: this.color.value.s*100, top: 100 - this.color.value.b*100}).end()
@@ -223,11 +227,13 @@
 				$(document).off({
 					'mousedown': this.hide
 				});
-				if (this.component){
-					this.element.find('input').prop('value', this.format.call(this));
+				if (this.colorpicked) {
+					if (this.component){
+						this.element.find('input').prop('value', this.format.call(this));
+					}
+					this.element.data('color', this.format.call(this));
 				}
-				this.element.data('color', this.format.call(this));
-			} else {
+			} else if (this.colorpicked) {
 				this.element.prop('value', this.format.call(this));
 			}
 			this.element.trigger({
@@ -326,6 +332,7 @@
 			if (this.slider.callTop) {
 				this.color[this.slider.callTop].call(this.color, top/100);
 			}
+			this.colorpicked = true;
 			this.previewColor();
 			this.element.trigger({
 				type: 'changeColor',

--- a/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
+++ b/app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js
@@ -136,6 +136,7 @@
 		this.format = CPGlobal.translateFormats[format] || CPGlobal.translateFormats.hex; // unknown or coerced formats fall back instead of leaving format undefined (hide() calls it uncaught)
 		this.isInput = this.element.is('input');
 		this.component = this.element.is('.color') ? this.element.find('.input-group-addon') : false;
+		if (this.component && !this.component.length) this.component = false; // an empty match is no component
 		
 		this.picker = $(CPGlobal.template)
 							.appendTo('body')
@@ -160,10 +161,11 @@
 			this.alpha = this.picker.find('.colorpicker-alpha')[0].style;
 		}
 		
-		if (this.component){
+		if (this.component && this.element.find('i').length){
 			this.picker.find('.colorpicker-color').hide();
 			this.preview = this.element.find('i')[0].style;
 		} else {
+			// no swatch icon in the markup: preview inside the popup instead of crashing
 			this.preview = this.picker.find('div:last')[0].style;
 		}
 		

--- a/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
+++ b/app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb
@@ -178,9 +178,13 @@ module CamaleonCms
         def permitted_field_options
           return {} if params[:field_options].blank?
 
+          # Every per-kind extra option the settings panels offer (custom_fields_helper) must be
+          # listed here or it is silently stripped on save. :command (select_eval) is deliberately
+          # not permitted.
           params.require(:field_options).permit(params[:field_options].keys.index_with do
             [:field_key, :multiple, :required, :translate, :default_value, :dimension, :width, :height, :class,
-             :placeholder, { default_values: [], multiple_options: %i[title value default] }]
+             :placeholder, :color_format, :type_date, :formats, :versions, :panel_hidden,
+             { default_values: [], multiple_options: %i[title value default], post_types: [] }]
           end).to_h
         end
 

--- a/docs/upgrading-to-2.9.5.md
+++ b/docs/upgrading-to-2.9.5.md
@@ -21,6 +21,7 @@ what theme/plugin developers should know.
 | Reads `site.public_media` / `site.private_media` or `media.is_public` **directly** (reports, plugins, exports) | Those now return what their names say — drop any compensating inversion ([details](#notes-for-theme--plugin-developers)) |
 | Hit `NameError: undefined local variable or method custom_field_groups` deleting a site or taxonomy row | Nothing — retry the delete after upgrading ([details](#deleting-legacy-taxonomy-rows-no-longer-crashes)) |
 | Uses the **contact form** | The same bundle update raises `cama_contact_form` to `~> 0.1.14` |
+| Has colorpicker custom fields that ever held free text | Review affected records — sibling field values may have been blanked ([details](#audit-custom-field-values-after-a-colorpicker-crash)) |
 
 ---
 
@@ -101,6 +102,25 @@ throttle, an attachment-count cap, upload-scan coverage, an e-mail tracking-pixe
 response-file-cleanup confinement). Drop-in; no config or API change.
 
 ---
+
+## Audit custom-field values after a colorpicker crash
+
+A colorpicker custom field accepts free text, and a saved non-colour value (for example a bare
+number) crashed the admin edit form's field rendering on 2.9.4 and earlier. The damage was wider
+than the broken picker: the crash aborted the rendering of every custom field registered after it,
+and **saving the record in that state silently blanked those unrendered fields' stored values**
+(the save replaces all of a record's field values with what the form posts, and the broken form
+posted empties).
+
+**Action:** if any of your colorpicker custom fields ever held a non-colour value, review records
+of that post type that were edited and saved while on an affected version — their *other*
+custom-field values may have been emptied and need re-entering. Rendering now survives bad values,
+and a picker that is opened but not used no longer rewrites the field on close.
+
+Separately, the per-kind field options in the custom-fields settings — colorpicker **Color
+Format**, the date field's date-vs-datetime toggle, image **versions**, file **formats**, and the
+posts field's post-type filter — were silently discarded on every save. They persist now, but any
+choice made before this release was never stored: reopen the field group and pick them again.
 
 ## Notes for theme & plugin developers
 

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -9,17 +9,17 @@ describe 'the colorpicker custom field', :js do
   init_site
 
   before do
-    post_type = @site.post_types.create!(name: 'Colored', slug: 'colored', description: 'x')
-    @colored_post = post_type.add_post(title: 'Tinted', slug: 'tinted', content: 'x')
-    @colored_post.add_field(
-      { 'name' => 'Tint', 'slug' => 'tint' }, { 'field_key' => 'colorpicker', 'translate' => false }
-    )
-    @colored_post.set_field_value('tint', '2')
+    @post.add_field({ 'name' => 'Tint', 'slug' => 'tint' }, { 'field_key' => 'colorpicker' })
+    @post.set_field_value('tint', '2')
+  end
+
+  def visit_post_edit
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/post_type/#{@post.post_type.id}/posts/#{@post.id}/edit"
   end
 
   it 'initialises the picker even when the saved value is not a colour string' do
-    admin_sign_in
-    visit "#{cama_root_relative_path}/admin/post_type/#{@colored_post.post_type.id}/posts/#{@colored_post.id}/edit"
+    visit_post_edit
 
     expect(page).to have_css('.my-colorpicker')
     initialised = page.evaluate_script(<<~JS)

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -65,6 +65,19 @@ describe 'the colorpicker custom field', :js do
 
     expect(page).to have_css('.my-colorpicker', count: 1)
     expect(page.evaluate_script("jQuery('[data-field-key=tail] .input-value').val()")).to eq('after the radio')
+    # and the stored option is actually selected, not merely tolerated
+    expect(page.evaluate_script(%(jQuery("[data-field-key=pick] input:checked").val()))).to eq("Bob's pick")
+  end
+
+  it 'checks a checkboxes option whose value holds a quote' do
+    @post.add_field({ 'name' => 'Tags', 'slug' => 'tags' },
+                    { 'field_key' => 'checkboxes',
+                      'multiple_options' => [{ 'title' => 'Bobs', 'value' => "Bob's tag" },
+                                             { 'title' => 'Plain', 'value' => 'plain' }] })
+    @post.set_field_value('tags', "Bob's tag")
+    visit_post_edit
+
+    expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
   it 'warns when a render callback breaks instead of dying silently' do

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -4,13 +4,17 @@
 # data-color attribute and initialising the picker. jQuery coerces a numeric-looking attribute
 # to a Number when the widget reads it back, and the picker's colour parser takes only strings -
 # so a saved free-text value like "2" crashed the picker's constructor mid-render, taking the
-# rest of the form's custom fields down with it.
+# rest of the form's custom fields down with it. The examples pin the picker, its value, the
+# fields rendered after it, and the whole class of values jQuery coerces.
 describe 'the colorpicker custom field', :js do
   init_site
 
+  # The text field after the colorpicker pins the blast radius: the old crash aborted the
+  # rendering of every custom field after the broken one.
   before do
     @post.add_field({ 'name' => 'Tint', 'slug' => 'tint' }, { 'field_key' => 'colorpicker' })
-    @post.set_field_value('tint', '2')
+    @post.add_field({ 'name' => 'Caption', 'slug' => 'caption' }, { 'field_key' => 'text_box' })
+    @post.set_field_value('caption', 'after the picker')
   end
 
   def visit_post_edit
@@ -18,15 +22,46 @@ describe 'the colorpicker custom field', :js do
     visit "#{cama_root_relative_path}/admin/post_type/#{@post.post_type.id}/posts/#{@post.id}/edit"
   end
 
-  it 'initialises the picker even when the saved value is not a colour string' do
+  def initialised_picker_count
+    page.evaluate_script(<<~JS)
+      jQuery('.my-colorpicker').filter(function(){ return !!jQuery(this).data('colorpicker'); }).length
+    JS
+  end
+
+  def caption_field_value
+    page.evaluate_script("jQuery('.c-field-text_box .input-value').val()")
+  end
+
+  it 'renders the picker, its value and the fields after it despite a non-colour value' do
+    @post.set_field_value('tint', '2')
     visit_post_edit
 
-    expect(page).to have_css('.my-colorpicker')
-    initialised = page.evaluate_script(<<~JS)
-      jQuery('.my-colorpicker').toArray().every(function(el){
-        return !!jQuery(el).data('colorpicker');
-      })
-    JS
-    expect(initialised).to be(true)
+    expect(page).to have_css('.my-colorpicker', count: 1)
+    expect(initialised_picker_count).to eq(1)
+    expect(page.find('.my-colorpicker input').value).to eq('2')
+    expect(caption_field_value).to eq('after the picker')
+  end
+
+  it 'renders a valid stored colour on the swatch' do
+    @post.set_field_value('tint', '#00ff00')
+    visit_post_edit
+
+    expect(page).to have_css('.my-colorpicker', count: 1)
+    expect(initialised_picker_count).to eq(1)
+    expect(page.find('.my-colorpicker input').value).to eq('#00ff00')
+    expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(0, 255, 0)')
+  end
+
+  # Everything jQuery's data() coerces to a non-string crashed identically: numbers, booleans,
+  # null, and JSON objects/arrays.
+  ['true', 'null', '{"a":1}'].each do |stored|
+    it "still initialises when the stored value is #{stored.inspect}" do
+      @post.set_field_value('tint', stored)
+      visit_post_edit
+
+      expect(page).to have_css('.my-colorpicker', count: 1)
+      expect(initialised_picker_count).to eq(1)
+      expect(caption_field_value).to eq('after the picker')
+    end
   end
 end

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -52,6 +52,30 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(0, 255, 0)')
   end
 
+  it 'tolerates coercible or missing data-color through the plain initialiser too' do
+    # custom_field_colorpicker is a public global themes can name in data-callback-render; it
+    # crashed on the same coercion, and harder - markup without data-color gave undefined.
+    visit_post_edit
+
+    initialised = page.evaluate_script(<<~JS)
+      (function(){
+        function widget(attrs){
+          return jQuery('<div><div class="input-group color my-colorpicker"' + attrs +
+                        '><input type="text"><span class="input-group-addon"><i></i></span></div></div>');
+        }
+        var no_attr = widget('');
+        var coercible = widget(' data-color="2"');
+        try {
+          custom_field_colorpicker(no_attr);
+          custom_field_colorpicker(coercible);
+        } catch(e){ return String(e); }
+        return !!no_attr.find('.my-colorpicker').data('colorpicker') &&
+               !!coercible.find('.my-colorpicker').data('colorpicker');
+      })()
+    JS
+    expect(initialised).to be(true)
+  end
+
   it 'keeps the markup default white when the field has no stored value' do
     # An empty value used to overwrite the template's data-color="#fff", and the widget's
     # no-match default is red - every unset field showed a red swatch.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -52,6 +52,30 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(0, 255, 0)')
   end
 
+  it 'keeps the markup default white when the field has no stored value' do
+    # An empty value used to overwrite the template's data-color="#fff", and the widget's
+    # no-match default is red - every unset field showed a red swatch.
+    visit_post_edit
+
+    expect(page).to have_css('.my-colorpicker', count: 1)
+    expect(initialised_picker_count).to eq(1)
+    expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(255, 255, 255)')
+  end
+
+  it 'preserves a falsy-but-real value like a numeric 0 default' do
+    visit_post_edit
+
+    preserved = page.evaluate_script(<<~JS)
+      (function(){
+        var f = jQuery('<div><div class="input-group color my-colorpicker" data-color="#fff">' +
+                       '<input type="text"><span class="input-group-addon"><i></i></span></div></div>');
+        custom_field_colorpicker_val(f, 0);
+        return f.find('.my-colorpicker').data('color');
+      })()
+    JS
+    expect(preserved).to eq('0')
+  end
+
   it 'does not overwrite the stored value when the picker is opened and closed untouched' do
     # hide() used to write the picker's formatted colour into the input unconditionally, so just
     # looking at the picker turned a stored non-colour value (or a blank) into #ff0000.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -52,6 +52,42 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(0, 255, 0)')
   end
 
+  it 'renders the fields after a radio whose option value holds a quote' do
+    # The radio render callback splices its stored value into a jQuery selector; a quote used to
+    # throw a selector syntax error and abort every field after it - the same cascade the
+    # colorpicker fix closed, through another door.
+    @post.add_field({ 'name' => 'Pick', 'slug' => 'pick' },
+                    { 'field_key' => 'radio', 'multiple_options' => [{ 'title' => 'Bobs', 'value' => "Bob's pick" }] })
+    @post.set_field_value('pick', "Bob's pick")
+    @post.add_field({ 'name' => 'Tail', 'slug' => 'tail' }, { 'field_key' => 'text_box' })
+    @post.set_field_value('tail', 'after the radio')
+    visit_post_edit
+
+    expect(page).to have_css('.my-colorpicker', count: 1)
+    expect(page.evaluate_script("jQuery('[data-field-key=tail] .input-value').val()")).to eq('after the radio')
+  end
+
+  it 'warns when a render callback breaks instead of dying silently' do
+    visit_post_edit
+
+    warned = page.evaluate_script(<<~JS)
+      (function(){
+        var warns = [];
+        var original = console.warn;
+        console.warn = function(){ warns.push(String(arguments[0])); };
+        window.cama_broken_callback = function(){ throw new Error('boom'); };
+        var panel = jQuery('<div><div class="group-input-fields-content" data-callback-render="cama_broken_callback">' +
+                           '<input class="input-value" name="x[values][]"></div></div>');
+        try {
+          cama_build_custom_field(panel, { kind: 'text_box', default_value: '' }, ['v']);
+        } catch(e){ console.warn = original; return 'threw: ' + e; }
+        console.warn = original;
+        return warns.length > 0;
+      })()
+    JS
+    expect(warned).to be(true)
+  end
+
   it 'tolerates coercible or missing data-color through the plain initialiser too' do
     # custom_field_colorpicker is a public global themes can name in data-callback-render; it
     # crashed on the same coercion, and harder - markup without data-color gave undefined.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -80,6 +80,28 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
+  it 'falls back to hex when the colour format is unrecognised' do
+    # data-color-format rides the same coercing data() read; an unknown format left this.format
+    # undefined - surviving init (previewColor rescues) but throwing on the first close, so the
+    # picked colour was never written back.
+    visit_post_edit
+
+    result = page.evaluate_script(<<~JS)
+      (function(){
+        var f = jQuery('<div><div class="input-group color my-colorpicker" data-color="#fff" data-color-format="123">' +
+                       '<input type="text"><span class="input-group-addon"><i></i></span></div></div>');
+        custom_field_colorpicker_val(f, '#00ff00');
+        var picker = f.find('.my-colorpicker').data('colorpicker');
+        try {
+          picker.setValue('#0000ff');
+          picker.hide();
+        } catch(e){ return 'threw: ' + e; }
+        return f.find('input').val();
+      })()
+    JS
+    expect(result).to eq('#0000ff')
+  end
+
   it 'renders a disabled field readonly' do
     # The render partial emits the flag as is_disabled; the JS tested field_data.disabled, so
     # the readonly branch never ran and a locked field was fully editable.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# The colorpicker custom field re-renders its saved value by stamping it on the widget's
+# data-color attribute and initialising the picker. jQuery coerces a numeric-looking attribute
+# to a Number when the widget reads it back, and the picker's colour parser takes only strings -
+# so a saved free-text value like "2" crashed the picker's constructor mid-render, taking the
+# rest of the form's custom fields down with it.
+describe 'the colorpicker custom field', :js do
+  init_site
+
+  before do
+    post_type = @site.post_types.create!(name: 'Colored', slug: 'colored', description: 'x')
+    @colored_post = post_type.add_post(title: 'Tinted', slug: 'tinted', content: 'x')
+    @colored_post.add_field(
+      { 'name' => 'Tint', 'slug' => 'tint' }, { 'field_key' => 'colorpicker', 'translate' => false }
+    )
+    @colored_post.set_field_value('tint', '2')
+  end
+
+  it 'initialises the picker even when the saved value is not a colour string' do
+    admin_sign_in
+    visit "#{cama_root_relative_path}/admin/post_type/#{@colored_post.post_type.id}/posts/#{@colored_post.id}/edit"
+
+    expect(page).to have_css('.my-colorpicker')
+    initialised = page.evaluate_script(<<~JS)
+      jQuery('.my-colorpicker').toArray().every(function(el){
+        return !!jQuery(el).data('colorpicker');
+      })
+    JS
+    expect(initialised).to be(true)
+  end
+end

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -80,6 +80,28 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
+  it 'initialises on themed markup missing the swatch internals' do
+    # An empty jQuery match is truthy, so markup with class "color" but no addon - or an addon
+    # without the inner <i> - dereferenced undefined in the constructor and aborted the render.
+    visit_post_edit
+
+    ok = page.evaluate_script(<<~JS)
+      (function(){
+        var no_addon = jQuery('<div><div class="input-group color my-colorpicker" data-color="#fff">' +
+                              '<input type="text"></div></div>');
+        var no_icon = jQuery('<div><div class="input-group color my-colorpicker" data-color="#fff">' +
+                             '<input type="text"><span class="input-group-addon"></span></div></div>');
+        try {
+          custom_field_colorpicker_val(no_addon, '#00ff00');
+          custom_field_colorpicker_val(no_icon, '#00ff00');
+        } catch(e){ return 'threw: ' + e; }
+        return !!no_addon.find('.my-colorpicker').data('colorpicker') &&
+               !!no_icon.find('.my-colorpicker').data('colorpicker');
+      })()
+    JS
+    expect(ok).to be(true)
+  end
+
   it 'repaints when re-rendered with a new value' do
     # The bare colorpicker() call is a no-op on an element whose widget already exists, so a
     # second _val call updated both storage channels while the swatch kept the old colour.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -80,6 +80,22 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
+  it 'decodes a non-string translated value without crashing' do
+    # Values reach the translator through jQuery's data(), which preserves JSON types - a
+    # plugin-set numeric or boolean default on a translatable select threw text.trim is not a
+    # function.
+    visit_post_edit
+
+    ok = page.evaluate_script(<<~JS)
+      (function(){
+        if (typeof get_translations != 'function') return 'helper not loaded';
+        try { get_translations(1); get_translations(true); } catch(e){ return 'threw: ' + e; }
+        return true;
+      })()
+    JS
+    expect(ok).to be(true)
+  end
+
   it 'initialises on themed markup missing the swatch internals' do
     # An empty jQuery match is truthy, so markup with class "color" but no addon - or an addon
     # without the inner <i> - dereferenced undefined in the constructor and aborted the render.

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -80,6 +80,23 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
+  it 'repaints when re-rendered with a new value' do
+    # The bare colorpicker() call is a no-op on an element whose widget already exists, so a
+    # second _val call updated both storage channels while the swatch kept the old colour.
+    visit_post_edit
+
+    swatch = page.evaluate_script(<<~JS)
+      (function(){
+        var f = jQuery('<div><div class="input-group color my-colorpicker" data-color="#fff">' +
+                       '<input type="text"><span class="input-group-addon"><i></i></span></div></div>');
+        custom_field_colorpicker_val(f, '#ff0000');
+        custom_field_colorpicker_val(f, '#00ff00');
+        return f.find('i')[0].style.backgroundColor;
+      })()
+    JS
+    expect(swatch).to eq('rgb(0, 255, 0)')
+  end
+
   it 'falls back to hex when the colour format is unrecognised' do
     # data-color-format rides the same coercing data() read; an unknown format left this.format
     # undefined - surviving init (previewColor rescues) but throwing on the first close, so the

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -80,6 +80,16 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script(%(jQuery("[data-field-key=tags] input:checked").val()))).to eq("Bob's tag")
   end
 
+  it 'renders a disabled field readonly' do
+    # The render partial emits the flag as is_disabled; the JS tested field_data.disabled, so
+    # the readonly branch never ran and a locked field was fully editable.
+    @post.add_field({ 'name' => 'Locked', 'slug' => 'locked' }, { 'field_key' => 'text_box', 'disabled' => 'true' })
+    @post.set_field_value('locked', 'frozen')
+    visit_post_edit
+
+    expect(page.evaluate_script("jQuery('[data-field-key=locked] .input-value').prop('readonly')")).to be(true)
+  end
+
   it 'warns when a render callback breaks instead of dying silently' do
     visit_post_edit
 

--- a/spec/features/admin/custom_field_colorpicker_spec.rb
+++ b/spec/features/admin/custom_field_colorpicker_spec.rb
@@ -52,6 +52,31 @@ describe 'the colorpicker custom field', :js do
     expect(page.evaluate_script("jQuery('.my-colorpicker i')[0].style.backgroundColor")).to eq('rgb(0, 255, 0)')
   end
 
+  it 'does not overwrite the stored value when the picker is opened and closed untouched' do
+    # hide() used to write the picker's formatted colour into the input unconditionally, so just
+    # looking at the picker turned a stored non-colour value (or a blank) into #ff0000.
+    @post.set_field_value('tint', '2')
+    visit_post_edit
+    expect(page).to have_css('.my-colorpicker', count: 1)
+
+    page.find('.my-colorpicker .input-group-addon').click
+    page.execute_script('jQuery(document).trigger("mousedown")')
+
+    expect(page.find('.my-colorpicker input').value).to eq('2')
+  end
+
+  it 'still writes the colour back when one was actually picked' do
+    @post.set_field_value('tint', '2')
+    visit_post_edit
+    expect(page).to have_css('.my-colorpicker', count: 1)
+
+    page.execute_script(%(jQuery('.my-colorpicker').data('colorpicker').setValue('#00ff00');))
+    page.find('.my-colorpicker .input-group-addon').click
+    page.execute_script('jQuery(document).trigger("mousedown")')
+
+    expect(page.find('.my-colorpicker input').value).to eq('#00ff00')
+  end
+
   # Everything jQuery's data() coerces to a non-string crashed identically: numbers, booleans,
   # null, and JSON objects/arrays.
   ['true', 'null', '{"a":1}'].each do |stored|

--- a/spec/requests/admin/settings/custom_field_extra_options_spec.rb
+++ b/spec/requests/admin/settings/custom_field_extra_options_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Saving a custom field group must persist the per-kind extra options the settings UI offers.
+# The permit list allowed only :dimension of them, so Color Format, date type, file formats,
+# image versions, the posts-field post-type filter and the panel collapse state were silently
+# stripped on every save - and, because saving replaces the field's whole options meta, a
+# re-save also wiped any previously stored value.
+RSpec.describe 'saving custom field extra options', type: :request do
+  init_site
+
+  let(:current_site) { Cama::Site.first.decorate }
+  let(:admin) { create(:user, role: 'admin', site: current_site) }
+  let(:post_type) { current_site.post_types.where(slug: 'post').first }
+
+  before do
+    allow_any_instance_of(CamaleonCms::AdminController).to receive(:current_site).and_return(current_site)
+    sign_in_as(admin, site: current_site)
+  end
+
+  it 'persists every extra option the field settings panels offer' do
+    post '/admin/settings/custom_fields', params: {
+      custom_field_group: { name: 'Style options', assign_group: "PostType,#{post_type.id}" },
+      fields: {
+        '0' => { name: 'Tint', slug: 'tint' },
+        '1' => { name: 'Cover', slug: 'cover' },
+        '2' => { name: 'Due', slug: 'due' },
+        '3' => { name: 'Related', slug: 'related' }
+      },
+      field_options: {
+        '0' => { field_key: 'colorpicker', color_format: 'rgba', panel_hidden: '1' },
+        '1' => { field_key: 'image', dimension: '640x480', versions: '100x100' },
+        '2' => { field_key: 'date', type_date: '1' },
+        '3' => { field_key: 'posts', post_types: [post_type.id.to_s] }
+      }
+    }
+
+    group = current_site.custom_field_groups.find_by!(name: 'Style options')
+    expect(group.fields.find_by!(slug: 'tint').options).to include(color_format: 'rgba', panel_hidden: '1')
+    expect(group.fields.find_by!(slug: 'cover').options).to include(dimension: '640x480', versions: '100x100')
+    expect(group.fields.find_by!(slug: 'due').options).to include(type_date: '1')
+    expect(group.fields.find_by!(slug: 'related').options[:post_types]).to eq([post_type.id.to_s])
+  end
+end


### PR DESCRIPTION
## What and Why

The colorpicker custom field re-renders a saved value by stamping it onto the widget's `data-color` attribute and initialising the picker. jQuery's `data()` coerces a numeric-looking attribute value to a Number when the widget reads it back, and the picker's colour parser calls `toLowerCase` on what it receives — so a saved free-text value like `2` (the field accepts any text) crashed the picker's constructor mid-render. Custom fields are built in one loop inside a jQuery-ready handler, so the throw also aborted the rendering of every field after it — and **saving the record in that state silently blanked those unrendered fields' stored values**, since the save replaces all of a record's field values with what the (broken) form posted.

The core fix primes jQuery's data cache with the string form of the value — the coercion happens at read time, which is why writing the attribute alone cannot fix it — so the widget always receives a string. Around it, the render pipeline is hardened end to end:

- A field with no stored value keeps the markup's declared `#fff` default (previously overwritten with `''`, which the widget renders as red), and falsy-real values such as a numeric `0` default survive stringification.
- A picker that is opened but never used no longer rewrites the field on close: the widget now writes its formatted colour back only after an actual pick (slider drag or `setValue`), so the rescued free-text value — or a blank — isn't quietly replaced with `#ff0000` one click later.
- The per-field render callback is typeof-guarded and rescued with a console warning naming the callback, so any field kind that breaks degrades alone instead of taking the rest of the page's fields and initialisers down.
- The checkbox, checkboxes and radio callbacks match stored values by input property instead of splicing them into jQuery selectors — an option value holding a quote used to throw a selector syntax error and trigger the same cascade (the checkboxes variant also crashed on a scalar value).
- The plain `custom_field_colorpicker` initialiser — a public global themes can name in `data-callback-render` — routes through the hardened helper, closing its own harsher case (markup without `data-color` handed the widget `undefined`). Re-rendering a field repaints the swatch (the bare widget call is a no-op once initialised), an unrecognised `data-color-format` falls back to hex instead of throwing on close, and themed markup missing the swatch internals no longer crashes the constructor.
- The custom-fields settings controller now permits the per-kind extra options its own panels offer — colorpicker Color Format, the date field's date-vs-datetime toggle, image versions, file formats, the posts-field post-type filter, and the panel collapse state — which were silently stripped on every save (and wiped from previously saved fields on re-save). `command` (select_eval) stays unpermitted deliberately.
- The translator's decoder stringifies non-string values (jQuery's `data()` preserves JSON types), and the render pipeline honours the `disabled`/`readonly` field option, whose key the JS had never actually read.

The changelog entry states the data-loss blast radius, and the 2.9.5 upgrade guide gains a section telling operators which records to review and that pre-release picks of the discarded field options must be re-made.

## User-Visible Impact

Editing content whose colorpicker custom field holds a non-colour value no longer breaks that field, the fields after it, or — on save — their stored values; looking inside a picker without choosing a colour no longer overwrites the field; unset pickers show the intended white instead of red; quotes in radio/checkbox option values no longer break the edit form; and the custom-field settings options (colour format, date type, image versions, file formats, post-type filter) actually persist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
