### PR TITLE
Rightsize the agent docs for the Claude 5 generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,79 +1,32 @@
 # Camaleon CMS: Agent Entry Point
 
-This file is self-sufficient: every rule below applies to every task. Load the documents in §5 only when the task needs them — no other reading is required before starting work.
+Camaleon CMS is a Rails engine shipped as the `camaleon_cms` gem. Everything below applies to every task; load the documents in the table only when the task calls for them.
 
-## 1. Ground Rules (always apply)
+## Ground rules
 
-- **Stack:** Ruby (infer from `.tool-versions`), Rails (infer from `Gemfile` and `Gemfile.lock`).
-- **Branch first:** create a branch prefixed with `feature/`, `fix/`, or `security/` before writing code (full protocol: `docs/ai/workflows.md` Phase 1).
-- **Gem quirk:** this project is a gem — Rails commands like `rails routes` or `bin/rails zeitwerk:check` MUST be run from the `spec/dummy` folder. Always use subshells or `&&` to ensure you return to the project root, e.g. `(cd spec/dummy && bin/rails ...)`.
-- **Spec coverage:** ALL code changes must be covered by specs, except pure behavior-preserving refactors, documentation-only changes, and config changes with no code path modifications. If writing tests is infeasible, state why explicitly.
-- **Security fixes:** vulnerability fixes MUST include a test that reproduces the vulnerability (unless reproducing is infeasible). Integration/feature specs are preferred over controller specs. Triage protocol: `docs/ai/workflows.md` Phase 2A; spec templates: `docs/ai/testing.md`.
-- **Security remedy rule (reject at save; don't transform, don't constrain downstream):** content or uploads from untrusted users are **scanned and rejected at save** — never sanitized, stripped, escaped-away, or otherwise rewritten. The save-time decision is the **only** lever: content that passes is stored *and served* verbatim, and no response header, CSP, content-disposition, separate origin or other serving-side control may constrain what a stored file does in the browser. Before proposing any control, ask whether it would constrain a **trusted** user's content — if it would, it is outside the model however conventional it is as security hygiene. Admins can do anything. For other roles, **prefer the scan**: a dedicated default-off permission is the remedy only where a scan cannot reach a verdict at all (uploaded JavaScript has no safe subset, so no scan can decide it) — never a substitute for scanning where scanning works, and never a restriction on file types the scan can judge. Full model: `docs/security/permissions.md` ("The remedy rule" and "The gating rule"); codified in `openspec/specs/security-capability-gating/spec.md`.
+- **Gem, not an app.** Root `bin/rails` only runs engine commands. Run app commands (`routes`, `zeitwerk:check`, …) from the dummy app in a subshell: `(cd spec/dummy && bin/rails …)`.
+- **Support range.** CI runs Rails 7.1 through 8.1 on Ruby 3.2 through 4.0 (`gemfiles/`, `.github/workflows/`); the gemspec floor is Rails 6.1. Use framework and language APIs that hold across that range.
+- **Branch first.** Prefix `feature/`, `fix/` or `security/` before writing code (`docs/ai/workflows.md` Phase 1).
+- **Specs.** Code changes ship with specs; behavior-preserving refactors and docs/config-only changes are exempt. Say so when a test is infeasible. A vulnerability fix starts with a spec that reproduces it, request or feature over controller (triage: `docs/ai/workflows.md` Phase 2A; templates: `docs/ai/testing.md`).
+- **Security remedy: reject, don't transform.** Content and uploads from untrusted users are scanned and refused at save, never sanitized, stripped or escaped, at save or at render. What passes is stored and served verbatim, so no header, CSP, content-disposition or separate origin may constrain it either: a control that would constrain a trusted user's content is out. Admins can do anything. For other roles prefer the scan; a dedicated default-off permission is the remedy only where no scan can reach a verdict (uploaded JavaScript). Model: `docs/security/permissions.md`.
+- **Ecosystem.** Most plugins and themes are separate gems; `README.md` lists the known ones and more exist. A public helper's contract cannot be verified from this repo, so consult `docs/ai/ecosystem.md` before removing, renaming or hardening one.
 
-## 2. OpenSpec Workflow
+## Verify before pushing
 
-Use OpenSpec when the user requests it or when planned work has non-trivial behavior, contract, or cross-cutting concerns. Work directly for trivial, narrowly scoped, and documentation-only changes.
+`bin/rspec`, `bin/rubocop -A` (auto-correct only what you touched), `bin/brakeman --no-pager`, `(cd spec/dummy && bin/rails zeitwerk:check)`. All four, CI parity.
 
-Before creating a change, run `openspec list --json` and continue a relevant active change rather than creating a duplicate. Use the installed `/opsx:*` prompts or matching OpenSpec skills to:
+## OpenSpec
 
-- Explore uncertain problems with `/opsx:explore`.
-- Create or continue planning artifacts with `/opsx:propose`, `/opsx:new`, or `/opsx:continue`.
-- Implement planned tasks with `/opsx:apply`.
-- Confirm implementation matches the artifacts with `/opsx:verify`.
-- Preserve completed decisions with `/opsx:archive` — on the branch, before merge, committed as part of the PR (sequence: `docs/ai/workflows.md` Phase 4).
+Plan with OpenSpec (`/opsx:explore`, `/opsx:propose` or `/opsx:new`, then `/opsx:apply`, `/opsx:verify`, `/opsx:archive`) when work has non-trivial behavior, contract or cross-cutting concerns; work directly on trivial or documentation-only changes. Run `openspec list --json` first and continue a matching active change instead of opening a duplicate. Archive on the branch, before merge, committed in the PR (`docs/ai/workflows.md` Phase 4). Lasting decisions go in the change's `design.md`; durable behavior becomes requirements in `openspec/specs/`, not journals under `docs/`.
 
-Record lasting decisions in the active change's `design.md`, and durable domain behavior as requirements in `openspec/specs/` — not in parallel journals under `docs/`.
+## Load per task
 
-## 3. Agent Behaviour
-
-### Think Before Coding
-- Don't assume. State assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them—don't pick silently.
-
-### Simplicity First
-- Minimum code that solves the problem. Nothing speculative.
-- No features beyond what was asked.
-
-### Surgical Changes
-- Touch only what you must. Clean up only your own mess.
-- Don't refactor things that aren't broken. For refactors that are in scope, follow the Refactoring Protocol in `docs/ai/workflows.md` Phase 2C.
-
-### Goal-Driven Execution
-- "Fix the bug" → Write a test that reproduces it, then make it pass.
-- Verify before reporting completion.
-
-## 4. Key Commands
-
-- **Test:** `bin/rspec` or `bin/rspec spec/path:line`
-- **Lint:** `bin/rubocop -A` (auto-correct only what you touched)
-- **Security:** `bin/brakeman --no-pager`
-- **Verify load:** `(cd spec/dummy && bin/rails zeitwerk:check)`
-
-All four must pass before pushing (CI parity).
-
-## 5. Load Per Task
-
-| When the task involves | Load |
-|------|---------|
+| Task | Load |
+|---|---|
 | Branching, vulnerability triage, refactoring protocol, commits, PRs, changelog | `docs/ai/workflows.md` |
 | Writing or running tests; reproducing vulnerabilities | `docs/ai/testing.md` |
-| Reading or writing app code: paths, namespacing, models, decorators, hooks, plugins, style idioms | `docs/ai/reference.md` |
-| Removing, renaming or hardening a public helper/hook/API that external plugins or themes may bind to | `docs/ai/ecosystem.md` |
+| Reading or writing app code: paths, namespacing, decorators, hooks, plugins, idioms | `docs/ai/reference.md` |
+| Removing, renaming or hardening a public helper, hook or API | `docs/ai/ecosystem.md` |
 | Env files, keys, credentials | `docs/ai/secrets.md` |
 | Self-audit before opening a PR | `docs/ai/criteria.md` |
-| Cutting a release: version bump, tag, publishing the gem | `docs/releasing.md` |
-
-## 6. Quick Reference
-
-| Path | Purpose |
-|------|---------|
-| `spec/dummy/` | Test Rails app |
-| `app/apps/plugins/` | Plugins bundled in this repo (4 only) |
-| `app/apps/themes/` | Themes |
-| `config/routes/` | Split routes |
-
-**Namespaces:** `CamaleonCms::*`, shortcuts: `Cama::Site`, `Cama::Post`
-**Patterns:** decorators (`object.the_title`, `object.the_url`), hooks (`hooks_run('hook_name')`) — details in `docs/ai/reference.md`
-
-**Ecosystem:** most plugins and themes live in separate gems, not in this repo — `README.md` lists the known ones. When assessing whether a change breaks downstream consumers, treat that list as the visible surface and assume more exist: a public helper's return contract cannot be verified from this repo alone.
+| Cutting a release | `docs/releasing.md` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Tooling:** Slim `AGENTS.md`, the agent entry point `CLAUDE.md` imports, to what the Claude 5 context-engineering guidance says belongs there: a one-line repo description plus codebase gotchas, at about half the previous size. Generic behaviour rules, the OpenSpec command list and the quick-reference lines that `docs/ai/reference.md` owns are dropped. Development-only. [#1289](https://github.com/owen2345/camaleon-cms/pull/1289).
+
 - **Bug fix:** A colorpicker custom field whose saved value was not a colour crashed the edit form's field rendering, and saving then silently blanked the record's other custom-field values. Rendering now survives bad values and broken field callbacks, an opened-but-unused picker no longer overwrites the field, and the per-kind field options (colour format, date type, image versions, file formats, post-type filter) persist on save. [#1288](https://github.com/owen2345/camaleon-cms/pull/1288).
   - [Upgrade notes](docs/upgrading-to-2.9.5.md#audit-custom-field-values-after-a-colorpicker-crash).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- **Tooling:** Slim `AGENTS.md`, the agent entry point `CLAUDE.md` imports, to what the Claude 5 context-engineering guidance says belongs there: a one-line repo description plus codebase gotchas, at about half the previous size. Generic behaviour rules, the OpenSpec command list and the quick-reference lines that `docs/ai/reference.md` owns are dropped. Development-only. [#1289](https://github.com/owen2345/camaleon-cms/pull/1289).
+- **Tooling:** Rightsize the agent docs for the Claude 5 generation: `AGENTS.md` keeps a one-line repo description plus codebase gotchas, and the docs it routes to (`docs/ai/workflows.md`, `testing.md`, `reference.md`, `criteria.md`) drop generic advice, duplicated rules and stale claims in favour of pointers to real code; `docs/security/permissions.md` no longer says post content is sanitized. Development-only. [#1289](https://github.com/owen2345/camaleon-cms/pull/1289).
 
 - **Bug fix:** A colorpicker custom field whose saved value was not a colour crashed the edit form's field rendering, and saving then silently blanked the record's other custom-field values. Rendering now survives bad values and broken field callbacks, an opened-but-unused picker no longer overwrites the field, and the per-kind field options (colour format, date type, image versions, file formats, post-type filter) persist on save. [#1288](https://github.com/owen2345/camaleon-cms/pull/1288).
   - [Upgrade notes](docs/upgrading-to-2.9.5.md#audit-custom-field-values-after-a-colorpicker-crash).

--- a/docs/ai/criteria.md
+++ b/docs/ai/criteria.md
@@ -1,33 +1,8 @@
 # Quality Criteria
 
-Before marking any task complete, evaluate against these criteria.
+Before marking a task complete:
 
-## Code Quality
-
-- Code passes RuboCop: `bin/rubocop`
-- No new RuboCop violations introduced
-
-## Testing
-
-- Specs pass: `bin/rspec`
-- New functionality has test coverage
-- Bug fixes include a test that would have caught the bug
-
-## Security
-
-- No `eval`, `instance_eval`, or `class_eval` with user input
-- SQL queries use parameterized forms
-- Untrusted input follows the remedy rule: dangerous content is **rejected** at save with an error — never sanitized, stripped, or otherwise transformed (no render-time sanitization either). See `docs/security/permissions.md` ("The remedy rule").
-- Security-sensitive actions follow the gating rule: admin-only by default, gated for non-admins by a dedicated, off-by-default, fail-closed permission — never a path/filename/flag proxy, never fail-open. See `docs/security/permissions.md` ("The gating rule") and the `security-capability-gating` spec.
-
-## Rails Conventions
-
-- Controllers use strong parameters
-- Models have proper associations and validations
-- Views use helpers instead of logic
-
-## Camaleon CMS Specific
-
-- Plugins/themes follow the established patterns
-- Hooks are used for extensibility
-- Custom fields are handled correctly
+- The four CI-parity commands in `AGENTS.md` pass, with no new RuboCop offenses.
+- New behavior has specs; a bug fix includes the spec that would have caught it.
+- Security: SQL is parameterized; nothing evaluates user input (the gated `select_eval` field is the one deliberate exception); untrusted content is rejected at save, never transformed, and a new security-sensitive action is admin-only or behind a dedicated default-off permission — `docs/security/permissions.md`, "The remedy rule" and "The gating rule".
+- Camaleon: plugins and themes follow the bundled ones under `app/apps/`; extension points are hooks, not patches; custom fields go through the existing field pipeline; public helpers, hooks and ivars that external consumers bind to keep their contracts (`docs/ai/ecosystem.md`).

--- a/docs/ai/reference.md
+++ b/docs/ai/reference.md
@@ -44,6 +44,10 @@ Cama::PostType # = CamaleonCms::PostType
 
 - `CamaleonRecord` is the base class for Camaleon CMS ActiveRecord models (inherits from `ActiveRecord::Base`).
 - Always specify `class_name` and `foreign_key` explicitly on associations.
+- Data backfills and repairs are Rake tasks under `lib/tasks/` (`camaleon_cms:` namespace, e.g.
+  `media_visibility_repair.rake`), never migrations: the schema has not changed since 2018, a migration
+  would regenerate `spec/dummy/db/schema.rb`, and the engine appends its migrations to every host app's
+  `db:migrate` — an operator runs a task deliberately and can re-run it.
 
 ### The media table is a rebuildable cache
 

--- a/docs/ai/reference.md
+++ b/docs/ai/reference.md
@@ -1,190 +1,44 @@
 # Code Reference and Conventions for Camaleon CMS
 
-Load this file when reading or writing application code.
+Load this file when reading or writing application code. Version floors are in `AGENTS.md`; test conventions in `docs/ai/testing.md`.
 
-## Baseline
+## Layout
 
-- Ruby version target: infer from `.tool-versions`.
-- Rails version target: infer from `Gemfile` and `Gemfile.lock`.
-- Test framework: `rspec-rails` (see `docs/ai/testing.md`).
-- Secrets: follow [`docs/ai/secrets.md`](./secrets.md) for what counts as a secret and how to handle it.
+- `app/apps/plugins/` and `app/apps/themes/` hold the plugins and themes bundled with the gem; most of the ecosystem lives in separate gems (`docs/ai/ecosystem.md`).
+- `spec/dummy/` is the host Rails app for specs and for Rails commands; `Rails.root` in specs points there.
+- Routes are split under `config/routes/` (`admin.rb`, `frontend.rb`) and joined by `config/routes.rb`.
 
 ## Namespacing
 
-Modules and classes are namespaced under `CamaleonCms`. The codebase defines `Cama::*` aliases for convenience:
+Everything is under `CamaleonCms::`. `config/initializers/model_alias.rb` defines the `Cama::*` shortcuts (`Cama::Site`, `Cama::Post`, `Cama::PostType`, …) and, when the host app sets `user_model`, replaces `CamaleonCms::User` with the host's class plus `CamaleonCms::UserMethods` — never assume `CamaleonCms::User` is the engine's own model.
 
-```ruby
-# Defined in config/initializers/model_alias.rb
-Cama::Site     # = CamaleonCms::Site
-Cama::Post     # = CamaleonCms::Post
-Cama::Category # = CamaleonCms::Category
-Cama::PostType # = CamaleonCms::PostType
-```
+## Models and data
 
-## Key Paths
+- `CamaleonRecord` is the base class for the engine's ActiveRecord models. Give every association an explicit `class_name` and `foreign_key`.
+- Data backfills and repairs are Rake tasks under `lib/tasks/` (`camaleon_cms:` namespace, e.g. `media_visibility_repair.rake`), never migrations: the schema has not changed since 2018 (`db/migrate/`, mirrored by `spec/dummy/db/schema.rb`, SQLite in tests), a migration would regenerate that `schema.rb`, and the engine appends its migrations to every host app's `db:migrate` — an operator runs a task deliberately and can re-run it.
+- **The media table is a rebuildable cache.** Every `CamaleonCms::Media` column is derived from storage by the uploaders' `browser_files`/`file_parse`; nothing on a row is user-authored. Never repair rows by transforming them in place — purge and let the cache rebuild from storage, which is what `clear_cache`, lazy rebuild on browse and `rake camaleon_cms:repair_media_visibility` all rely on (an in-place transform cannot know which rows are already correct; the archived `2026-08-31-correct-media-is-public-flag` change's `design.md` has the argument). `media.is_public` and `Site#public_media`/`#private_media` mean what they say since #1286; access control never reads the stored flag — it keys off `is_private_uploader?` and the storage path. Uploaders reach private mode via `enable_private_mode!` on a public-constructed instance (the controller path); constructing with `private: true` skips `setup_private_folder` and leaves the storage root public, so keep it to base-class tests.
 
-| Path | Purpose |
-|------|---------|
-| `spec/dummy/` | Test Rails application |
-| `spec/support/` | Test helpers and shared configuration |
-| `spec/factories/` | FactoryBot factory definitions |
-| `app/apps/plugins/` | Plugins |
-| `app/apps/themes/` | Themes |
-| `config/routes/` | Split route files |
-| `config/locales/` | Translation files |
+## Decorators
 
-## Environment Variables
+Draper decorators live in `app/decorators/camaleon_cms/`; the presentation methods views and themes call are prefixed `the_` (`the_title`, `the_url`, `the_content`, …). Admin pages render frontend decorators and plugin helpers during preview flows, so keep the `cama_get_i18n_frontend` / `cama_is_admin_request?` compatibility path when changing locale behavior around admin previews — theme previews render plugins such as `camaleon-ecommerce`.
 
-| Variable | Purpose |
-|----------|---------|
-| `RAILS_ENV` | Rails environment (test, development, production) |
-| `DISABLE_DATABASE_ENVIRONMENT_CHECK` | Skip DB environment check |
+## Hooks
 
-## Models
+`hooks_run('hook_name', args)` dispatches to handlers registered in a plugin's or theme's `config/config.json`: the helper class under `"helpers"`, the hook-to-method map under `"hooks"` (`app/apps/plugins/authoring_post/config/config.json` is a complete example). A handler receives one `args` hash and communicates back by mutating it in place; the caller reads it afterwards (`hooks_run('safe_redirect_hosts', r)`, then `r[:hosts]`). `PluginRoutes.add_anonymous_hook(name, ->(args) { … })` registers one without a manifest; there is no `HooksManager.add_listener`. The 130-hook inventory and the session/auth contracts are in `docs/hooks.md`.
 
-- `CamaleonRecord` is the base class for Camaleon CMS ActiveRecord models (inherits from `ActiveRecord::Base`).
-- Always specify `class_name` and `foreign_key` explicitly on associations.
-- Data backfills and repairs are Rake tasks under `lib/tasks/` (`camaleon_cms:` namespace, e.g.
-  `media_visibility_repair.rake`), never migrations: the schema has not changed since 2018, a migration
-  would regenerate `spec/dummy/db/schema.rb`, and the engine appends its migrations to every host app's
-  `db:migrate` — an operator runs a task deliberately and can re-run it.
+## Public API compatibility
 
-### The media table is a rebuildable cache
+Kept on purpose for external plugins and themes; check `docs/ai/ecosystem.md` before removing any of it:
 
-Every column on a `CamaleonCms::Media` row is derived from storage by the uploaders'
-`browser_files`/`file_parse`; nothing on a row is user-authored. Consequences:
-
-- **Never repair media rows by transforming them in place** — purge and let the cache rebuild
-  from storage (that is what `clear_cache`, lazy rebuild on browse, and
-  `rake camaleon_cms:repair_media_visibility` all rely on). An in-place transform cannot know
-  which rows are already correct; see the archived
-  `2026-08-31-correct-media-is-public-flag` change's `design.md` for the full argument.
-- `media.is_public` and `Site#public_media` / `Site#private_media` mean what they say (since
-  #1286): the uploader's mode maps to the collection whose `is_public` matches the file's real
-  visibility. Access control never reads the stored flag — it keys off `is_private_uploader?`
-  and the storage path.
-- Uploaders reach private mode via `enable_private_mode!` on a public-constructed instance (the
-  controller path); constructing with `private: true` skips `setup_private_folder` and leaves the
-  storage root public — do not use it outside base-class tests.
-
-## Decorators (Draper)
-
-Located in `app/decorators/`:
-
-```ruby
-module CamaleonCms
-  class PostDecorator < CamaleonCms::ApplicationDecorator
-    delegate_all
-
-    def the_title
-      "#{object.title} - #{site.name}"
-    end
-  end
-end
-```
-
-Common decorator methods:
-
-```ruby
-@object.decorate       # Returns decorated object
-@object.the_title      # Decorated title
-@object.the_url        # Decorated URL
-@object.the_next_post  # Next post in sequence
-@object.the_prev_post  # Previous post in sequence
-```
-
-- Admin pages can render frontend decorators and plugin helpers during preview flows.
-- Preserve the `cama_get_i18n_frontend` / `cama_is_admin_request?` compatibility path when changing locale behavior around admin previews, especially for theme previews that render plugins such as `camaleon-ecommerce`.
-
-## Controllers
-
-Dynamic layout based on request type:
-
-```ruby
-layout proc { |_controller|
-  params[:cama_ajax_request].present? ? 'camaleon_cms/admin/_ajax' : 'camaleon_cms/admin'
-}
-```
-
-Exception handling:
-
-```ruby
-rescue_from CanCan::AccessDenied do |exception|
-  flash[:error] = "Error: #{exception.message}"
-  redirect_to cama_admin_dashboard_path
-end
-```
-
-## Hook System
-
-Camaleon CMS provides a hook system for plugin extensibility:
-
-```ruby
-# Trigger a hook (engine side). Handlers receive one `args` hash and mutate it in place;
-# the caller reads the mutated hash back after the call.
-hooks_run('admin_before_load')
-hooks_run('safe_redirect_hosts', r) # r[:hosts] is read back afterwards
-```
-
-Register a handler (in a plugin/theme) by mapping the hook to a helper method in `config/config.json`:
-
-```json
-"helpers": ["Plugins::MyPlugin::MainHelper"],
-"hooks":   { "admin_before_load": ["my_before_load"] }
-```
-
-```ruby
-# in Plugins::MyPlugin::MainHelper — the handler mutates the single `args` hash
-def my_before_load(args)
-  args[:links] << link_to('My link', root_url)
-end
-```
-
-`PluginRoutes.add_anonymous_hook('admin_before_load', ->(args) { ... })` registers one programmatically
-without a manifest. (There is no `HooksManager.add_listener`.)
-
-Common hook points (full 130-hook inventory and the session/auth contracts in [docs/hooks.md](../hooks.md)):
-`app_before_load`/`app_after_load`, `admin_before_load`/`admin_after_load`,
-`front_before_load`/`front_after_load`, `after_login`, `user_registered`, `on_render_post`,
-`before_upload`, `on_active`/`on_inactive`.
-
-## Routes
-
-Routes are split by scope in `config/routes/`:
-- `config/routes/admin.rb`
-- `config/routes/frontend.rb`
-- `config/routes.rb`
-
-## Plugin System
-
-Plugins live in `app/apps/plugins/` and can:
-- Add controllers (frontend and admin)
-- Add helpers
-- Add routes
-- Hook into lifecycle events
-- Add migrations
-
-Compatibility notes:
-- `CamaleonHelper#cama_is_admin_request?` is still a public plugin API. Keep it available for admin-rendered frontend flows such as theme preview pages that call plugin helpers like `camaleon-ecommerce`, where the plugin must detect admin preview mode instead of visitor/frontend mode.
-- Frontend visited-state compatibility ivars (`@cama_visited_post`, `@cama_visited_category`, etc.) are still assigned by `FrontendVisitedStateConcern` for ecosystem compatibility, but are deprecated in favor of `CurrentRequest.frontend_visited_*`.
-- Controller `@current_site` assignment is retained for legacy theme template rendering compatibility; new code should read site context from `current_site`/`CurrentRequest.site` instead of template-level ivar coupling.
-- `ThemeHelper#theme_view` still accepts the legacy second argument for compatibility, but this call shape is deprecated; pass the view name as the first argument.
+- `CamaleonHelper#cama_is_admin_request?` — admin-rendered frontend flows (theme previews calling plugin helpers) detect admin mode with it.
+- The frontend visited-state ivars (`@cama_visited_post`, `@cama_visited_category`, …) are still assigned by `FrontendVisitedStateConcern`; new code reads `CurrentRequest.frontend_visited_*`.
+- Controller `@current_site` stays assigned for legacy theme templates; new code reads `current_site` / `CurrentRequest.site`.
+- `ThemeHelper#theme_view` still accepts the legacy second argument; pass the view name first.
 
 ## Authorization
 
-- Roles and permissions managed via `CamaleonCms::UserRole` and CanCanCan's `Ability` class
-- Admins have all permissions by default
-- Permissions are defined per site
+Roles and permissions are `CamaleonCms::UserRole` plus CanCanCan's `Ability`, defined per site; admins pass every check. Anything security-sensitive follows the gating and remedy rules in `docs/security/permissions.md`.
 
-## Assets and Test Database
+## Style beyond RuboCop
 
-- Uses **Dart Sass** via `dartsass-sprockets`
-- Tests use SQLite; schema in `spec/dummy/db/schema.rb`
-- Migrations run from both `db/migrate/` AND `spec/dummy/db/migrate/`
-
-## Style Idioms (beyond RuboCop)
-
-Formatting is enforced by RuboCop (`bin/rubocop -A`). Additional idioms:
-- Prefer `defined?` checks for memoization
-- Avoid mutation of method parameters
-- Use `dup` when needing a mutable copy
+Prefer `defined?` checks for memoization, do not mutate method parameters, and `dup` when a mutable copy is needed.

--- a/docs/ai/testing.md
+++ b/docs/ai/testing.md
@@ -1,192 +1,35 @@
 # Testing Guide
 
-> **Important:** Always run the specs with `bin/rspec`.
-> Remember the gem quirk from `AGENTS.md` Ground Rules: run Rails commands from `spec/dummy` via a subshell.
+Run specs with `bin/rspec` (it forces `RAILS_ENV=test` and boots `spec/dummy`); `bin/rspec spec/path_spec.rb:12` runs one example. Rails commands go through `spec/dummy` in a subshell (`AGENTS.md` Ground rules).
 
-## Running Tests
+## Database
 
-```bash
-# All specs
-bin/rspec
+`rails_helper` keeps the SQLite test schema current from `spec/dummy/db/schema.rb` (`maintain_test_schema!`); `bundle exec rake app:db:test:prepare` rebuilds it by hand.
 
-# Single spec file
-bin/rspec spec/models/site_spec.rb
-
-# Specific spec by line number
-bin/rspec spec/models/site_spec.rb:12
-
-# Specs matching a pattern
-bin/rspec spec/models/
-bin/rspec spec/features/admin/
-```
-
-## Database Setup
-
-```bash
-bundle exec rake app:db:migrate
-bundle exec rake app:db:test:prepare
-```
-
-## Test Helpers (`spec/support/common.rb`)
+## Helpers (`spec/support/common.rb`)
 
 ```ruby
 init_site              # exposes the suite-wide shared site as @site (+ @post)
-init_site(fresh: true) # replaces it with a per-example site — only for specs
-                       # that need the slug to match the Capybara server host
-                       # (e.g. multi-site UI flows)
-admin_sign_in          # authenticate by setting the auth cookie (fast; verifies
-admin_sign_in(user, pass)  # the password and raises on mismatch)
-admin_form_sign_in     # authenticate through the real login form — use only in
-                       # specs that test the sign-in flow itself
-wait(2)                # wait for JS execution
-cama_root_relative_path # site URL helper
+init_site(fresh: true) # a per-example site, only when the slug must match the
+                       # Capybara server host (multi-site UI flows)
+admin_sign_in          # sets the auth cookie directly (fast; verifies the password)
+admin_form_sign_in     # the real login form; only for specs of the sign-in flow
+wait(2)                # wait for JS
+cama_root_relative_path
 confirm_dialog         # accept JS dialogs
 ```
 
-### Shared site (`spec/support/shared_site.rb`)
+### The shared site (`spec/support/shared_site.rb`)
 
-Installing a Camaleon site costs ~0.6s, so one canonical site is installed
-per suite run (committed, outside the per-example transactions) and reused
-everywhere: `init_site`, `Cama::Site.first`, and the `post`/`post_type`/`user`
-factories all resolve to it by default. Example-level mutations roll back with
-the transaction. Only create additional sites when the test is about
-multi-site behavior; explicit `create(:site)` still installs a real site.
+Installing a site costs ~0.6s, so one canonical site is installed per suite run, committed outside the per-example transactions, and reused everywhere: `init_site`, `Cama::Site.first` and the `post`/`post_type`/`user` factories resolve to it, and example-level mutations roll back. Create another site only when the test is about multi-site behavior (`create(:site)` installs a real one). Installation already claims the default slugs — roles `admin`/`editor`/`contributor`/`client`, post types `post`/`page` — and slugs are unique per parent and taxonomy, so reuse those records (`site.user_roles.find_by!(slug: 'admin')`) instead of creating same-slug duplicates.
 
-Site installation already claims the default slugs — user roles `admin` /
-`editor` / `contributor` / `client`, post types `post` / `page` — and slugs are
-unique per parent and taxonomy, so reuse those records (e.g.
-`site.user_roles.find_by!(slug: 'admin')`) instead of creating same-slug
-duplicates.
+## Conventions
 
-## RSpec Conventions
+- A spec starts at the `# frozen_string_literal: true` magic comment: `.rspec` requires `rails_helper` for every file, so no spec requires it itself. Spec type is inferred from the directory (`spec/models`, `spec/requests`, `spec/features`, `spec/helpers`).
+- Factories live in `spec/factories/`; `rails_helper` points FactoryBot at them explicitly because `Rails.root` is `spec/dummy` and the default lookup finds nothing. The engine does not inject them into host apps — a host or plugin harness that wants them sets `FactoryBot.definition_file_paths` itself, as the cama_contact_form harness does. Site-owned factories default to the shared site; pass `site:` for another. `spec/factories/site.rb` shows the install-on-create pattern.
+- Shared examples live in `spec/shared_specs/`: `it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]` and `it_behaves_like 'i18n value translation safety', described_class`.
+- Feature specs are tagged `:js`, call `init_site` and `admin_sign_in`, then `visit "#{cama_root_relative_path}/admin/…"`; `spec/features/admin/categories_spec.rb` is a compact example. Request specs (`spec/requests/`) are preferred over controller specs.
 
-Specs do not `require 'rails_helper'` themselves — `.rspec` (`--require rails_helper`) loads it for
-every spec, and `rails_helper` forces `RAILS_ENV=test` before the app boots. Start a spec at the
-magic comment:
+## Security Vulnerability Reproduction
 
-```ruby
-# frozen_string_literal: true
-
-RSpec.describe CamaleonCms::Site, type: :model do
-  it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]
-
-  describe 'check metas relationships' do
-    let!(:site) { create(:site).decorate }
-
-    it 'creates metas with correct object_class' do
-      front_cache_elements = site.metas.where(key: 'front_cache_elements').first
-      expect(front_cache_elements.object_class).to eql('Site')
-    end
-  end
-end
-```
-
-**Guidelines:**
-- Use `described_class` instead of hardcoding class names
-- Use `let!` when data is needed for all examples in a describe block
-- Use factories: `create(:site)`, `create(:post)`, `create(:post_type)`
-- Use `decorate` when testing Draper-decorated methods
-- Use `init_site` helper in feature specs
-- Use shared examples (`spec/shared_specs/`) for common behavior
-- Use `:js` tag for feature specs requiring JavaScript: `RSpec.describe 'Posts', :js do`
-
-## Factory Bot Conventions
-
-Factories live in `spec/factories/` and are loaded by `spec/rails_helper.rb`, which sets
-`FactoryBot.definition_file_paths` to that directory explicitly and calls `FactoryBot.reload`
-(Rails.root is `spec/dummy`, so factory_bot_rails' root-relative defaults find nothing). The engine
-does NOT inject its factories into applications that load the gem — a host app or plugin harness
-that wants them must point `FactoryBot.definition_file_paths` at them itself (the cama_contact_form
-harness does exactly this with its own factories).
-
-```ruby
-FactoryBot.define do
-  factory :site, class: 'CamaleonCms::Site' do
-    name { Faker::Name.unique.name }
-    sequence(:slug) { |n| "test-site-#{n}" } # Capybara server host:port in feature specs
-    description { Faker::Lorem.sentence }
-
-    transient do
-      theme { 'default' }
-      skip_intro { true }
-    end
-
-    after(:create) do |site, evaluator|
-      site_after_install(site, evaluator.theme)
-    end
-  end
-end
-```
-
-Factories that belong to a site (`post`, `post_type`, `user`) default to the
-suite-wide shared site (`CamaleonCms::Site.first`) instead of installing a new
-one; pass `site:` explicitly when the test needs a different site.
-
-## Feature Spec Pattern (Admin UI Tests)
-
-```ruby
-# frozen_string_literal: true
-
-describe 'Posts workflows for Admin', :js do
-  let(:post) { site.the_post('sample-post').decorate }
-  let(:post_type_id) { site.post_types.where(slug: :post).pick(:id) }
-  let!(:site) { CamaleonCms::Site.first.decorate }
-
-  it 'Creates a new post' do
-    admin_sign_in
-    visit "#{cama_root_relative_path}/admin/post_type/#{post_type_id}/posts/new"
-    wait(2)
-    # ... test steps
-  end
-end
-```
-
-## Shared Examples
-
-Located in `spec/shared_specs/`:
-
-```ruby
-it_behaves_like 'sanitize attrs', model: described_class, attrs_to_sanitize: %i[name description]
-it_behaves_like 'i18n value translation safety', described_class
-```
-
-## Test Types
-
-| Type | Location | Description |
-|------|----------|-------------|
-| `type: :model` | `spec/models/` | Unit tests for models |
-| `type: :request` | `spec/requests/` | HTTP request tests |
-| `type: :feature` | `spec/features/` | Browser-based UI tests |
-| Default | `spec/helpers/` | Helper method tests |
-
-## Security Vulnerability Reproduction (PoC)
-Reproducing a reported vulnerability with a failing test before fixing it (required — see `AGENTS.md` Ground Rules) proves the vulnerability is "Legit" and prevents regressions.
-
-### 1. Request Spec Template (for RCE, SQLi, XSS)
-Use a Request Spec to simulate the attack payload.
-```ruby
-# spec/requests/security/repro_<name>_spec.rb
-RSpec.describe "Security Reproduction: <Brief Name>", type: :request do
-  let(:attacker_payload) { " <PAYLOAD_HERE> " } # e.g., "'); DROP TABLE users; --"
-
-  it "demonstrates the vulnerability" do
-    # 1. Execute the action with the payload
-    get "/vulnerable_path", params: { input: attacker_payload }
-
-    # 2. Assert failure (The test should FAIL if the vulnerability is present)
-    # For XSS: expect(response.body).not_to include("<script>")
-    # For SQLi: expect { subject }.not_to change { User.count }
-    # For RCE: expect(File.exist?("/tmp/rce_proof")).to be false
-  end
-end
-```
-
-### 2. Dependency Audit Check
-If the vulnerability is a gem dependency (CVE):
-- Run: `bundle exec bundle-audit check --update`
-- **Verification:** The output must explicitly list the CVE provided in the prompt. If not found, the report is likely a "False Positive" for this repo version.
-
-### 3. Static Analysis (Brakeman) Triage
-To isolate the specific file and line:
-- Run: `bin/brakeman -z --only-files path/to/file.rb`
-- **Legitimacy Rule:** If Brakeman does not flag the line with the exact error type (e.g., "High Confidence SQL Injection"), you must ask the user for clarification before proceeding.
+A vulnerability fix starts with a failing spec that reproduces it (`AGENTS.md` Ground rules); whether the report is legit is decided first by the triage protocol in `docs/ai/workflows.md` Phase 2A. Reproductions live in `spec/requests/security/`, driven through the real endpoint so the request context the permission decision reads is the real one. `repro_markup_and_script_upload_scanning_spec.rb` is the model: state the gap in the header comment, exercise it as the attacker would, and assert the safe outcome so the spec fails while the vulnerability is present.

--- a/docs/ai/workflows.md
+++ b/docs/ai/workflows.md
@@ -1,124 +1,79 @@
 # Workflows
 
-## Phase 1: Branch Initialization (MANDATORY)
+## Phase 1: Branch Initialization
 
 Before writing any code:
 
-1. Ensure you are on the latest `master`.
-2. Create a new branch: `git checkout -b <type>/<brief-description>` using the prefixes from `AGENTS.md` (`feature/`, `fix/`, `security/`).
-3. *Protocol:* Announce the branch name to the user immediately.
-4. If this is a security fix, follow the **Vulnerability Triage Protocol** (Phase 2A) before writing the fix.
+1. Start from the latest `master`.
+2. `git checkout -b <type>/<brief-description>` with the prefixes from `AGENTS.md` (`feature/`, `fix/`, `security/`), and tell the user the branch name.
+3. For a security fix, run the Vulnerability Triage Protocol (Phase 2A) before writing the fix.
 
 ---
 
 ## Phase 2: Execution
 
-### A. Vulnerability Triage Protocol (Hypothesis-Driven)
-**Objective:** Verify that a reported vulnerability is "Legit" (exploitable or present in our specific context) before acting.
+### A. Vulnerability Triage Protocol
 
-1.  **Step 1: Proof of Presence:** Do not assume the report is correct.
-    - **For Dependency Reports:** Run `bundle exec bundle-audit check`. Does the reported gem/version match our `Gemfile.lock`?
-    - **For Code/Static Reports:** Run `bin/brakeman -z --only-files <file_path>`. Does Brakeman flag the specific line mentioned?
-    - **Manual Grep:** If no tool finds it, `grep -r` the codebase for the vulnerable pattern.
-2.  **Step 2: Legitimacy Verdict:** State your finding to the user. You must pick one:
-    - ✅ **Legit:** "Confirmed. We are using version X; version Y is required." or "Confirmed. Brakeman flags this as a High risk SQLi."
-    - ❌ **False Positive:** "The report is for a library we don't use." or "The code pattern exists but is in a test-only file not reachable in production."
-    - ⚠️ **Unverifiable:** "I see the code, but my tools cannot confirm the risk. I recommend a deeper manual audit."
-3.  **Step 3: Authorization to Proceed:** ONLY if the verdict is ✅ Legit:
-    - Write a failing test that reproduces the risk before applying the fix (rule in `AGENTS.md`; spec templates in `docs/ai/testing.md`, "Security Vulnerability Reproduction").
+Verify that a reported vulnerability is present and exploitable in this codebase before acting on it.
+
+1. **Proof of presence.** Do not assume the report is correct. Dependency report: `bundle exec bundle-audit check` — does the gem and version match `Gemfile.lock`? Code or static report: `bin/brakeman -z --only-files <file_path>` — does Brakeman flag the line? Otherwise grep the codebase for the pattern.
+2. **Verdict**, stated to the user as one of: ✅ **Legit** (present in our context, with the evidence), ❌ **False positive** (a library we do not use, a pattern only in test-only code, …), ⚠️ **Unverifiable** (the tools cannot confirm the risk; recommend a manual audit).
+3. **Only on ✅ Legit**, write the failing reproduction first (rule in `AGENTS.md`; shape in `docs/ai/testing.md`, "Security Vulnerability Reproduction"), then the fix.
 
 ### B. Development
-The spec-coverage and security-fix testing rules are stated in `AGENTS.md`. Test commands, helpers, and conventions live in `docs/ai/testing.md`.
 
-**Security remedies are rejections, not transforms.** When a fix must stop dangerous content from an untrusted user, the remedy is a save-time refusal with an error naming the problem — never sanitizing, stripping, or escaping-away what the author wrote. Stored content must always equal authored content, so the frontend may render it verbatim. Do not add render-time sanitization either. Trusted skips (admins, the relevant dedicated permission), fail-closed defaults, and explicit server-side opt-outs (`unfiltered_content!`-style bang methods) follow `docs/security/permissions.md`; the shared detector for authored markup is `CamaleonCms::UnsafeMarkup`. Pre-existing stored data is reported (`rake camaleon_cms:security:scan_content` for authored content, `rake camaleon_cms:security:scan_uploads` for stored media), never rewritten. Positions the platform already escapes by default (plain `<%= %>` output of non-markup values) are not "escaping as a remedy" — they simply carry no gate.
-
-Two boundaries on that rule, both of which have been crossed by proposals that read as reasonable:
-
-- **The save-time decision is the only lever.** Content that passes is stored *and served* verbatim — no response header, CSP, content-disposition or separate origin constrains what a stored file does in the browser. A response header transforms nothing and acts after the save, so it slips past the letter of "reject, don't transform" while breaking it. Test any proposed control by asking whether it would constrain a *trusted* user's content; if it would, it is out.
-- **Prefer the scan; a permission gate is the last resort.** Where content can be judged, the scan judges it — refusing a whole file type or format by permission is wrong there. A gate is the remedy only where no scan can reach a verdict at all (uploaded JavaScript). Never a substitute for scanning where scanning works.
+The spec-coverage, reproduce-first and reject-don't-transform rules are in `AGENTS.md`. The full security model — the gating rule, the remedy rule, and the pieces that implement them (`CamaleonCms::UnsafeMarkup`, model-level gates, `unfiltered_content!`-style opt-outs, the `camaleon_cms:security:scan_*` audit tasks) — is `docs/security/permissions.md`; read it before touching content saves, uploads, or a permission.
 
 ### C. Refactoring Protocol
-- **Step-0 cleanup:** Before any structural refactor of a file larger than 300 LOC, first remove dead code (unused methods, unused requires, debug output) and commit that cleanup separately, before the real refactor.
-- **Phased execution:** Do not attempt large multi-file refactors in one pass. Break the work into explicit phases touching no more than 5 files each; run verification and wait for explicit approval before starting the next phase.
+
+- **Step-0 cleanup:** before a structural refactor of a file over 300 LOC, remove dead code (unused methods, unused requires, debug output) in its own commit first.
+- **Phased execution:** no large multi-file refactor in one pass. Phases touch at most 5 files each; run verification and wait for explicit approval between phases.
 
 ### D. CI Parity
-Before pushing, your code must pass the key commands listed in `AGENTS.md` (security scan, lint, specs, zeitwerk check). Auto-correct only what you touched.
+
+Before pushing, the four commands in `AGENTS.md` pass. Auto-correct only what you touched.
 
 ---
 
 ## Phase 3: Commit Guidelines
 
-**🔴 MANDATORY: `[skip ci]` for Non-Code Commits**
+Whether a push skips CI is decided **per push, not per commit**: GitHub reads the marker off the head commit of the push, and a marked head suppresses every workflow for that push, including the `pull_request` event when the PR is opened at that tip. When invoked, the marker is the literal token on its own line at the end of the message:
 
-Before EVERY commit, check: **Does this commit contain ONLY documentation, changelog, or config changes with NO code changes?**
-
-If YES, you MUST format the commit message as:
 ```
 <commit subject>
 
 [skip ci]
 ```
 
-**Examples of commits requiring `[skip ci]`:**
-- Documentation updates (`.md` files, README, docs/)
-- Changelog entries (`CHANGELOG.md`)
-- Configuration files with no code path changes
-- Comment-only changes
+It matches anywhere in the message, so a commit that merely explains the directive skips CI too — write "skip-ci directive" in prose unless you are invoking it.
 
-**⚠️ The marker is per-push, not per-commit.** GitHub evaluates it against the **head commit of the push**, so a `[skip ci]` commit at the tip suppresses every workflow for that push — including the `pull_request` event when the PR is opened at that tip. Push three commits ending on a docs-only one and *nothing* runs, for any of them.
+A commit is **docs-only** when it touches only documentation (`.md` files, `README.md`, `docs/`), `CHANGELOG.md`, `openspec/`, comments, or config with no code path.
 
-**First: is the *entire PR* docs-only?** If every commit on the branch touches only documentation, specs (`openspec/`), `CHANGELOG.md`, or config with no code paths, mark **every** commit `[skip ci]` — including the first — so the PR runs no CI at all. Such a tree gives the code matrix nothing to validate, and `master` carries **no branch protection** (no required status checks), so a PR with zero runs still merges. This is the primary path for a documentation-, spec-, or changelog-only PR, and it overrides the one-run rule below. *(It depends on `master` staying unprotected: if a required-status-check rule is ever added, a PR with no run would be unmergeable and this carve-out must be revisited — re-check with `gh api repos/owen2345/camaleon-cms/branches/master --jq '.protected'`.)*
-
-**Otherwise** — the PR includes a code change in some commit — decide the marker per push, not per commit, by answering one question:
-
-> Has this PR already had a full check run on an earlier push?
-
-- **No** — omit the marker on that push, *even if the push itself is docs-only*, and say why in the message. A mixed PR must get one full check run over its code, and a push whose head carries the marker produces none. This is the case when the branch has no PR yet, or when every push so far has been docs-only.
-- **Yes** — include the marker. A second run on a docs-only change revalidates nothing. CI validates the tree at the head commit, and a `CHANGELOG.md` edit does not change any tree the earlier run already covered.
-
-**The Phase 4 changelog commit is normally in the "Yes" branch.** It lands after the PR exists, which means an earlier push already opened the PR and triggered CI. Omitting the marker there duplicates the entire matrix to validate a Markdown edit. Do not read "the changelog commit lands last" as a reason to omit the marker — *lands last* is not the condition; *no run yet* is.
-
-Other consequences to plan for:
-
-- **Including the marker moves the PR head without triggering a run.** The passing checks stay attached to the previous SHA. Before merge, check whether branch protection requires checks on the head commit, and re-trigger only if it does — `master` currently has none, so no re-trigger is needed.
-- **If you have already pushed a docs-only commit without the marker**, cancel the now-stale runs on the *previous* SHA, not the new ones. The PR head has moved, so the new runs are the ones that count for merge.
-- **The marker matches anywhere in the message, including the body.** A commit that merely *explains* the directive will skip CI too. Write "skip-ci directive" in prose rather than the literal token — unless you are actually invoking it, in which case it belongs on its own line as shown above.
-- **Never mark a release PR.** The Release workflow refuses to publish a commit that has no successful `current_support.yml` and `audit.yml` runs recorded against it, and a marker on the head of the push to `master` produces none. A version bump is a code change, so the rule above already lands a release PR in the "omit the marker" branch — keep it there. See `docs/releasing.md`.
+1. **The entire PR is docs-only** (every commit on the branch): mark **every** commit, including the first, so the PR runs no CI at all — this overrides rule 2. `master` carries no branch protection, so a PR with zero runs still merges; if a required-status-check rule is ever added this carve-out must go (check with `gh api repos/owen2345/camaleon-cms/branches/master --jq '.protected'`).
+2. **The PR contains a code change somewhere.** For each push ask: *has this PR already had a full check run on an earlier push?*
+   - **No** (no PR yet, or every push so far was docs-only): omit the marker, even on a docs-only push, and say why in the message. A mixed PR gets one full run over its code, and a marked head produces none.
+   - **Yes**: include it. CI validates the tree at the head commit, and a changelog edit changes no tree an earlier run covered. The Phase 4 changelog commit lands after the PR exists, so it is normally this case — *lands last* is not the condition, *no run yet* is.
+3. **Consequences to plan for.** A marked push moves the PR head without a run and leaves the passing checks on the previous SHA; fine while `master` has no required checks, re-trigger only if that changes. If you pushed a docs-only commit *without* the marker by mistake, cancel the now-stale runs on the *previous* SHA, not the new ones.
+4. **Never mark a release PR.** The Release workflow refuses a commit with no successful `current_support.yml` and `audit.yml` runs, and a version bump is a code change anyway. See `docs/releasing.md`.
 
 ---
 
 ## Phase 4: PR Submission & Maintenance
 
-1.  **PR Protocol:** Generate a description following these STRICT negative constraints:
-    - **NO** `Files Changed` section.
-    - **NO** Test failure/example counts.
-    - **NO** Verification logs/commands.
-    - **NO** Commit SHAs or history references.
-    - **NO** evolution narrative — describe the PR's net what/why/how as it now stands; when commits are added later, integrate their substance into the description, never append follow-up or review-history sections.
-    - **REQUIRED:** One sentence on **User-Visible Impact** (or state "None").
-    - **REQUIRED:** A "What and Why" summary.
+1. **PR description.** Required: a **What and Why** summary and one sentence of **User-Visible Impact** (or "None"). Not allowed: a Files Changed section, test or example counts, verification logs or commands, commit SHAs or history references, and any evolution narrative — describe the PR's net what/why/how as it now stands, and when commits are added later fold their substance into the description instead of appending follow-up or review-history sections.
 
-2.  **Metadata Maintenance:** If you change setup, test, or CI commands, you are **REQUIRED** to update:
-    - `AGENTS.md`
-    - `docs/ai/testing.md` (if applicable)
-    - `README.md`
-    *All updates must be part of the same PR.*
+2. **Metadata maintenance.** A change to setup, test, or CI commands updates `AGENTS.md`, `docs/ai/testing.md` (if applicable) and `README.md` in the same PR.
 
-3.  **Changelog:** After creating the PR, you MUST generate and commit a changelog entry referencing the PR:
+3. **Changelog.** After creating the PR, commit an entry under `## Unreleased` that links it:
+
     ```
     - **Security fix:** Fix mass assignment and open redirect vulnerabilities in SitesController, [#1152](https://github.com/owen2345/camaleon-cms/pull/1152)
     ```
 
-    **🔴 Keep the entry short. The PR description is where the reasoning lives.** The changelog is read by someone deciding whether an upgrade affects them — not by someone auditing your analysis. A lead paragraph carrying the PR link is the whole entry for most changes; the **entire entry — every paragraph included — MUST NOT exceed 500 characters**, and the PR link and any reporter credit count toward that limit. Do not restate the root cause, the code path, the attack mechanics, or the design rationale — every one of those is already in the PR body, one click away through the link you just added.
+    The entry is a lookup target for someone deciding whether an upgrade affects them, not a narrative; the reasoning lives in the PR description. The **entire entry must not exceed 500 characters**, PR link and reporter credit included, and it does not restate the root cause, the code path, the attack mechanics or the design rationale. Keep a **Breaking changes** list inline only for what the reader must act on or will observe: two to four bullets, one or two sentences each, *what changed for the reader*, never *why*.
 
-    Keep a **Breaking changes** list in the changelog entry — a short list, *only* for what the reader must act on or will observe (behavior that changed, output that moved, a dependency floor that was raised, data that is or is not rewritten). Two to four bullets, one or two sentences each. If a bullet explains *why* rather than *what changed for the reader*, delete it.
+    Everything else an upgrader must do or know lives in the release's upgrade guide, `docs/upgrading-to-<version>.md`: operator actions with copy-paste commands, observable behavior changes, notes for theme and plugin developers. Each released version's CHANGELOG section carries a single banner linking the guide (see the `## [2.9.3] …` section), and every entry whose notes moved ends with a link to its guide section anchor, e.g. `[Upgrade notes](docs/upgrading-to-<version>.md#sessions--login)`. Mid-cycle, before the guide exists, draft an upgrader note inline under a **Notes for upgraders** bullet; the release step consolidates those (`docs/releasing.md` Step 1). Once `docs/upgrading-to-<version>.md` exists mid-cycle, new and existing unreleased entries put their detail there and keep only the one-line action plus the anchor link. Before committing, re-read the entry as someone who has never seen the PR: anything that would not change what they do belongs in the PR description or the upgrade guide instead.
 
-    **Everything else an upgrader must do or know lives in the release's upgrade guide, `docs/upgrading-to-<version>.md` — not spelled out in the changelog entries.** That guide is the runbook: audience-organized (operator actions with copy-paste commands, observable behavior changes, notes for theme/plugin developers). Each released version's CHANGELOG section carries a **single banner** linking the guide (see the `## [2.9.3] …` section for the shape), and every entry whose upgrader notes were moved ends with a link to the specific guide section anchor — e.g. `[Upgrade notes](docs/upgrading-to-<version>.md#sessions--login)` — so the entry stays terse while a reader can jump straight to what they must do. When a PR mid-cycle must record an upgrader note before the version's guide exists, draft it inline under a **Notes for upgraders** bullet; the release step consolidates those into the guide, keeps the Breaking changes inline, and adds the banner and the per-entry anchor links (`docs/releasing.md` Step 1). A mid-cycle guide may also be started early (maintainer's call) — once `docs/upgrading-to-<version>.md` exists, new and existing unreleased entries put their detail in the guide and keep only the one-line action plus the section-anchor link inline; the release step then only extends the guide and adds the banner.
+4. **Archive the OpenSpec change before merge.** If the work was planned with OpenSpec, run `/opsx:archive` on the branch and commit the result as part of the PR: it syncs the delta specs into `openspec/specs/<capability>/spec.md` and moves the change to `openspec/changes/archive/YYYY-MM-DD-<name>/`. `master` never carries a completed-but-unarchived change, and every box in `tasks.md`, the archive task included, is checked before the branch merges.
 
-    The entry is a lookup target, not a narrative. Before committing it, re-read it as someone who has never seen the PR and ask what they would do differently — anything that does not change their answer belongs in the PR description (for reasoning) or the upgrade guide (for upgrade steps) instead.
-
-4.  **Archive the OpenSpec change — before merge, not after.** If the work was planned with OpenSpec, run `/opsx:archive` **on the branch** and commit the result as part of the PR. This syncs the change's delta specs into `openspec/specs/<capability>/spec.md` and moves the change to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
-
-    Archiving is **not** a post-merge step. `master` must never carry a completed-but-unarchived change, and every box in `tasks.md` — including the archive task itself — must be checked before the branch merges. See PR [#1213](https://github.com/owen2345/camaleon-cms/pull/1213), where the archive commit precedes the merge commit on the branch.
-
-5.  **Quality Gate:** Before completion, self-audit against `docs/ai/criteria.md`.
+5. **Quality gate.** Self-audit against `docs/ai/criteria.md` before completion.

--- a/docs/security/permissions.md
+++ b/docs/security/permissions.md
@@ -236,9 +236,9 @@ Security notes
 Camaleon restricts the HTML a role may store, and three permissions lift that restriction. **They are different permissions with similar names**, they
 do not all live in the same family, and holding one does not grant the others. All three are introduced in 2.9.3.
 
-They also work differently, which matters when you are deciding who to grant them to. Post content is **sanitized**: an untrusted author's save
-succeeds and the disallowed markup is quietly removed. Contact forms and uploads are **refused**: an untrusted author's save or upload does not happen
-at all. Nothing in a contact form or an uploaded file is ever rewritten.
+All three work the same way: without the permission, an untrusted author's save or upload is **refused** outright, and nothing is ever
+rewritten — the remedy rule above. (Post content was sanitized rather than refused before
+[#1263](https://github.com/owen2345/camaleon-cms/pull/1263).)
 
 | | `post_content_unfiltered_html` | `contact_form_unfiltered_html` | `media_unfiltered_upload` |
 |---|---|---|---|
@@ -246,7 +246,7 @@ at all. Nothing in a contact form or an uploaded file is ever rewritten.
 | Role meta | `_post_type_<site_id>` | `_manager_<site_id>` | `_manager_<site_id>` |
 | Scope | per post type | all contact forms on the site | all uploads on the site |
 | Checked as | `can?(:post_content_unfiltered_html, post_type)` | `can?(:manage, :contact_form_unfiltered_html)` | `can?(:manage, :media_unfiltered_upload)` |
-| Without it | `Post#content` is sanitized on save | the save is refused; nothing is stored | the upload is refused; nothing is stored |
+| Without it | the save is refused; nothing is stored | the save is refused; nothing is stored | the upload is refused; nothing is stored |
 | Covers | `Post#content` | every contact-form value that reaches the page | every upload, whatever its source |
 | Introduced in | [#1206](https://github.com/owen2345/camaleon-cms/pull/1206) | [#1215](https://github.com/owen2345/camaleon-cms/pull/1215) | [#1228](https://github.com/owen2345/camaleon-cms/pull/1228) |
 
@@ -256,9 +256,10 @@ administrator who views the affected page or opens the affected file. Grant them
 
 ### `post_content_unfiltered_html` — raw HTML in post content
 
-Without this permission, `Post#content` is sanitized at save time with `CamaleonRecord.cama_sanitize_translatable`, which strips `<script>`,
-`<iframe>`, event-handler attributes such as `onerror`/`onload`, and `javascript:` URLs, while preserving ordinary formatting. With it, content is
-stored exactly as submitted.
+Without this permission, a `Post#content` save carrying disallowed markup — `<script>`, `<iframe>`, event-handler attributes such as
+`onerror`/`onload`, `javascript:` URLs — is refused with an error naming the remedy (`Post#reject_untrusted_dangerous_content`, judged by
+`CamaleonCms::UnsafeMarkup` against the post's allowed tags and attributes); ordinary formatting passes. With it, content is stored exactly as
+submitted. `Post#unfiltered_content!` opts a trusted server-side pipeline out per record.
 
 The permission is granted per post type, so a role may hold it for one post type and not another.
 
@@ -414,7 +415,8 @@ As with `select_eval`, the Admin role's checkboxes may appear unchecked in the U
 ### Background jobs and console usage
 
 All three checks read the acting user and site from `CurrentRequest` and **fail closed**: when either is missing, the caller is treated as untrusted
-regardless of any role's permissions — post content is sanitized, a contact-form save is refused, and an upload is scanned. Saves and uploads from
+regardless of any role's permissions — a post-content save carrying disallowed markup is refused, a contact-form save is refused, and an
+upload is scanned. Saves and uploads from
 background jobs, rake tasks, or the console therefore get the untrusted treatment by default. To save raw HTML or upload an unscanned file from those
 contexts, set the request context first, as shown in the `select_eval` section above:
 


### PR DESCRIPTION
## What and why

Anthropic's guidance for the Claude 5 generation, [The new rules of context engineering for Claude 5 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models), is to keep `CLAUDE.md`-style context lightweight (a line on what the repo is, the rest on gotchas inside the codebase), to drop what the agent can read from the file system, to prefer judgment over generic rules and repeated tool documentation, and to point at real code rather than paste examples. This PR applies that to the agent entry point and to every document it routes to.

`AGENTS.md`, imported by `CLAUDE.md` into every session, is about half its previous size. Gone: the stack-inference line, the generic behaviour section, the quick-reference paths and namespaces that `docs/ai/reference.md` owns, the per-command OpenSpec list that the installed skills describe themselves, and the emphatic phrasing. Kept in fewer words: the gem-not-app quirk (root `bin/rails` only runs engine commands), the branch prefixes, the spec-coverage and reproduce-first rules, the reject-don't-transform rule with both of its boundaries, the ecosystem warning, the four CI-parity commands, OpenSpec routing and the load-per-task table, plus one new line naming the Rails and Ruby range CI exercises.

The per-task documents keep every team rule and gotcha and lose the rest:

- `docs/ai/workflows.md` restates the skip-ci and changelog rules as short decision procedures with every condition intact, and replaces its third copy of the security remedy rule with a pointer to the authoritative one in `docs/security/permissions.md`.
- `docs/ai/testing.md` points at the real spec support files, the site factory, a compact feature spec and a security reproduction instead of pasting templates, drops generic RSpec advice and the triage steps duplicated from the workflow doc, and loses a factory example that no longer matched the code.
- `docs/ai/reference.md` drops code samples that duplicate the source and the obvious path and env tables, keeps the hook contract, the media-cache invariant, the public-API compatibility notes and the style idioms, corrects the claim that migrations also run from `spec/dummy/db/migrate` (that directory does not exist), and adds the gotcha that data backfills are Rake tasks, never migrations.
- `docs/ai/criteria.md` is a four-line repo-specific checklist.
- `docs/security/permissions.md` no longer says untrusted post content is sanitized on save; it has been refused since #1263, as the file's own remedy rule requires.

`docs/ai/ecosystem.md`, `docs/ai/secrets.md` and `docs/releasing.md` are untouched: the first two are non-derivable inventories and the third is an operator runbook whose step-by-step form is its value.

The `agent-guidance-progressive-disclosure` spec's invariants remain satisfied: every item it requires is still in `AGENTS.md`, references use plain paths, and every referenced file and section resolves. No spec change is needed.

## User-visible impact

None. Development-only; nothing in the gem changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
