### PR TITLE
Run RuboCop in the Audit workflow with its default formatter

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -51,4 +51,4 @@ jobs:
             rubocop-${{ runner.os }}-${{ env.DEPENDENCIES_HASH }}-
 
       - name: Lint code for consistent style
-        run: bin/rubocop -f github
+        run: bin/rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- **Tooling:** The Audit workflow runs RuboCop with its default formatter instead of `-f github`, so the job log lists the offenses and the summary. Development-only. [#1293](https://github.com/owen2345/camaleon-cms/pull/1293).
+
 - **Docs:** Capture the custom-field behaviors fixed in #1288 — the admin edit form's per-field render isolation and colorpicker value handling, and the settings save keeping every per-kind field option — as the `custom-field-render-resilience` and `custom-field-option-persistence` OpenSpec capabilities. No behavior change. [#1291](https://github.com/owen2345/camaleon-cms/pull/1291).
 
 - **Tooling:** The checked-in OpenSpec agent instructions (`/opsx:*` prompts and skills for the four integrations) are regenerated with OpenSpec 1.12.0. Development-only. [#1290](https://github.com/owen2345/camaleon-cms/pull/1290).


### PR DESCRIPTION
## What and Why

The Audit workflow's RuboCop step runs `bin/rubocop` with its default formatter instead of `-f github`, so the job log lists the offenses and the summary. This matches owen2345/camaleon-cms-seo#51.

## User-Visible Impact

None. This changes CI tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
