### PR TITLE
Specify the custom-field behaviors fixed in #1288

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Docs:** Capture the custom-field behaviors fixed in #1288 — the admin edit form's per-field render isolation and colorpicker value handling, and the settings save keeping every per-kind field option — as the `custom-field-render-resilience` and `custom-field-option-persistence` OpenSpec capabilities. No behavior change. [#1291](https://github.com/owen2345/camaleon-cms/pull/1291).
+
 - **Tooling:** The checked-in OpenSpec agent instructions (`/opsx:*` prompts and skills for the four integrations) are regenerated with OpenSpec 1.12.0. Development-only. [#1290](https://github.com/owen2345/camaleon-cms/pull/1290).
 
 - **Tooling:** Rightsize the agent docs for the Claude 5 generation: `AGENTS.md` keeps a one-line repo description plus codebase gotchas, and the docs it routes to (`docs/ai/workflows.md`, `testing.md`, `reference.md`, `criteria.md`) drop generic advice, duplicated rules and stale claims in favour of pointers to real code; `docs/security/permissions.md` no longer says post content is sanitized. Development-only. [#1289](https://github.com/owen2345/camaleon-cms/pull/1289).

--- a/openspec/changes/archive/2026-08-01-fix-contact-form-output-escaping/tasks.md
+++ b/openspec/changes/archive/2026-08-01-fix-contact-form-output-escaping/tasks.md
@@ -211,10 +211,10 @@ maintained by hand against a renderer whose contexts the *author* could move.
 - [x] 10.2 Plugin committed on `security/reject-unsafe-content`, [PR #65](https://github.com/owen2345/cama_contact_form/pull/65) opened, merged and released — `cama_contact_form` 0.1.12 is on RubyGems
 - [x] 10.3 Better than repointing at a tag: the override is removed from all six Gemfiles outright, and `camaleon_cms.gemspec` raises the dependency to `~> 0.1.12`. Left at `~> 0.1.0` the range would still have admitted the vulnerable 0.1.0
 - [x] 10.4 Local Bundler override removed (`bundle config unset local.cama_contact_form && rm -rf .bundle`); `Gemfile.lock` re-resolved and now carries no git source. `.bundle/` stays gitignored
-- [ ] 10.5 Amend/extend the Camaleon commit — the pushed branch predates the rejection design — and update the [#1215](https://github.com/owen2345/camaleon-cms/pull/1215) body
-- [ ] 10.6 `openspec archive fix-contact-form-output-escaping -y` on the branch, before merge
+- [x] 10.5 Amend/extend the Camaleon commit — the pushed branch predates the rejection design — and update the [#1215](https://github.com/owen2345/camaleon-cms/pull/1215) body
+- [x] 10.6 `openspec archive fix-contact-form-output-escaping -y` on the branch, before merge
 - [x] 10.7 Full gate: `bin/rspec`, `bin/rubocop`, `bin/brakeman --no-pager`, `(cd spec/dummy && bin/rails zeitwerk:check)` — all green, see 9b.16
-- [ ] 10.8 Re-confirm against the `2.9.2` tag that neither `allow_unfiltered_html` nor `post_unfiltered_html` appears, so the D8 rename still needs no migration
+- [x] 10.8 Re-confirm against the `2.9.2` tag that neither `allow_unfiltered_html` nor `post_unfiltered_html` appears, so the D8 rename still needs no migration
 
 ## 11. Superseded releases
 

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/design.md
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/design.md
@@ -1,0 +1,80 @@
+## Context
+
+The behaviors this change specifies shipped in PR
+[#1288](https://github.com/owen2345/camaleon-cms/pull/1288) on `master`, unreleased as of 2.9.5.
+See `proposal.md` for the motivation. The implementation sits in four places: the admin
+custom-field build loop and its per-kind render callbacks
+(`app/assets/javascripts/camaleon_cms/admin/_custom_fields.js`), the bundled colorpicker widget
+(`app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js`, whose constructor, `setValue`,
+`hide` and slider handler carry the fix), the translation decoder
+(`app/assets/javascripts/camaleon_cms/admin/_translator.js`), and the permit list of
+`Admin::Settings::CustomFieldsController#permitted_field_options`.
+
+Constraints:
+
+- The field build runs inside one jQuery-ready handler, so an uncaught throw in any field aborts
+  every field and initialiser after it. That is the cascade the render-resilience capability
+  exists to forbid.
+- The colorpicker reads its colour through jQuery's `data()`, which coerces a numeric-looking
+  attribute to a Number at read time, and the widget's colour parser takes only strings. The
+  attribute alone cannot fix this; the data cache has to be primed with the string form.
+- `custom_field_colorpicker` is a public global that a theme's field markup can name in its
+  `data-callback-render` attribute, so its contract is part of the capability.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- State the per-field isolation guarantee and the colorpicker's value contract as testable
+  requirements, so a future edit that reintroduces the cascade fails a spec rather than shipping.
+- State what a definition save keeps, and the one option it refuses, so the permit list is
+  maintained against a requirement instead of rediscovered per panel.
+
+**Non-Goals:**
+
+- Any change to the shipped behavior, the JavaScript, or the controller.
+- Re-specifying value-save gating (`custom-field-value-rejection`,
+  `custom-field-value-filtering`) or the other existing custom-field capabilities.
+- Repairing records whose sibling values were blanked before the fix; the 2.9.5 upgrade guide
+  tells operators which records to review.
+
+## Decisions
+
+**Two capabilities, not one.** Rendering the edit form and saving a definition are different
+layers with different tests (a `:js` feature spec, a request spec) and different failure modes
+(data loss on the record versus options lost on the definition). One spec would blur which
+requirement a future change touches. Alternative considered: folding the option persistence into
+`custom-field-definition-lifecycle`; rejected because that capability pins teardown, not what a
+save keeps.
+
+**Requirements state the observable contract, the mechanism lives here.** The specs say the
+picker accepts any stored value as text and that an untouched picker writes nothing; they do not
+name the data-cache priming or the `colorpicked` flag. Those are recorded in Context so the next
+maintainer understands why priming the attribute alone regresses, without freezing the mechanism
+into the contract.
+
+**Spell out the value shapes.** Everything `data()` coerces — numbers, booleans, `null`, JSON —
+crashed identically, so the colorpicker requirement lists the shapes rather than saying "any
+value": a fix that handles numbers only would pass a vaguer requirement.
+
+**The `command` exclusion is a requirement, not a comment.** The permit list's comment says
+`:command` is deliberately not permitted; the option holds a Ruby expression and `select_eval`
+is intentionally left non-working. A persistence requirement that read "keep every offered
+option" without the exclusion would invite a well-meaning edit to permit it. The scenario is
+implemented by the permit list; it is the one scenario in this change without a dedicated
+example, which is acceptable for a documentation-only capture and noted in the proposal.
+
+**Tasks are pre-checked.** The implementation and its tests merged in #1288; this change records
+them and is archived on the branch in the same PR (`docs/ai/workflows.md` Phase 4), so `master`
+never carries an unarchived completed change.
+
+## Risks / Trade-offs
+
+- **The `command` scenario has no example** → the permit list is the implementation and any
+  future edit to it is reviewed against this requirement; a request-spec example can be added
+  when the controller is next touched.
+- **Scenarios pin widget markup details (addon, icon, colour-format attribute)** → accepted: the
+  themed-markup contract is exactly what themes rely on, and the failures were markup-shaped.
+- **Warnings instead of errors hide a broken callback from the user** → the console warning names
+  the callback, and the alternative (the cascade) blanked stored values; degrading one field is
+  the lesser harm and the requirement says so.

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/proposal.md
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/proposal.md
@@ -1,0 +1,57 @@
+# Capture the custom-field edit-form and settings-save invariants fixed in #1288
+
+## Why
+
+PR [#1288](https://github.com/owen2345/camaleon-cms/pull/1288) fixed a data-loss bug — one custom
+field's bad stored value aborted the admin edit form's field rendering, and saving the record in
+that state blanked every unrendered field's stored value — and, alongside it, the settings save
+that silently discarded the per-kind field options. Both invariants shipped with tests but with
+no OpenSpec capability, so the behaviors the tests pin are recorded nowhere durable. This change
+captures them; it introduces no code.
+
+## What Changes
+
+- Add `custom-field-render-resilience`: the admin edit form renders each custom field
+  independently, so a field with a bad value or a broken render callback degrades alone and the
+  fields after it keep their stored values; the colorpicker field accepts any stored value as
+  text, keeps its default when unset, does not rewrite the field when opened untouched, and
+  survives themed markup and unknown colour formats; option-valued fields (checkbox, checkboxes,
+  radio) match stored values as text rather than by selector; a disabled field renders read-only;
+  the admin translation decoder accepts typed values.
+- Add `custom-field-option-persistence`: saving a custom-field group keeps every per-kind extra
+  option the settings panels offer, and deliberately does not accept the `select_eval` field's
+  `command` option from the request.
+- No application code changes. The behaviors are already on `master` (unreleased 2.9.5) and are
+  covered by `spec/features/admin/custom_field_colorpicker_spec.rb` and
+  `spec/requests/admin/settings/custom_field_extra_options_spec.rb`.
+
+## Capabilities
+
+### New Capabilities
+
+- `custom-field-render-resilience`: what the admin edit form guarantees when it renders a
+  record's custom fields — per-field failure isolation, the colorpicker's value handling, option
+  matching for choice fields, the disabled option, and the translation decoder's input types.
+- `custom-field-option-persistence`: what a custom-field group save stores for each field's
+  per-kind options, and the one option it refuses.
+
+### Modified Capabilities
+
+None. The existing custom-field capabilities cover other layers: `custom-field-value-rejection`
+and `custom-field-value-filtering` govern what a value save accepts, `custom-field-list-write-safety`
+the list endpoint, `custom-field-definition-lifecycle` teardown, `custom-field-group-tenancy` and
+`custom-field-group-placement` group scoping, and `custom-field-sort-ordering` the sort clause.
+None of them states what the edit form renders or what a definition save keeps.
+
+## Impact
+
+- **Specs (new):** `openspec/specs/custom-field-render-resilience/spec.md` and
+  `openspec/specs/custom-field-option-persistence/spec.md` via this change's deltas.
+- **Application code:** none. Referenced but not modified:
+  `app/assets/javascripts/camaleon_cms/admin/_custom_fields.js`,
+  `app/assets/javascripts/camaleon_cms/admin/bootstrap-colorpicker.js`,
+  `app/assets/javascripts/camaleon_cms/admin/_translator.js`,
+  `app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb`.
+- **Tests:** none added; the two spec files from #1288 already exercise every scenario except the
+  `command` exclusion, which the permit list implements and the design records.
+- **Behavior:** unchanged. Documentation plus the changelog entry only.

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/specs/custom-field-option-persistence/spec.md
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/specs/custom-field-option-persistence/spec.md
@@ -1,0 +1,34 @@
+## Purpose
+
+Saving a custom-field group replaces each field's whole option set with what the settings form
+posts, so any offered option the save drops is lost for good and wiped from a previously saved
+field on re-save. The capability pins which per-kind options a save keeps and the one it refuses.
+
+## ADDED Requirements
+
+### Requirement: Saving a field definition keeps its per-kind options
+
+Saving a custom-field group SHALL persist, for each field, every per-kind extra option the
+settings panels offer alongside the common options: the colorpicker's colour format, the date
+field's date-versus-datetime type, the image field's dimension and versions, the file field's
+formats, the posts field's post-type filter, and the panel's collapsed state. An offered option
+MUST NOT be silently discarded on save.
+
+#### Scenario: Every offered per-kind option is stored
+
+- **WHEN** an admin saves a group holding a colorpicker with a colour format and a collapsed
+  panel, an image field with a dimension and versions, a date field set to datetime, and a posts
+  field with a post-type filter
+- **THEN** each field's stored options include those values
+
+### Requirement: The select_eval command is not accepted from the request
+
+The save SHALL NOT accept the `select_eval` field's `command` option from the request, whatever
+the settings form posts: the option holds a Ruby expression, and the field stays a deliberately
+non-working capability. A submitted `command` SHALL be dropped without failing the save of the
+other options.
+
+#### Scenario: A submitted command is dropped
+
+- **WHEN** an admin saves a field whose posted options include a `command`
+- **THEN** the field's stored options do not include it and its other options are stored

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/specs/custom-field-render-resilience/spec.md
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/specs/custom-field-render-resilience/spec.md
@@ -1,0 +1,142 @@
+## Purpose
+
+The admin edit form must render every custom field of a record regardless of what any one field
+holds or how its renderer behaves: a save replaces all of a record's field values with what the
+form posts, so a field left unrendered posts nothing and its stored value is silently blanked.
+The capability pins that isolation and the value handling of the field kinds whose rendering used
+to break it.
+
+## ADDED Requirements
+
+### Requirement: One field's failure does not abort the rest of the form
+
+The admin edit form SHALL render each custom field of a record independently. A field whose
+stored value or per-kind render callback fails SHALL degrade alone: the failure is reported as a
+console warning naming the callback, the form's field build does not throw, and every field
+registered after it renders with its stored value, as do the page initialisers registered after
+the field build. A render callback whose name resolves to no function SHALL be reported the same
+way rather than thrown.
+
+#### Scenario: A broken render callback warns and leaves the rest of the form intact
+
+- **WHEN** a custom field's render callback throws while the edit form builds its fields
+- **THEN** a console warning naming the callback is emitted, the build completes, and the fields
+  after it render with their stored values
+
+#### Scenario: Fields after a colorpicker holding a non-colour value keep their values
+
+- **WHEN** a colorpicker field stores the free-text value `2` and a text field is registered after
+  it on the same record
+- **THEN** both render, the text field shows its stored value, and a save preserves it
+
+### Requirement: The colorpicker accepts any stored value as text
+
+The colorpicker field SHALL initialise for any stored value — a colour, free text, a number-like
+string, `true`, `null` or JSON — and show the stored value verbatim in its input, treating it as
+text no matter what type the value arrives as. A stored colour SHALL render on the swatch. A field
+with no stored value SHALL keep the markup's declared default colour (white) rather than an empty
+value, and a falsy-but-real value such as `0` SHALL be preserved as the text `0`. The plain
+initialiser that themes can name as a render callback SHALL tolerate markup whose colour
+attribute is coercible or absent. Markup missing the swatch internals (no addon, or an addon
+without its icon) SHALL still initialise, an unrecognised colour format SHALL fall back to hex,
+and rendering the field again with a new value SHALL repaint the swatch.
+
+#### Scenario: A number-like stored value initialises the picker
+
+- **WHEN** the stored value is `2`
+- **THEN** the picker initialises and its input shows `2`
+
+#### Scenario: Other typed shapes initialise the picker
+
+- **WHEN** the stored value is `true`, `null` or `{"a":1}`
+- **THEN** the picker initialises and the fields after it keep their stored values
+
+#### Scenario: A stored colour renders on the swatch
+
+- **WHEN** the stored value is `#00ff00`
+- **THEN** the input shows `#00ff00` and the swatch is green
+
+#### Scenario: No stored value keeps the default white
+
+- **WHEN** the field has no stored value
+- **THEN** the picker initialises and the swatch is white
+
+#### Scenario: A numeric zero survives as text
+
+- **WHEN** the field is rendered with the value `0`
+- **THEN** the widget's colour reads as the text `0`
+
+#### Scenario: The plain initialiser tolerates a coercible or missing colour attribute
+
+- **WHEN** the plain initialiser runs on markup whose colour attribute is `2`, or has none
+- **THEN** the widget initialises
+
+#### Scenario: Themed markup without the swatch internals initialises
+
+- **WHEN** the markup has no addon, or an addon without its icon
+- **THEN** the widget initialises
+
+#### Scenario: An unrecognised colour format falls back to hex
+
+- **WHEN** the markup declares an unrecognised colour format, a colour is picked and the picker
+  closes
+- **THEN** the input holds the picked colour in hex
+
+#### Scenario: Re-rendering with a new value repaints
+
+- **WHEN** the field is rendered with one colour and then rendered again with another
+- **THEN** the swatch shows the second colour
+
+### Requirement: An untouched picker leaves the stored value alone
+
+Opening and dismissing the colorpicker without choosing a colour SHALL NOT write to the field: the
+input keeps its stored value, free text or blank included. After an actual pick — a slider
+interaction or a programmatic set — dismissing the picker SHALL write the formatted colour back.
+
+#### Scenario: Opening and dismissing the picker untouched changes nothing
+
+- **WHEN** the stored value is `2` and the picker is opened, then dismissed without a pick
+- **THEN** the input still reads `2`
+
+#### Scenario: A pick is written back on dismiss
+
+- **WHEN** a colour is picked and the picker is dismissed
+- **THEN** the input holds the picked colour
+
+### Requirement: Choice fields match stored values as text
+
+The checkbox, checkboxes and radio fields SHALL select the option or options whose value equals
+the stored value by comparing values as text, so an option value holding a quote or another
+selector-significant character is selected and does not break the form. The checkboxes field
+SHALL accept a scalar stored value as well as a list.
+
+#### Scenario: A radio option holding a quote renders checked
+
+- **WHEN** a radio field's option value is `Bob's pick`, that value is stored, and a text field is
+  registered after the radio
+- **THEN** the option renders checked and the text field renders with its stored value
+
+#### Scenario: A checkboxes option holding a quote renders checked from a scalar value
+
+- **WHEN** a checkboxes field stores the scalar value `Bob's tag`
+- **THEN** that option renders checked
+
+### Requirement: A disabled field renders read-only
+
+A custom field whose definition carries the disabled (or readonly) option SHALL render its inputs
+read-only in the edit form.
+
+#### Scenario: A disabled text field is read-only
+
+- **WHEN** a text field is defined with the disabled option and holds a stored value
+- **THEN** its input renders read-only
+
+### Requirement: The translation decoder accepts typed values
+
+The admin translation decoder that translatable fields read their values through SHALL accept a
+value that arrives as a number or boolean, treating it as its text form, instead of throwing.
+
+#### Scenario: A numeric or boolean value decodes
+
+- **WHEN** the decoder receives `1` or `true`
+- **THEN** it returns without throwing

--- a/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/tasks.md
+++ b/openspec/changes/archive/2026-09-06-capture-custom-field-render-resilience/tasks.md
@@ -1,0 +1,30 @@
+## 1. Branch
+
+- [x] 1.1 Create `feature/capture-custom-field-render-resilience` from `master` per AGENTS.md Phase 1
+
+## 2. Behaviors already shipped in #1288 (verification: the named example passes on master)
+
+- [x] 2.1 Per-field failure isolation with a console warning — `spec/features/admin/custom_field_colorpicker_spec.rb` "warns when a render callback breaks instead of dying silently" and "renders the picker, its value and the fields after it despite a non-colour value"
+- [x] 2.2 Colorpicker accepts any stored value as text, keeps the default white, preserves `0`, tolerates coercible or missing attributes, themed markup, unknown formats, and repaints on re-render — the remaining colorpicker examples in the same file
+- [x] 2.3 An untouched picker writes nothing; a pick is written back — "does not overwrite the stored value when the picker is opened and closed untouched" and "still writes the colour back when one was actually picked"
+- [x] 2.4 Choice fields match stored values as text — the radio and checkboxes quote examples
+- [x] 2.5 A disabled field renders read-only — "renders a disabled field readonly"
+- [x] 2.6 The translation decoder accepts typed values — "decodes a non-string translated value without crashing"
+- [x] 2.7 A definition save keeps every offered per-kind option — `spec/requests/admin/settings/custom_field_extra_options_spec.rb`
+- [x] 2.8 `command` is not permitted — `permitted_field_options` in `app/controllers/camaleon_cms/admin/settings/custom_fields_controller.rb` (no dedicated example; see design.md)
+
+## 3. Specs
+
+- [x] 3.1 Write the `custom-field-render-resilience` delta spec and verify `openspec validate capture-custom-field-render-resilience --strict` passes
+- [x] 3.2 Write the `custom-field-option-persistence` delta spec and verify the same validation passes
+- [x] 3.3 Confirm no existing capability needs a MODIFIED delta (proposal "Modified Capabilities")
+
+## 4. Documentation
+
+- [x] 4.1 Add the CHANGELOG.md entry under Unreleased after the PR exists, linking it and stating no behavior change
+
+## 5. Close out
+
+- [x] 5.1 Run `/opsx:verify` and address its findings
+- [x] 5.2 Run `/opsx:archive` on the branch before merge: sync both capabilities into `openspec/specs/` and commit the archive in the PR
+- [x] 5.3 Open the docs-only PR against `master` with the skip-ci marker on every commit (`docs/ai/workflows.md` Phase 3 rule 1)

--- a/openspec/specs/custom-field-option-persistence/spec.md
+++ b/openspec/specs/custom-field-option-persistence/spec.md
@@ -1,0 +1,35 @@
+# custom-field-option-persistence Specification
+
+## Purpose
+Saving a custom-field group replaces each field's whole option set with what the settings form
+posts, so any offered option the save drops is lost for good and wiped from a previously saved
+field on re-save. The capability pins which per-kind options a save keeps and the one it refuses.
+
+## Requirements
+
+### Requirement: Saving a field definition keeps its per-kind options
+
+Saving a custom-field group SHALL persist, for each field, every per-kind extra option the
+settings panels offer alongside the common options: the colorpicker's colour format, the date
+field's date-versus-datetime type, the image field's dimension and versions, the file field's
+formats, the posts field's post-type filter, and the panel's collapsed state. An offered option
+MUST NOT be silently discarded on save.
+
+#### Scenario: Every offered per-kind option is stored
+
+- **WHEN** an admin saves a group holding a colorpicker with a colour format and a collapsed
+  panel, an image field with a dimension and versions, a date field set to datetime, and a posts
+  field with a post-type filter
+- **THEN** each field's stored options include those values
+
+### Requirement: The select_eval command is not accepted from the request
+
+The save SHALL NOT accept the `select_eval` field's `command` option from the request, whatever
+the settings form posts: the option holds a Ruby expression, and the field stays a deliberately
+non-working capability. A submitted `command` SHALL be dropped without failing the save of the
+other options.
+
+#### Scenario: A submitted command is dropped
+
+- **WHEN** an admin saves a field whose posted options include a `command`
+- **THEN** the field's stored options do not include it and its other options are stored

--- a/openspec/specs/custom-field-render-resilience/spec.md
+++ b/openspec/specs/custom-field-render-resilience/spec.md
@@ -1,0 +1,143 @@
+# custom-field-render-resilience Specification
+
+## Purpose
+The admin edit form must render every custom field of a record regardless of what any one field
+holds or how its renderer behaves: a save replaces all of a record's field values with what the
+form posts, so a field left unrendered posts nothing and its stored value is silently blanked.
+The capability pins that isolation and the value handling of the field kinds whose rendering used
+to break it.
+
+## Requirements
+
+### Requirement: One field's failure does not abort the rest of the form
+
+The admin edit form SHALL render each custom field of a record independently. A field whose
+stored value or per-kind render callback fails SHALL degrade alone: the failure is reported as a
+console warning naming the callback, the form's field build does not throw, and every field
+registered after it renders with its stored value, as do the page initialisers registered after
+the field build. A render callback whose name resolves to no function SHALL be reported the same
+way rather than thrown.
+
+#### Scenario: A broken render callback warns and leaves the rest of the form intact
+
+- **WHEN** a custom field's render callback throws while the edit form builds its fields
+- **THEN** a console warning naming the callback is emitted, the build completes, and the fields
+  after it render with their stored values
+
+#### Scenario: Fields after a colorpicker holding a non-colour value keep their values
+
+- **WHEN** a colorpicker field stores the free-text value `2` and a text field is registered after
+  it on the same record
+- **THEN** both render, the text field shows its stored value, and a save preserves it
+
+### Requirement: The colorpicker accepts any stored value as text
+
+The colorpicker field SHALL initialise for any stored value — a colour, free text, a number-like
+string, `true`, `null` or JSON — and show the stored value verbatim in its input, treating it as
+text no matter what type the value arrives as. A stored colour SHALL render on the swatch. A field
+with no stored value SHALL keep the markup's declared default colour (white) rather than an empty
+value, and a falsy-but-real value such as `0` SHALL be preserved as the text `0`. The plain
+initialiser that themes can name as a render callback SHALL tolerate markup whose colour
+attribute is coercible or absent. Markup missing the swatch internals (no addon, or an addon
+without its icon) SHALL still initialise, an unrecognised colour format SHALL fall back to hex,
+and rendering the field again with a new value SHALL repaint the swatch.
+
+#### Scenario: A number-like stored value initialises the picker
+
+- **WHEN** the stored value is `2`
+- **THEN** the picker initialises and its input shows `2`
+
+#### Scenario: Other typed shapes initialise the picker
+
+- **WHEN** the stored value is `true`, `null` or `{"a":1}`
+- **THEN** the picker initialises and the fields after it keep their stored values
+
+#### Scenario: A stored colour renders on the swatch
+
+- **WHEN** the stored value is `#00ff00`
+- **THEN** the input shows `#00ff00` and the swatch is green
+
+#### Scenario: No stored value keeps the default white
+
+- **WHEN** the field has no stored value
+- **THEN** the picker initialises and the swatch is white
+
+#### Scenario: A numeric zero survives as text
+
+- **WHEN** the field is rendered with the value `0`
+- **THEN** the widget's colour reads as the text `0`
+
+#### Scenario: The plain initialiser tolerates a coercible or missing colour attribute
+
+- **WHEN** the plain initialiser runs on markup whose colour attribute is `2`, or has none
+- **THEN** the widget initialises
+
+#### Scenario: Themed markup without the swatch internals initialises
+
+- **WHEN** the markup has no addon, or an addon without its icon
+- **THEN** the widget initialises
+
+#### Scenario: An unrecognised colour format falls back to hex
+
+- **WHEN** the markup declares an unrecognised colour format, a colour is picked and the picker
+  closes
+- **THEN** the input holds the picked colour in hex
+
+#### Scenario: Re-rendering with a new value repaints
+
+- **WHEN** the field is rendered with one colour and then rendered again with another
+- **THEN** the swatch shows the second colour
+
+### Requirement: An untouched picker leaves the stored value alone
+
+Opening and dismissing the colorpicker without choosing a colour SHALL NOT write to the field: the
+input keeps its stored value, free text or blank included. After an actual pick — a slider
+interaction or a programmatic set — dismissing the picker SHALL write the formatted colour back.
+
+#### Scenario: Opening and dismissing the picker untouched changes nothing
+
+- **WHEN** the stored value is `2` and the picker is opened, then dismissed without a pick
+- **THEN** the input still reads `2`
+
+#### Scenario: A pick is written back on dismiss
+
+- **WHEN** a colour is picked and the picker is dismissed
+- **THEN** the input holds the picked colour
+
+### Requirement: Choice fields match stored values as text
+
+The checkbox, checkboxes and radio fields SHALL select the option or options whose value equals
+the stored value by comparing values as text, so an option value holding a quote or another
+selector-significant character is selected and does not break the form. The checkboxes field
+SHALL accept a scalar stored value as well as a list.
+
+#### Scenario: A radio option holding a quote renders checked
+
+- **WHEN** a radio field's option value is `Bob's pick`, that value is stored, and a text field is
+  registered after the radio
+- **THEN** the option renders checked and the text field renders with its stored value
+
+#### Scenario: A checkboxes option holding a quote renders checked from a scalar value
+
+- **WHEN** a checkboxes field stores the scalar value `Bob's tag`
+- **THEN** that option renders checked
+
+### Requirement: A disabled field renders read-only
+
+A custom field whose definition carries the disabled (or readonly) option SHALL render its inputs
+read-only in the edit form.
+
+#### Scenario: A disabled text field is read-only
+
+- **WHEN** a text field is defined with the disabled option and holds a stored value
+- **THEN** its input renders read-only
+
+### Requirement: The translation decoder accepts typed values
+
+The admin translation decoder that translatable fields read their values through SHALL accept a
+value that arrives as a number or boolean, treating it as its text form, instead of throwing.
+
+#### Scenario: A numeric or boolean value decodes
+
+- **WHEN** the decoder receives `1` or `true`
+- **THEN** it returns without throwing


### PR DESCRIPTION
**User-visible impact:** None — documentation only. No application code changes.

**What & why:** [#1288](https://github.com/owen2345/camaleon-cms/pull/1288) fixed a data-loss bug in the admin edit form (one custom field's bad stored value aborted the rendering of every field after it, and saving the record then blanked those fields' stored values) and the settings save that silently discarded the per-kind field options. It shipped with tests but with no OpenSpec capability, so the invariants its tests pin were recorded nowhere durable. This PR captures them as two capabilities and archives the change on the branch, per the workflow:

- `custom-field-render-resilience`: the edit form renders each custom field independently (a broken value or render callback degrades alone, with a console warning); the colorpicker accepts any stored value as text, keeps its default when unset, does not rewrite the field when opened untouched, and survives themed markup and unknown colour formats; choice fields match stored values as text; a disabled field renders read-only; the admin translation decoder accepts typed values.
- `custom-field-option-persistence`: a custom-field group save keeps every per-kind extra option the settings panels offer, and does not accept the `select_eval` field's `command` option from the request.

Every scenario except the `command` exclusion is already exercised by the two spec files from #1288; the exclusion is implemented by the controller's permit list, which the design records. The proposal explains why none of the existing custom-field capabilities needed a modified delta. Documentation-only, so every commit carries the skip-ci marker.

The same branch ticks three tasks in the archived `2026-08-01-fix-contact-form-output-escaping` change that were completed but never checked — [#1215](https://github.com/owen2345/camaleon-cms/pull/1215) merged with the rejection design, its archive landed on the branch before the merge, and the `2.9.2` tag carries neither permission key — so `openspec validate --archived` passes again.
